### PR TITLE
serializable errors

### DIFF
--- a/packages/cli/src/llamaindexretreival.ts
+++ b/packages/cli/src/llamaindexretreival.ts
@@ -16,6 +16,7 @@ import {
     fileExists,
     installImport,
     lookupMime,
+    serializeError,
 } from "genaiscript-core"
 import type { BaseReader, NodeWithScore, Metadata } from "llamaindex"
 import type { GenericFileSystem } from "@llamaindex/env"
@@ -26,7 +27,7 @@ class BlobFileSystem implements GenericFileSystem {
     constructor(
         readonly filename: string,
         readonly blob: Blob
-    ) {}
+    ) { }
     writeFile(path: string, content: string): Promise<void> {
         throw new Error("Method not implemented.")
     }
@@ -66,7 +67,7 @@ export class LlamaIndexRetreivalService implements RetreivalService {
     private module: PromiseType<ReturnType<typeof tryImportLlamaIndex>>
     private READERS: Record<string, BaseReader>
 
-    constructor(readonly host: Host) {}
+    constructor(readonly host: Host) { }
 
     async init(trace?: MarkdownTrace) {
         if (this.module) return
@@ -198,7 +199,7 @@ export class LlamaIndexRetreivalService implements RetreivalService {
         if (!reader)
             return {
                 ok: false,
-                error: `no reader for content type '${type}'`,
+                error: serializeError(new Error(`no reader for content type '${type}'`)),
             }
         const fs = new BlobFileSystem(filenameOrUrl, blob)
         const documents = (await reader.loadData(filenameOrUrl, fs)).map(

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -9,6 +9,7 @@ import {
     outline,
     CORE_VERSION,
     ServerResponse,
+    serializeError,
 } from "genaiscript-core"
 
 export async function startServer(options: { port: string }) {
@@ -76,7 +77,7 @@ export async function startServer(options: { port: string }) {
                 }
                 response.ok = true
             } catch (e) {
-                response = { ok: false, error: e.message }
+                response = { ok: false, error: serializeError(e) }
             } finally {
                 if (response.error) logError(response.error)
                 ws.send(JSON.stringify({ id, response }))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "openai": "^4.29.0",
     "prettier": "^3.2.5",
     "pretty-bytes": "^6.1.1",
+    "serialize-error": "^11.0.3",
     "toml": "^3.0.0",
     "typescript": "^5.3.3",
     "yaml": "^2.4.1"

--- a/packages/core/src/aici.ts
+++ b/packages/core/src/aici.ts
@@ -2,14 +2,13 @@ import {
     ChatCompletionHandler,
     ChatCompletionResponse,
     LanguageModel,
-    RequestError,
 } from "./chat"
 import { PromptNode, visitNode } from "./promptdom"
 import wrapFetch from "fetch-retry"
 import { fromHex, logError, logVerbose, utf8Decode } from "./util"
 import { AICI_CONTROLLER, TOOL_ID } from "./constants"
 import { host } from "./host"
-import { NotSupportedError } from "./error"
+import { NotSupportedError, RequestError } from "./error"
 import { ChatCompletionContentPartText } from "openai/resources"
 
 function renderAICINode(node: AICINode) {

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -79,22 +79,6 @@ export interface ChatCompletionsOptions {
     maxDelay?: number
 }
 
-export class RequestError extends Error {
-    constructor(
-        public readonly status: number,
-        public readonly statusText: string,
-        public readonly body: any,
-        public readonly bodyText: string,
-        readonly retryAfter: number
-    ) {
-        super(
-            `OpenAI error: ${
-                body?.message ? body?.message : `${statusText} (${status})`
-            }`
-        )
-    }
-}
-
 export function toChatCompletionUserMessage(
     expanded: string,
     images?: PromptImage[]

--- a/packages/core/src/docx.ts
+++ b/packages/core/src/docx.ts
@@ -21,7 +21,7 @@ export async function DOCXTryParse(
         const results = await extractRawText({ path })
         return results.value
     } catch (error) {
-        logError(error.message)
+        logError(error)
         trace?.error(`reading docx`, error)
         return undefined
     }

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -44,9 +44,9 @@ export class RequestError extends Error {
     }
 }
 
-export function isCancelError(e: Error) {
+export function isCancelError(e: Error | ErrorObject) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return e.name === "CancelError" || e.name === "AbortError"
+    return e?.name === "CancelError" || e?.name === "AbortError"
 }
 
 export function isTokenError(e: Error) {

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -1,4 +1,5 @@
 import { CancellationToken } from "./cancellation"
+import { ErrorObject } from "./error"
 import { Progress } from "./progress"
 import { MarkdownTrace } from "./trace"
 
@@ -65,7 +66,7 @@ export interface RetreivalClientOptions {
 
 export interface ResponseStatus {
     ok: boolean
-    error?: string
+    error?: ErrorObject
     status?: number
 }
 

--- a/packages/core/src/oai_token.ts
+++ b/packages/core/src/oai_token.ts
@@ -1,5 +1,5 @@
-import { RequestError } from "./chat"
 import { AZURE_OPENAI_API_VERSION } from "./constants"
+import { RequestError } from "./error"
 import { OAIToken, host } from "./host"
 import { fromBase64, logInfo, logWarn, utf8Decode } from "./util"
 

--- a/packages/core/src/openai.ts
+++ b/packages/core/src/openai.ts
@@ -1,4 +1,3 @@
-import { initToken } from "./oai_token"
 import { logError, logVerbose } from "./util"
 import { host } from "./host"
 import {
@@ -16,9 +15,9 @@ import {
     ChatCompletionResponse,
     ChatCompletionToolCall,
     LanguageModel,
-    RequestError,
     getChatCompletionCache,
 } from "./chat"
+import { RequestError } from "./error"
 
 const OpenAIChatCompletion: ChatCompletionHandler = async (
     req,
@@ -137,11 +136,11 @@ const OpenAIChatCompletion: ChatCompletionHandler = async (
         let body: string
         try {
             body = await r.text()
-        } catch (e) {}
+        } catch (e) { }
         let bodyJSON: { error: unknown }
         try {
             bodyJSON = body ? JSON.parse(body) : undefined
-        } catch (e) {}
+        } catch (e) { }
         throw new RequestError(
             r.status,
             r.statusText,

--- a/packages/core/src/pdf.ts
+++ b/packages/core/src/pdf.ts
@@ -72,7 +72,7 @@ export async function PDFTryParse(
         }
         return pages
     } catch (error) {
-        logError(error.message)
+        logError(error)
         return undefined
     }
 }

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -6,7 +6,6 @@ import { OAIToken, host } from "./host"
 import { MarkdownTrace } from "./trace"
 import { YAMLParse, YAMLStringify } from "./yaml"
 import { createParsers } from "./parsers"
-import { throwError } from "./error"
 import { upsert, search } from "./retreival"
 import { outline } from "./highlights"
 import { readText } from "./fs"
@@ -29,6 +28,7 @@ import {
 } from "./runpromptcontext"
 import { CSVParse, CSVToMarkdown } from "./csv"
 import { INIParse, INIStringify, INITryParse } from "./ini"
+import { CancelError } from "./error"
 
 function stringLikeToFileName(f: string | LinkedFile) {
     return typeof f === "string" ? f : f?.filename
@@ -192,8 +192,8 @@ export function createPromptContext(
 
     const ctx = Object.freeze<PromptContext & RunPromptContextNode>({
         ...createRunPromptContext(options, env, trace),
-        script: () => {},
-        system: () => {},
+        script: () => { },
+        system: () => { },
         env,
         path,
         fs,
@@ -215,7 +215,7 @@ export function createPromptContext(
             appendPromptChild(createFileMergeNode(fn))
         },
         cancel: (reason?: string) => {
-            throwError(reason || "user cancelled", true)
+            throw new CancelError(reason || "user cancelled")
         },
         defData: (name, data, defOptions) => {
             appendPromptChild(createDefDataNode(name, data, env, defOptions))

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -324,7 +324,6 @@ export async function runTemplate(
                 resp = { text: "Request cancelled" }
                 error = undefined
             } else {
-                trace.heading(3, `Fetch error`)
                 trace.error(`fetch error`, error)
                 resp = { text: "Unexpected error" }
             }

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -11,7 +11,7 @@ export function estimateTokens(model: string, text: string) {
     try {
         return encode(text).length
     } catch (e) {
-        logError(e.message)
+        logError(e)
         return text.length >> 2
     }
 }
@@ -46,7 +46,7 @@ export function estimateChatTokens(
         const chatTokens = encodeChat(chat, model as any)
         return chatTokens.length | 0
     } catch (e) {
-        logError(e.message)
+        logError(e)
         return JSON.stringify(messages).length >> 2
     }
 }

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -147,10 +147,7 @@ ${title}
         this.guarded(() => {
             this.content += `\n> ❌ ${message}\n`
             const err = serializeError(error)
-            this.fence(err.message)
-            Object.entries(err).filter(([key]) => key !== "message").forEach(([key, value]) => {
-                this.itemValue(key, value)
-            })
+            this.fence(YAMLStringify(error), "yaml")
         })
     }
 }

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -2,11 +2,12 @@ import { CHANGE, TOOL_ID } from "./constants"
 import { fenceMD } from "./markdown"
 import { stringify as yamlStringify } from "yaml"
 import { YAMLStringify } from "./yaml"
-import { serializeError } from "./error"
+import { ErrorObject, serializeError } from "./error"
 
 export class MarkdownTrace
     extends EventTarget
     implements ChatFunctionCallTrace {
+    readonly errors: ErrorObject[] = []
     private _content: string = ""
 
     constructor() {
@@ -145,9 +146,12 @@ ${title}
 
     error(message: string, error?: unknown) {
         this.guarded(() => {
-            this.content += `\n> ❌ ${message}\n`
-            const err = serializeError(error)
-            this.fence(YAMLStringify(error), "yaml")
+            this.heading(3, `❌ ${message}`)
+            if (error) {
+                const err = serializeError(error)
+                this.errors.push(err)
+                this.fence(YAMLStringify(error), "yaml")
+            }
         })
     }
 }

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -107,6 +107,8 @@ ${title}
     }
 
     fence(message: string | unknown, contentType?: string) {
+        if (message === undefined || message === null) return
+
         let res: string
         if (typeof message !== "string") {
             if (contentType === "json") {
@@ -145,7 +147,10 @@ ${title}
         this.guarded(() => {
             this.content += `\n> ❌ ${message}\n`
             const err = serializeError(error)
-            this.fence(YAMLStringify(err))
+            this.fence(err.message)
+            Object.entries(err).filter(([key]) => key !== "message").forEach(([key, value]) => {
+                this.itemValue(key, value)
+            })
         })
     }
 }

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -2,11 +2,11 @@ import { CHANGE, TOOL_ID } from "./constants"
 import { fenceMD } from "./markdown"
 import { stringify as yamlStringify } from "yaml"
 import { YAMLStringify } from "./yaml"
+import { serializeError } from "./error"
 
 export class MarkdownTrace
     extends EventTarget
-    implements ChatFunctionCallTrace
-{
+    implements ChatFunctionCallTrace {
     private _content: string = ""
 
     constructor() {
@@ -141,16 +141,11 @@ ${title}
         )
     }
 
-    error(message: string, exception?: unknown) {
+    error(message: string, error?: unknown) {
         this.guarded(() => {
             this.content += `\n> ❌ ${message}\n`
-            if (typeof exception === "string") this.fence(exception)
-            else if (exception)
-                this.fence(
-                    `${(exception as Error).message}\n${
-                        (exception as Error).stack || ""
-                    }`
-                )
+            const err = serializeError(error)
+            this.fence(YAMLStringify(err))
         })
     }
 }

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,4 +1,5 @@
 import { GENAISCRIPT_FOLDER } from "./constants"
+import { ErrorObject, serializeError } from "./error"
 import { LogLevel, host } from "./host"
 
 export function trimNewlines(s: string) {
@@ -49,7 +50,7 @@ export function throttle(handler: () => void, delay: number): () => void {
 export function arrayShuffle<T>(a: T[]): T[] {
     for (let i = a.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1))
-        ;[a[i], a[j]] = [a[j], a[i]]
+            ;[a[i], a[j]] = [a[j], a[i]]
     }
     return a
 }
@@ -196,8 +197,11 @@ export function logWarn(msg: string) {
     host.log(LogLevel.Warn, msg)
 }
 
-export function logError(msg: string) {
-    host.log(LogLevel.Error, msg)
+export function logError(msg: string | Error | ErrorObject) {
+    const e = serializeError(msg)
+    host.log(LogLevel.Error, e.message || "error")
+    if (e.stack)
+        host.log(LogLevel.Verbose, e.stack)
 }
 
 export function concatArrays<T>(...arrays: T[][]): T[] {

--- a/packages/vscode/src/servermanager.ts
+++ b/packages/vscode/src/servermanager.ts
@@ -24,7 +24,7 @@ export class TerminalServerManager implements ServerManager {
                     try {
                         this.client?.kill()
                     } catch (error) {
-                        logError(error.message)
+                        logError(error)
                     }
                     this._terminal = undefined
                 }

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -244,8 +244,12 @@ retrieval/
             const req = await this.startAIRequest(options)
             if (!req) return
             const res = await req?.request
-            const { edits, text } = res || {}
-            if (text)
+            const { edits, text, error } = res || {}
+            if (error)
+                vscode.commands.executeCommand(
+                    "genaiscript.request.open.trace"
+                )
+            else if (text)
                 vscode.commands.executeCommand(
                     "genaiscript.request.open.output"
                 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -8095,6 +8095,13 @@ semver@^7.3.4, semver@^7.3.5, semver@^7.3.8, semver@^7.5.2, semver@^7.5.4, semve
   dependencies:
     lru-cache "^6.0.0"
 
+serialize-error@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-11.0.3.tgz#b54f439e15da5b4961340fbbd376b6b04aa52e92"
+  integrity sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==
+  dependencies:
+    type-fest "^2.12.2"
+
 serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz"
@@ -8926,7 +8933,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-fest@^2.13.0:
+type-fest@^2.12.2, type-fest@^2.13.0:
   version "2.19.0"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==


### PR DESCRIPTION
- use `serialize-error` to convert Error into JSON, clean stack
- show trace when error occurs in execution