### PR TITLE
defImages in sub prompts

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -165,29 +165,6 @@ export function createPromptContext(
         },
     }
 
-    const defImages = (files: StringLike, defOptions?: DefImagesOptions) => {
-        const { detail } = defOptions || {}
-        if (Array.isArray(files))
-            files.forEach((file) => defImages(file, defOptions))
-        else if (typeof files === "string")
-            appendPromptChild(createImageNode({ url: files, detail }))
-        else {
-            const file: WorkspaceFile = files
-            appendPromptChild(
-                createImageNode(
-                    (async () => {
-                        const url = await resolveFileDataUri(file, { trace })
-                        return {
-                            url,
-                            filename: file.filename,
-                            detail,
-                        }
-                    })()
-                )
-            )
-        }
-    }
-
     const defOutputProcessor = (fn: PromptOutputProcessorHandler) => {
         if (fn) appendPromptChild(createOutputProcessor(fn))
     }
@@ -226,7 +203,6 @@ export function createPromptContext(
         XML,
         retrieval,
         host: promptHost,
-        defImages,
         defOutputProcessor,
         defFileMerge: (fn) => {
             appendPromptChild(createFileMergeNode(fn))

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1229,6 +1229,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1490,7 +1491,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/genaisrc/describe-image-run-prompt.genai.js
+++ b/packages/sample/genaisrc/describe-image-run-prompt.genai.js
@@ -1,0 +1,26 @@
+script({
+    title: "Describe objects in each image",
+    model: "gpt-3.5-turbo",
+    maxTokens: 4000,
+    system: [],
+    tests: {
+        files: "src/robots.jpg",
+        keywords: "robot",
+    },
+})
+
+for (const file of env.files) {
+    const res = await runPrompt(
+        (_) => {
+            _.$`Return the list of objects in the images.`
+            _.defImages(file, { detail: "low" })
+        },
+        {
+            model: "gpt-4-turbo-v",
+            maxTokens: 4000,
+        }
+    )
+    def("OBJECTS", res.text)
+}
+
+$`Summarize the objects in images.`

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1263,6 +1263,7 @@ interface RunPromptContext {
         generator: string | RunPromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
+    defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
         description: string,
@@ -1524,7 +1525,6 @@ interface ContainerHost extends ShellHost {
 interface PromptContext extends RunPromptContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
-    defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
     fetchText(


### PR DESCRIPTION
Moving defImages logic to run prompt to allow image analysis in sub requests

<!-- genaiscript begin pr-describe -->

### Library Changes
- 🚚 The `defImages` function has been removed from the `PromptContext` interface in `promptcontext.ts`.
- ✨ A new `defImages` function has been added to the `RunPromptContext` interface in `runpromptcontext.ts`. This function is responsible for defining images within the run prompt context, handling both string URLs and workspace files.
- 🔄 The `defImages` function now appends the image node directly to the current node in the run prompt context, instead of appending it to the prompt child as it did before.

### CLI Changes
- 🆕 A new script file `describe-image-run-prompt.genai.js` has been added to the `packages/sample/genaisrc` directory. This script is designed to describe objects in images using a run prompt with the model "gpt-4-turbo-v". It defines the images to be described and then summarizes the objects found in those images.

> generated by genaiscript [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9435002065)



<!-- genaiscript end pr-describe -->

