### PR TITLE
pull request review commit blame

### DIFF
--- a/.github/workflows/genai-pr-commit-review.yml
+++ b/.github/workflows/genai-pr-commit-review.yml
@@ -1,4 +1,4 @@
-name: genai pull request review
+name: genai pull request commit review
 on:
     pull_request:
         paths:

--- a/.github/workflows/genai-pr-review.yml
+++ b/.github/workflows/genai-pr-review.yml
@@ -1,6 +1,7 @@
-name: genai pull request review
+name: genai pull request commit review
 on:
     pull_request:
+        types: [review_requested]
         paths:
             - yarn.lock
             - ".github/workflows/ollama.yml"
@@ -33,11 +34,18 @@ jobs:
               run: yarn compile
             - name: git stuff
               run: git fetch origin && git pull origin main:main
-            - name: genaiscript pr-review-commit
-              run: node packages/cli/built/genaiscript.cjs run pr-review-commit --out ./temp/genai/pr-review-commit -prr
+            - name: genaiscript pr-describe
+              run: node packages/cli/built/genaiscript.cjs run pr-describe --out ./temp/genai/pr-describe -prd pr-describe
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha}}
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                  OPENAI_API_TYPE: ${{ secrets.OPENAI_API_TYPE }}
+                  OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
+            - name: genaiscript pr-review
+              run: node packages/cli/built/genaiscript.cjs run pr-review --out ./temp/genai/pr-review -prc pr-review
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.base.sha}}
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
                   OPENAI_API_TYPE: ${{ secrets.OPENAI_API_TYPE }}
                   OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}

--- a/.github/workflows/genai-pr-review.yml
+++ b/.github/workflows/genai-pr-review.yml
@@ -1,7 +1,7 @@
-name: genai pull request commit review
+name: genai pull request review
 on:
     pull_request:
-        types: [review_requested]
+        types: [review_requested, ready_for_review]
         paths:
             - yarn.lock
             - ".github/workflows/ollama.yml"

--- a/docs/src/content/docs/reference/cli/run.md
+++ b/docs/src/content/docs/reference/cli/run.md
@@ -66,12 +66,12 @@ Output the entire response as YAML to the stdout.
 
 Populate values in the `env.vars` map that can be used when running the prompt.
 
-### --out-trace <file>
+### --out-trace &lt;file&gt;
 
 Save the markdown trace to the specified file.
 
 ```sh
-npx genaiscript run <script> <spec> --out-trace <file>
+npx genaiscript run <script> <spec> --out-trace &lt;file&gt;
 ```
 
 In a GitHub Actions workflow, you can use this feature to save the trace as a step summary (`GITHUB_STEP_SUMMARY`):
@@ -82,7 +82,7 @@ In a GitHub Actions workflow, you can use this feature to save the trace as a st
       genaiscript run <script> <spec> --out-trace $GITHUB_STEP_SUMMARY
 ```
 
-### --out-annotations <file>
+### --out-annotations &lt;file&gt;
 
 Emit annotations in the specified file as a JSON array, JSON Lines, [SARIF](https://sarifweb.azurewebsites.net/) or a CSV file if the file ends with `.csv`.
 
@@ -96,7 +96,7 @@ Use JSON lines (`.jsonl`) to aggregate annotations from multiple runs in a singl
 npx genaiscript run <script> <spec> --out-annotations diags.jsonl
 ```
 
-### --out-data <file>
+### --out-data &lt;file&gt;
 
 Emits parsed data as JSON, YAML or JSONL. If a JSON schema is specified
 and availabe, the JSON validation result is also stored.
