### PR TITLE
no workflow cache

### DIFF
--- a/.github/workflows/genai-pr-commit-review.yml
+++ b/.github/workflows/genai-pr-commit-review.yml
@@ -22,11 +22,6 @@ jobs:
                   node-version: "20"
                   cache: yarn
             - run: yarn install --frozen-lockfile
-            - name: cache .genaiscript
-              uses: actions/cache@v4
-              with:
-                  path: .genaiscript/cache
-                  key: genaiscript-${{ hashFiles('**/yarn.lock') }}
             - name: compile
               run: yarn compile
             - name: git stuff

--- a/.github/workflows/genai-pr-docs-commit-review.yml
+++ b/.github/workflows/genai-pr-docs-commit-review.yml
@@ -19,11 +19,6 @@ jobs:
                   node-version: "20"
                   cache: yarn
             - run: yarn install --frozen-lockfile
-            - name: cache .genaiscript
-              uses: actions/cache@v4
-              with:
-                  path: .genaiscript/cache
-                  key: genaiscript-${{ hashFiles('**/yarn.lock') }}
             - name: compile
               run: yarn compile
             - name: git stuff

--- a/.github/workflows/genai-pr-review.yml
+++ b/.github/workflows/genai-pr-review.yml
@@ -23,11 +23,6 @@ jobs:
                   node-version: "20"
                   cache: yarn
             - run: yarn install --frozen-lockfile
-            - name: cache .genaiscript
-              uses: actions/cache@v4
-              with:
-                  path: .genaiscript/cache
-                  key: genaiscript-${{ hashFiles('**/yarn.lock') }}
             - name: compile
               run: yarn compile
             - name: git stuff

--- a/docs/src/content/docs/getting-started/automating-scripts.mdx
+++ b/docs/src/content/docs/getting-started/automating-scripts.mdx
@@ -83,19 +83,6 @@ Make sure to pass the secrets and variables to the script.
             OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-### Caching LLM queries
-
-GenAIScript stores LLM request caches in the `.genaiscript/cache` folder.
-You can use the [actions/cache](https://github.com/actions/cache) action to cache the LLM queries.
-
-```yaml
-    - name: cache genaiscript
-        uses: actions/cache@v4
-        with:
-            path: .genaiscript/cache
-            key: genaiscript
-```
-
 ### Add the trace to the action summary
 
 Use the `out-trace` flag to output the trace to the summary file, `$GITHUB_STEP_SUMMARY`

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,4 +1,5 @@
-import { GENAISCRIPT_FOLDER } from "./constants"
+import path from "path"
+import { GENAISCRIPT_FOLDER, HTTPS_REGEX } from "./constants"
 import { serializeError } from "./error"
 import { LogLevel, host } from "./host"
 import { YAMLStringify } from "./yaml"
@@ -184,14 +185,8 @@ export function dotGenaiscriptPath(...segments: string[]) {
 }
 
 export function relativePath(root: string, fn: string) {
-    if (!fn) return fn
-
-    const afn = host.path.resolve(fn)
-    if (afn.startsWith(root)) {
-        return afn.slice(root.length).replace(/^[\/\\]+/, "")
-    }
-
-    return fn
+    if (!fn || HTTPS_REGEX.test(fn)) return fn
+    return path.relative(root, fn)
 }
 
 export function logInfo(msg: string) {

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -185,8 +185,13 @@ export function dotGenaiscriptPath(...segments: string[]) {
 }
 
 export function relativePath(root: string, fn: string) {
+    // ignore empty path or urls
     if (!fn || HTTPS_REGEX.test(fn)) return fn
-    return path.relative(root, fn)
+    const afn = host.path.resolve(fn)
+    if (afn.startsWith(root)) {
+        return afn.slice(root.length).replace(/^[\/\\]+/, "")
+    }
+    return fn
 }
 
 export function logInfo(msg: string) {

--- a/packages/sample/genaisrc/summarize-link.genai.js
+++ b/packages/sample/genaisrc/summarize-link.genai.js
@@ -6,9 +6,7 @@ script({
     system: ["system", "system.files"],
     temperature: 0,
     tests: {
-        files: [
-            `https://raw.githubusercontent.com/microsoft/genaiscript/main/packages/sample/src/rag/markdown.md`,
-        ],
+        files: `https://raw.githubusercontent.com/microsoft/genaiscript/main/packages/sample/src/rag/markdown.md`,
         keywords: "markdown",
     },
 })


### PR DESCRIPTION
Fix incorrect usag of workflow cache.

<!-- genaiscript begin pr-describe -->

- 🚫 Removed caching section from documentation:
  - The section about caching LLM queries in the `automating-scripts.mdx` file has been deleted. This includes instructions on using the `actions/cache` action to cache LLM queries.

- ✂️ Simplified `relativePath` function in `util.ts`:
  - The check for an empty filename has been removed, and now there's an additional check for URLs using the `HTTPS_REGEX`. If the filename is a URL, it returns the filename as is.

- 📝 Updated `summarize-link.genai.js` test files parameter:
  - Changed the `files` parameter within the `tests` object from an array to a single string URL.

> generated by genaiscript [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9379173959)



<!-- genaiscript end pr-describe -->

