### PR TITLE
better generate automation help

### DIFF
--- a/docs/src/content/docs/reference/cli/run.md
+++ b/docs/src/content/docs/reference/cli/run.md
@@ -6,7 +6,7 @@ sidebar:
 keywords: CLI tool execution, genai script running, stdout streaming, file globbing, environment configuration
 ---
 
-Runs a genai script on a file and streams the LLM output to stdout.
+Runs a script on files and streams the LLM output to stdout.
 
 ```bash
 npx genaiscript run <script> "<files...>"

--- a/docs/src/content/docs/reference/cli/test.mdx
+++ b/docs/src/content/docs/reference/cli/test.mdx
@@ -1,0 +1,25 @@
+---
+title: Test
+sidebar:
+  order: 3.5
+---
+
+Runs the tests in scripts using [promptfoo](https://www.promptfoo.dev/).
+
+```bash
+npx genaiscript test "<scripts...>"
+```
+
+You can override which models to use in the tests using `--models`:
+
+```bash "--models openai:gpt-4 ollama:phi3"
+npx genaiscript test "<scripts...>" --models openai:gpt-4 ollama:phi3
+```
+
+## result viewer
+
+Run the `test view` command to launch the test result viewer:
+
+```bash
+npx genaiscript test view
+```

--- a/packages/core/src/clihelp.ts
+++ b/packages/core/src/clihelp.ts
@@ -38,7 +38,7 @@ export function traceCliArgs(
 ) {
     trace.details(
         "🤖 automation",
-        `This operation can be automated using the command line interface using the \`run\` command:
+        `This operation can be automated using the [command line interface](https://microsoft.github.io/genaiscript/reference/cli/run/):
 
 \`\`\`bash
 ${generateCliArguments(template, options, "run")}
@@ -46,7 +46,7 @@ ${generateCliArguments(template, options, "run")}
 
 
 -   You will need to install [Node.js LTS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
--   The CLI uses the same secrets in the \`.env\` file.
+-   The cli uses the same secrets in the \`.env\` file.
 `
     )
 