@@ -105,7 +105,7 @@ and availabe, the JSON validation result is also stored.
 npx genaiscript run <script> <spec> --out-data data.jsonl
 ```
 
-### --out-changelogs <file>
+### --out-changelogs &lt;file&gt;
 
 Emit changelogs in the specified file as text.
 
@@ -117,16 +117,16 @@ npx genaiscript run <script> <spec> --out-changelogs changelogs.txt
 
 Skips the LLM invocation and only prints the expanded system and user chat messages.
 
-### --retry <number>
+### --retry &lt;number&gt;
 
 Specifies the number of retries when the LLM invocations fails with throttling (429).
 Default is 3.
 
-### --retry-delay <number>
+### --retry-delay &lt;number&gt;
 
 Minimum delay between retries in milliseconds.
 
-### --label <label>
+### --label &lt;label&gt;
 
 Adds a run label that will be used in generating the trace title.
 
@@ -135,15 +135,15 @@ Adds a run label that will be used in generating the trace title.
 Enables LLM caching in JSONL file under `.genaiscript/tmp/openai.genaiscript.cjsonl`. Caching is enabled by default in VSCode
 but not for the CLI.
 
-### --temperature <number>
+### --temperature &lt;number&gt;
 
 Overrides the LLM run temperature.
 
-### --top-p <number>
+### --top-p &lt;number&gt;
 
 Overrides the LLM run `top_p` value.
 
-### --model <string>
+### --model &lt;string&gt;
 
 Overrides the LLM model identifier.
 

--- a/genaisrc/pr-review-commit.genai.js
+++ b/genaisrc/pr-review-commit.genai.js
@@ -30,6 +30,7 @@ Provide feedback to the author using annotations.
 
 Think step by step and for each annotation explain your result.
 
+- Assume the TypeScript code is type correct. do NOT report issues that the TypeScript type checker would find.
 - report 3 most serious errors only, ignore notes and warnings
 - only report issues you are absolutely certain about
 - do NOT repeat the same issue multiple times

--- a/genaisrc/pr-review-commit.genai.js
+++ b/genaisrc/pr-review-commit.genai.js
@@ -34,6 +34,7 @@ Think step by step and for each annotation explain your result.
 - report 3 most serious errors only, ignore notes and warnings
 - only report issues you are absolutely certain about
 - do NOT repeat the same issue multiple times
+- do NOT report common convention issues
 - use a friendly tone
 - use emojis
 - read the full source code of the files if you need more context

--- a/genaisrc/pr-review.genai.js
+++ b/genaisrc/pr-review.genai.js
@@ -32,6 +32,8 @@ GIT_DIFF contains the changes the pull request branch.
 
 Provide a high level review of the changes in the pull request. Do not enter into details.
 
+- All the TypeScript files are compiled and type-checked by the TypeScript compiler. Do not report issues that the TypeScript compiler would find.
+
 If the changes look good, respond LGTM (Looks Good To Me). If you have any concerns, provide a brief description of the concerns.
 
 `

--- a/genaisrc/pr-review.genai.js
+++ b/genaisrc/pr-review.genai.js
@@ -32,8 +32,10 @@ GIT_DIFF contains the changes the pull request branch.
 
 Provide a high level review of the changes in the pull request. Do not enter into details.
 
-- All the TypeScript files are compiled and type-checked by the TypeScript compiler. Do not report issues that the TypeScript compiler would find.
-
 If the changes look good, respond LGTM (Looks Good To Me). If you have any concerns, provide a brief description of the concerns.
+
+- All the TypeScript files are compiled and type-checked by the TypeScript compiler. Do not report issues that the TypeScript compiler would find.
+- Use emojis
+- If available, suggest code fixes and improvements
 
 `

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,7 +10,6 @@ import {
     UNHANDLED_ERROR_CODE,
     errorMessage,
     dotGenaiscriptPath,
-    GITHUB_COMMENT_ID_NONE,
 } from "genaiscript-core"
 import { NodeHost } from "./nodehost"
 import { program } from "commander"

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -170,5 +170,4 @@ export const DOCKER_CONTAINER_VOLUME = "/app"
 export const CLI_RUN_FILES_FOLDER = "files"
 
 export const GITHUB_API_VERSION = "2022-11-28"
-export const GITHUB_COMMENT_ID_NONE = "none"
 export const GITHUB_TOKEN = "GITHUB_TOKEN"


### PR DESCRIPTION
Add logic to handle resolve the commit in the pull request that contributed to the particular line commit.



<!-- genaiscript begin pr-describe -->

- 📝 Updated documentation in `run.md`:
  - Replaced angle brackets (`<`, `>`) with HTML entities (`&lt;`, `&gt;`) for command-line argument placeholders to likely prevent issues with HTML rendering.
  
- 🧹 Removed a constant `GITHUB_COMMENT_ID_NONE` from `cli.ts`:
  - The constant was likely used for GitHub integration and its removal suggests a change in how GitHub comments are handled or that the constant was no longer needed.

- 🚚 Deleted the `GITHUB_COMMENT_ID_NONE` definition from `constants.ts`:
  - This aligns with the removal in `cli.ts` and indicates a cleanup or refactoring related to GitHub comment handling.

> generated by genaiscript [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9350565561)



<!-- genaiscript end pr-describe -->