@@ -54,13 +54,7 @@ ${generateCliArguments(template, options, "run")}
         trace.details(
             "🧪 testing",
             `
-- [promptfoo](https://www.promptfoo.dev/) configuration
-
-\`\`\`yaml
-${YAMLStringify(generatePromptFooConfiguration(template, { models: [options] }))}
-\`\`\`
-
-- run the test command
+- run the [test command](https://microsoft.github.io/genaiscript/reference/cli/test):
 
 \`\`\`sh
 npx --yes genaiscript test ${template.id}

--- a/packages/core/src/clihelp.ts
+++ b/packages/core/src/clihelp.ts
@@ -1,11 +1,9 @@
-import { Fragment } from "./ast"
 import { NPM_CLI_PACKAGE } from "./constants"
 import { GenerationOptions } from "./promptcontext"
-import { generatePromptFooConfiguration } from "./test"
 import { MarkdownTrace } from "./trace"
-import { arrayify } from "./util"
+import { arrayify, relativePath } from "./util"
 import { CORE_VERSION } from "./version"
-import { YAMLStringify } from "./yaml"
+import { host } from "./host"
 
 export function generateCliArguments(
     template: PromptScript,
@@ -20,7 +18,7 @@ export function generateCliArguments(
         `${NPM_CLI_PACKAGE}@^${CORE_VERSION}`,
         command,
         template.id,
-        `"${cliInfo.spec}"`,
+        `"${relativePath(host.projectFolder(), cliInfo.spec)}"`,
         "--apply-edits",
     ]
     if (model) cli.push(`--model`, model)
@@ -38,7 +36,7 @@ export function traceCliArgs(
 ) {
     trace.details(
         "🤖 automation",
-        `This operation can be automated using the [command line interface](https://microsoft.github.io/genaiscript/reference/cli/run/):
+        `Use the [command line interface \`run\`](https://microsoft.github.io/genaiscript/reference/cli/run/) to automate this task:
 
 \`\`\`bash
 ${generateCliArguments(template, options, "run")}
@@ -54,7 +52,7 @@ ${generateCliArguments(template, options, "run")}
         trace.details(
             "🧪 testing",
             `
-- run the [test command](https://microsoft.github.io/genaiscript/reference/cli/test):
+Use the [command line interface \`test\`://microsoft.github.io/genaiscript/reference/cli/test) to run the tests for this script:
 
 \`\`\`sh
 npx --yes genaiscript test ${template.id}

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -29,7 +29,6 @@ import {
     GENAI_JS_REGEX,
     GENAI_JS_GLOB,
     fixPromptDefinitions,
-    DEFAULT_MODEL,
     resolveModelConnectionInfo,
     AI_REQUESTS_CACHE,
 } from "genaiscript-core"
@@ -125,7 +124,9 @@ export function snapshotAIRequest(r: AIRequest): AIRequestSnapshot {
 }
 
 function getAIRequestCache() {
-    return JSONLineCache.byName<AIRequestSnapshotKey, AIRequestSnapshot>(AI_REQUESTS_CACHE)
+    return JSONLineCache.byName<AIRequestSnapshotKey, AIRequestSnapshot>(
+        AI_REQUESTS_CACHE
+    )
 }
 
 export class ExtensionState extends EventTarget {
@@ -134,8 +135,10 @@ export class ExtensionState extends EventTarget {
     private _project: Project = undefined
     private _aiRequest: AIRequest = undefined
     private _diagColl: vscode.DiagnosticCollection
-    private _aiRequestCache: JSONLineCache<AIRequestSnapshotKey, AIRequestSnapshot> =
-        undefined
+    private _aiRequestCache: JSONLineCache<
+        AIRequestSnapshotKey,
+        AIRequestSnapshot
+    > = undefined
     readonly output: vscode.LogOutputChannel
 
     lastSearch: RetrievalSearchResult
@@ -353,11 +356,17 @@ ${errorMessage(e)}`
             cache: cache && template.cache,
             stats: { toolCalls: 0, repairs: 0 },
             cliInfo: {
-                spec: vscode.workspace.asRelativePath(
-                    this.host.isVirtualFile(fragment.file.filename)
-                        ? fragment.file.filename.replace(/\.gpspec\.md$/i, "")
-                        : fragment.file.filename
-                ),
+                spec:
+                    this.host.isVirtualFile(fragment.file.filename) &&
+                    this.host.path.basename(fragment.file.filename) ===
+                        "dir.gpspec.md"
+                        ? fragment.file.filename.replace(
+                              /dir\.gpspec\.md$/i,
+                              "**"
+                          )
+                        : this.host.isVirtualFile(fragment.file.filename)
+                          ? fragment.file.filename.replace(/\.gpspec\.md$/i, "")
+                          : fragment.file.filename,
             },
             model: info.model,
         }


### PR DESCRIPTION
Correctly specify glob in file location

<!-- genaiscript begin pr-describe -->

### CLI Changes
- 📝 Updated the `run.md` file to generalize the description of the `run` command from "Runs a genai script on a file" to "Runs a script on files".
- ✨ Added a new `test.mdx` file to document the `test` command, which runs tests in scripts using [promptfoo](https://www.promptfoo.dev/).
- 🚀 Introduced the ability to override models in tests with the `--models` flag.
- 🌐 Added a `test view` command to launch the test result viewer.

### Library Changes
- 🛠️ Modified the `generateCliArguments` function to use `relativePath` from the `host` object for generating the CLI command.
- 📚 Updated the `traceCliArgs` function to provide a link to the CLI `run` command documentation and corrected the text from "The CLI uses" to "The cli uses".
- 🧹 Cleaned up the `traceCliArgs` function by removing the generation of the PromptFoo configuration YAML and updating the text to direct users to the CLI `test` command documentation for running script tests.
- 🔄 Changed the `ExtensionState` class to handle virtual file paths differently, including a special case for files named `dir.gpspec.md`.

> generated by genaiscript [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9404680332)



<!-- genaiscript end pr-describe -->

