### PR TITLE
Participant

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/cli/src/batch.ts
+++ b/packages/cli/src/batch.ts
@@ -183,7 +183,7 @@ export async function batchScript(
                     retryDelay,
                     maxDelay,
                     vars,
-                    stats: { toolCalls: 0, repairs: 0 },
+                    stats: { toolCalls: 0, repairs: 0, turns: 0 },
                     trace,
                 }
             )

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -234,6 +234,7 @@ ${Array.from(files)
             stats: {
                 toolCalls: 0,
                 repairs: 0,
+                turns: 0
             },
         })
     } catch (err) {

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -453,6 +453,7 @@ export async function executeChatSession(
     functions: ChatFunctionCallback[],
     schemas: Record<string, JSONSchema>,
     completer: ChatCompletionHandler,
+    chatParticipants: ChatParticipantHandler[],
     genOptions: GenerationOptions
 ) {
     const {

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -546,12 +546,14 @@ function renderMessagesToMarkdown(messages: ChatCompletionMessageParam[]) {
     const res: string[] = []
     messages.forEach((msg) => {
         const { role } = msg
-        res.push(`> ${role}`)
+        const roleMsg = `> ${role}`
         switch (role) {
             case "system":
+                res.push(roleMsg)
                 res.push(fenceMD(msg.content, "markdown"))
                 break
             case "user":
+                res.push(roleMsg)
                 if (typeof msg.content === "string")
                     res.push(fenceMD(msg.content, "markdown"))
                 else if (Array.isArray(msg.content))
@@ -565,9 +567,19 @@ function renderMessagesToMarkdown(messages: ChatCompletionMessageParam[]) {
                 else res.push(fenceMD(YAMLStringify(msg), "yaml"))
                 break
             case "assistant":
+                res.push(roleMsg)
                 res.push(fenceMD(msg.content, "markdown"))
                 break
+            case "aici":
+                res.push(`> ${role} ${msg.functionName}`)
+                res.push(fenceMD(msg.content, "markdown"))
+                break
+            case "tool":
+                res.push(`> ${role} ${msg.tool_call_id}`)
+                res.push(fenceMD(msg.content, "json"))
+                break
             default:
+                res.push(roleMsg)
                 res.push(fenceMD(YAMLStringify(msg), "yaml"))
                 break
         }

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -27,7 +27,7 @@ import { isCancelError, serializeError } from "./error"
 import { fenceMD } from "./markdown"
 import { YAMLStringify } from "./yaml"
 import { estimateChatTokens } from "./tokens"
-import { createChatGenerationContext } from "./runpromptcontext"
+import { createChatGenerationContext, createChatTurnGenerationContext } from "./runpromptcontext"
 
 export type ChatCompletionTool = OpenAI.Chat.Completions.ChatCompletionTool
 
@@ -445,7 +445,7 @@ async function processChatMessage(
                 const { label } = participantOptions || {}
                 trace.startDetails(`participant ${label || ""}`)
 
-                const ctx = createChatGenerationContext(options, vars, trace)
+                const ctx = createChatTurnGenerationContext(options, vars, trace)
                 await generator(ctx, structuredClone(messages))
                 const node = ctx.node
                 checkCancelled(cancellationToken)

--- a/packages/core/src/expander.ts
+++ b/packages/core/src/expander.ts
@@ -111,6 +111,7 @@ async function callExpander(
     let functions: ChatFunctionCallback[] = []
     let fileMerges: FileMergeHandler[] = []
     let outputProcessors: PromptOutputProcessorHandler[] = []
+    let chatParticipants: ChatParticipantHandler[] = []
     let aici: AICIRequest
 
     const logCb = (msg: any) => {
@@ -139,6 +140,7 @@ async function callExpander(
                 functions: fns,
                 fileMerges: fms,
                 outputProcessors: ops,
+                chatParticipants: cps,
             } = await renderPromptNode(model, node, { trace })
             text = prompt
             assistantText = assistantPrompt
@@ -147,6 +149,7 @@ async function callExpander(
             functions = fns
             fileMerges = fms
             outputProcessors = ops
+            chatParticipants = cps
             if (errors?.length) {
                 for (const error of errors) trace.error(``, error)
                 status = "error"
@@ -182,6 +185,7 @@ async function callExpander(
         functions,
         fileMerges,
         outputProcessors,
+        chatParticipants,
         aici,
     }
 }
@@ -313,6 +317,7 @@ export async function expandTemplate(
     const functions = prompt.functions
     const fileMerges = prompt.fileMerges
     const outputProcessors = prompt.outputProcessors
+    const chatParticipants = prompt.chatParticipants
 
     if (prompt.logs?.length) trace.details("📝 console.log", prompt.logs)
     if (prompt.text) {
@@ -361,6 +366,7 @@ export async function expandTemplate(
         if (sysr.functions) functions.push(...sysr.functions)
         if (sysr.fileMerges) fileMerges.push(...sysr.fileMerges)
         if (sysr.outputProcessors) outputProcessors.push(...outputProcessors)
+        if (sysr.chatParticipants) chatParticipants.push(...chatParticipants)
         if (sysr.logs?.length) trace.details("📝 console.log", sysr.logs)
         if (sysr.text) {
             systemMessage.content += SYSTEM_FENCE + "\n" + sysr.text + "\n"
@@ -434,5 +440,6 @@ ${schemaTs}
         responseSchema,
         fileMerges,
         outputProcessors,
+        chatParticipants,
     }
 }

--- a/packages/core/src/expander.ts
+++ b/packages/core/src/expander.ts
@@ -88,6 +88,7 @@ export interface GenerationResult extends GenerationOutput {
 export interface GenerationStats {
     toolCalls: number
     repairs: number
+    turns: number
 }
 
 export type GenerationStatus = "success" | "error" | "cancelled" | undefined
@@ -111,7 +112,7 @@ async function callExpander(
     let functions: ChatFunctionCallback[] = []
     let fileMerges: FileMergeHandler[] = []
     let outputProcessors: PromptOutputProcessorHandler[] = []
-    let chatParticipants: ChatParticipantHandler[] = []
+    let chatParticipants: ChatParticipant[] = []
     let aici: AICIRequest
 
     const logCb = (msg: any) => {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -9,6 +9,7 @@ import { readText } from "./fs"
 import {
     PromptNode,
     appendChild,
+    createChatParticipant,
     createFileMergeNode,
     createImageNode,
     createOutputProcessor,
@@ -192,6 +193,10 @@ export function createPromptContext(
         if (fn) appendPromptChild(createOutputProcessor(fn))
     }
 
+    const defChatParticipant = (participant: ChatParticipantHandler) => {
+        if (participant) appendPromptChild(createChatParticipant(participant))
+    }
+
     const promptHost: PromptHost = {
         askUser: (question) =>
             host.askUser({
@@ -228,6 +233,7 @@ export function createPromptContext(
         host: promptHost,
         defImages,
         defOutputProcessor,
+        defChatParticipant,
         defFileMerge: (fn) => {
             appendPromptChild(createFileMergeNode(fn))
         },

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -18,7 +18,7 @@ import { bingSearch } from "./websearch"
 import { CancellationToken } from "./cancellation"
 import {
     RunPromptContextNode,
-    createRunPromptContext,
+    createChatGenerationContext,
 } from "./runpromptcontext"
 import { CSVParse, CSVToMarkdown } from "./csv"
 import { INIParse, INIStringify } from "./ini"
@@ -170,10 +170,6 @@ export function createPromptContext(
         if (fn) appendPromptChild(createOutputProcessor(fn))
     }
 
-    const defChatParticipant = (participant: ChatParticipantHandler) => {
-        if (participant) appendPromptChild(createChatParticipant(participant))
-    }
-
     const promptHost: PromptHost = {
         askUser: (question) =>
             host.askUser({
@@ -193,7 +189,7 @@ export function createPromptContext(
     }
 
     const ctx = Object.freeze<PromptContext & RunPromptContextNode>({
-        ...createRunPromptContext(options, env, trace),
+        ...createChatGenerationContext(options, env, trace),
         script: () => {},
         system: () => {},
         env,
@@ -209,7 +205,6 @@ export function createPromptContext(
         retrieval,
         host: promptHost,
         defOutputProcessor,
-        defChatParticipant,
         defFileMerge: (fn) => {
             appendPromptChild(createFileMergeNode(fn))
         },

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -29,6 +29,7 @@ export interface PromptNode extends ContextExpansionOptions {
         | "stringTemplate"
         | "assistant"
         | "def"
+        | "chatParticipant"
         | undefined
     children?: PromptNode[]
     error?: unknown
@@ -96,6 +97,11 @@ export interface PromptFileMergeNode extends PromptNode {
 export interface PromptOutputProcessorNode extends PromptNode {
     type: "outputProcessor"
     fn: PromptOutputProcessorHandler
+}
+
+export interface PromptChatParticipantNode extends PromptNode {
+    type: "chatParticipant"
+    participant: ChatParticipantHandler
 }
 
 export function createTextNode(
@@ -227,6 +233,12 @@ export function createOutputProcessor(
     return { type: "outputProcessor", fn }
 }
 
+export function createChatParticipant(
+    participant: ChatParticipantHandler
+): PromptChatParticipantNode {
+    return { type: "chatParticipant", participant }
+}
+
 export function createDefDataNode(
     name: string,
     data: object | object[],
@@ -277,6 +289,7 @@ export interface PromptNodeVisitor {
     stringTemplate?: (node: PromptStringTemplateNode) => Awaitable<void>
     outputProcessor?: (node: PromptOutputProcessorNode) => Awaitable<void>
     assistant?: (node: PromptAssistantNode) => Awaitable<void>
+    chatParticipant?: (node: PromptChatParticipantNode) => Awaitable<void>
 }
 
 export async function visitNode(node: PromptNode, visitor: PromptNodeVisitor) {
@@ -309,6 +322,9 @@ export async function visitNode(node: PromptNode, visitor: PromptNodeVisitor) {
         case "assistant":
             await visitor.assistant?.(node as PromptAssistantNode)
             break
+        case "chatParticipant":
+            await visitor.chatParticipant?.(node as PromptChatParticipantNode)
+            break
     }
     if (node.error) visitor.error?.(node)
     if (!node.error && node.children) {
@@ -328,6 +344,7 @@ export interface PromptNodeRender {
     functions: ChatFunctionCallback[]
     fileMerges: FileMergeHandler[]
     outputProcessors: PromptOutputProcessorHandler[]
+    chatParticipants: ChatParticipantHandler[]
     messages: ChatCompletionMessageParam[]
 }
 
@@ -501,6 +518,7 @@ export async function renderPromptNode(
     const functions: ChatFunctionCallback[] = []
     const fileMerges: FileMergeHandler[] = []
     const outputProcessors: PromptOutputProcessorHandler[] = []
+    const chatParticipants: ChatParticipantHandler[] = []
 
     await visitNode(node, {
         text: async (n) => {
@@ -589,7 +607,11 @@ ${trimNewlines(schemaText)}
         },
         outputProcessor: (n) => {
             outputProcessors.push(n.fn)
-            trace.itemValue(`output processor`, n.fn)
+            trace.itemValue(`output processor`, n.fn.name)
+        },
+        chatParticipant: (n) => {
+            chatParticipants.push(n.participant)
+            trace.itemValue(`chat participant`, n.participant.name)
         },
     })
 
@@ -609,6 +631,7 @@ ${trimNewlines(schemaText)}
         functions,
         fileMerges,
         outputProcessors,
+        chatParticipants,
         errors,
         messages,
     }

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -101,7 +101,7 @@ export interface PromptOutputProcessorNode extends PromptNode {
 
 export interface PromptChatParticipantNode extends PromptNode {
     type: "chatParticipant"
-    participant: ChatParticipantHandler
+    participant: ChatParticipant
 }
 
 export function createTextNode(
@@ -234,7 +234,7 @@ export function createOutputProcessor(
 }
 
 export function createChatParticipant(
-    participant: ChatParticipantHandler
+    participant: ChatParticipant
 ): PromptChatParticipantNode {
     return { type: "chatParticipant", participant }
 }
@@ -344,7 +344,7 @@ export interface PromptNodeRender {
     functions: ChatFunctionCallback[]
     fileMerges: FileMergeHandler[]
     outputProcessors: PromptOutputProcessorHandler[]
-    chatParticipants: ChatParticipantHandler[]
+    chatParticipants: ChatParticipant[]
     messages: ChatCompletionMessageParam[]
 }
 
@@ -518,7 +518,7 @@ export async function renderPromptNode(
     const functions: ChatFunctionCallback[] = []
     const fileMerges: FileMergeHandler[] = []
     const outputProcessors: PromptOutputProcessorHandler[] = []
-    const chatParticipants: ChatParticipantHandler[] = []
+    const chatParticipants: ChatParticipant[] = []
 
     await visitNode(node, {
         text: async (n) => {
@@ -611,7 +611,10 @@ ${trimNewlines(schemaText)}
         },
         chatParticipant: (n) => {
             chatParticipants.push(n.participant)
-            trace.itemValue(`chat participant`, n.participant.name)
+            trace.itemValue(
+                `chat participant`,
+                n.participant.options?.label || n.participant.generator.name
+            )
         },
     })
 

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -102,6 +102,7 @@ export interface PromptOutputProcessorNode extends PromptNode {
 export interface PromptChatParticipantNode extends PromptNode {
     type: "chatParticipant"
     participant: ChatParticipant
+    options?: ChatParticipantOptions
 }
 
 export function createTextNode(

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -168,14 +168,6 @@ export async function runTemplate(
             topP: topP,
             seed: seed,
         }
-        const updateStatus = (text?: string) => {
-            options.infoCb?.({
-                vars,
-                text,
-                label,
-            })
-        }
-
         const fileEdits: Record<string, { before: string; after: string }> = {}
         const changelogs: string[] = []
         const edits: Edits[] = []
@@ -221,6 +213,7 @@ export async function runTemplate(
             connection.configuration,
             cancellationToken,
             messages,
+            vars,
             functions,
             schemas,
             completer,

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -100,6 +100,7 @@ export async function runTemplate(
             functions,
             fileMerges,
             outputProcessors,
+            chatParticipants,
             status,
             statusText,
             temperature,
@@ -223,6 +224,7 @@ export async function runTemplate(
             functions,
             schemas,
             completer,
+            chatParticipants,
             genOptions
         )
         const {

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -30,7 +30,7 @@ import { consoleLogFormat } from "./logging"
 import { host } from "./host"
 import { resolveFileDataUri } from "./file"
 
-export interface RunPromptContextNode extends RunPromptContext {
+export interface RunPromptContextNode extends PromptGenerationContext {
     node: PromptNode
 }
 

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -3,6 +3,7 @@ import {
     PromptNode,
     appendChild,
     createAssistantNode,
+    createChatParticipant,
     createDefDataNode,
     createDefNode,
     createFunctionNode,
@@ -104,6 +105,10 @@ export function createRunPromptContext(
         }
     }
 
+    const defChatParticipant = (participant: ChatParticipantHandler) => {
+        appendChild(node, createChatParticipant(participant))
+    }
+
     const ctx = <RunPromptContextNode>{
         node,
         writeText: (body, options) => {
@@ -167,6 +172,7 @@ export function createRunPromptContext(
         defTool,
         defSchema,
         defImages,
+        defChatParticipant,
         fence(body, options?: DefOptions) {
             ctx.def("", body, options)
             return undefined

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -162,6 +162,7 @@ export function createRunPromptContext(
                 let messages: ChatCompletionMessageParam[] = []
                 let functions: ChatFunctionCallback[] = undefined
                 let schemas: Record<string, JSONSchema> = undefined
+                let chatParticipants: ChatParticipantHandler[] = undefined
                 // expand template
                 const { provider } = parseModelIdentifier(genOptions.model)
                 if (provider === MODEL_PROVIDER_AICI) {
@@ -174,12 +175,14 @@ export function createRunPromptContext(
                         schemas: scs,
                         functions: fns,
                         messages: msgs,
+                        chatParticipants: cps,
                     } = await renderPromptNode(genOptions.model, node, {
                         trace,
                     })
 
                     schemas = scs
                     functions = fns
+                    chatParticipants = cps
                     messages.push(...msgs)
 
                     if (errors?.length)
@@ -207,6 +210,7 @@ export function createRunPromptContext(
                     functions,
                     schemas,
                     completer,
+                    chatParticipants,
                     genOptions
                 )
                 const { json, text } = resp

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -47,7 +47,7 @@ export function createRunPromptContext(
         const line = consoleLogFormat(...args)
         if (line) trace.log(line)
     }
-    const console = Object.freeze<PromptConsole>({
+    const console = Object.freeze<PromptGenerationConsole>({
         log,
         debug: log,
         warn: (args) => trace.warn(consoleLogFormat(...args)),

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -477,8 +477,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1204,7 +1205,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1214,7 +1215,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1230,7 +1231,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1493,7 +1494,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1242,7 +1242,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -477,9 +477,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1233,6 +1233,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1242,10 +1246,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1253,7 +1253,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -479,7 +479,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1239,6 +1239,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1497,7 +1498,6 @@ interface PromptContext extends RunPromptContext {
     defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    defChatParticipant(participant: ChatParticipantHandler): void
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -477,9 +477,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1205,7 +1214,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1214,8 +1223,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1225,6 +1233,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1241,8 +1253,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1494,7 +1505,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1233,10 +1233,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1513,6 +1509,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1207,7 +1207,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1232,7 +1232,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -476,6 +476,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1493,6 +1497,7 @@ interface PromptContext extends RunPromptContext {
     defImages(files: StringLike, options?: DefImagesOptions): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -192,7 +192,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -179,7 +179,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -178,7 +178,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -5,7 +5,7 @@
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -189,6 +189,12 @@ declare function runPrompt(
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
 
 /**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
+
+/**
  * @deprecated Use `defOutputProcessor` instead.
  */
 declare function defOutput(fn: PromptOutputProcessorHandler): void

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/sample/genaisrc/multi-turn.genai.js
+++ b/packages/sample/genaisrc/multi-turn.genai.js
@@ -1,0 +1,82 @@
+script({
+    model: "openai:gpt-3.5-turbo",
+    title: "Multi-turn conversation",
+    files: ["src/rag/markdown.md"],
+    system: ["system", "system.files"],
+})
+
+def("FILE", env.files)
+
+let turn = 0
+defChatParticipant(
+    async (_, messages) => {
+        turn++
+        if (turn <= 1) {
+            const text = messages.at(-1).content
+            const questions =
+                text
+                    ?.split("\n")
+                    .map((q) => q.trim())
+                    .filter((q) => q.length > 0) || []
+
+            _.$`Here is the list of answers to the questions in the file. 
+            
+## Task 1:
+
+Validate the quality of the answer.
+
+## Task 2:
+
+Write the question/answers pairs for each file in a "<filename>.qt.txt" file
+using the following format:
+
+\`\`\`\`markdown
+File: <filename>.qt.txt
+\`\`\`
+## <question>
+
+<answer>
+...
+\`\`\`
+\`\`\`\`
+
+
+            `
+
+            for (const question of questions) {
+                const res = await runPrompt(
+                    (_) => {
+                        _.def("FILE", env.files)
+                        _.def("QUESTION", question)
+                        _.$`
+## Roles
+                
+You are an expert educator at explaining concepts simply. 
+                
+## Task
+
+Answer the QUESTION using the contents in FILE. 
+
+## Instructions
+
+- Use information in FILE exclusively.
+- Be concise.
+- Use simple language.
+- use emojis.
+`
+                    },
+                    { label: question }
+                )
+
+                _.$`
+            
+- question: ${question}`
+                _.fence(res.text)
+                _.$`\n\n`
+            }
+        }
+    },
+    { label: "answerer" }
+)
+
+$`Generate a set of questions for the files to build a FAQ. Format one line per question in text.`

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/sample/genaisrc/pr-describe.genai.js
+++ b/packages/sample/genaisrc/pr-describe.genai.js
@@ -24,11 +24,11 @@ $`You are an expert software developer and architect.
 
 ## Task
 
-- Describe a summary of the changes in GIT_DIFF in a way that a software engineer will understand.
+- Describe a high level summary of the changes in GIT_DIFF in a way that a software engineer will understand.
 
 ## Instructions
 
-- separate changes that affect the CLI from changes that affect the library
+- try to extract the intent of the changes, don't focus on the details
 - use bullet points to list the changes
 - use emojis to make the description more engaging
 - focus on the most important changes

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -354,7 +354,7 @@ ${errorMessage(e)}`
             maxCachedTopP,
             vars: options.parameters,
             cache: cache && template.cache,
-            stats: { toolCalls: 0, repairs: 0 },
+            stats: { toolCalls: 0, repairs: 0, turns: 0 },
             cliInfo: {
                 spec:
                     this.host.isVirtualFile(fragment.file.filename) &&

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -511,9 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: ChatGenerationContext,
+    context: ChatTurnGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<ChatCompletionMessageParam[]>
+) => Awaitable<void>
 
 interface ChatParticipantOptions {
     label?: string
@@ -1267,6 +1267,10 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1276,10 +1280,6 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         schema: JSONSchema,
         options?: DefSchemaOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
         name: string,
@@ -1287,7 +1287,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
+    defChatParticipant(
+        participant: ChatParticipantHandler,
+        options?: ChatParticipantOptions
+    ): void
 }
 
 interface GenerationOutput {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1267,10 +1267,6 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     console: PromptGenerationConsole
 }
 
@@ -1547,6 +1543,10 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
     fetchText(
         urlOrFile: string | WorkspaceFile,
         options?: FetchTextOptions

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1241,7 +1241,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
 
 type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
-interface RunPromptOptions extends ModelOptions {
+interface PromptGeneratorOptions extends ModelOptions {
     /**
      * Label for trace
      */
@@ -1266,7 +1266,7 @@ interface PromptGenerationContext {
     ): string
     runPrompt(
         generator: string | PromptGenerator,
-        options?: RunPromptOptions
+        options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
     defTool(
@@ -1738,7 +1738,7 @@ declare function cancel(reason?: string): void
  */
 declare function runPrompt(
     generator: string | PromptGenerator,
-    options?: RunPromptOptions
+    options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
 
 /**

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -511,9 +511,18 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
-    context: PromptGenerationContext,
+    context: ChatGenerationContext,
     messages: ChatCompletionMessageParam[]
 ) => Awaitable<ChatCompletionMessageParam[]>
+
+interface ChatParticipantOptions {
+    label?: string
+}
+
+interface ChatParticipant {
+    generator: ChatParticipantHandler
+    options: ChatParticipantOptions
+}
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1239,7 +1248,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
+type PromptGenerator = (ctx: ChatGenerationContext) => Awaitable<void>
 
 interface PromptGeneratorOptions extends ModelOptions {
     /**
@@ -1248,8 +1257,7 @@ interface PromptGeneratorOptions extends ModelOptions {
     label?: string
 }
 
-// keep in sync with prompt_type.d.ts
-interface PromptGenerationContext {
+interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1259,6 +1267,10 @@ interface PromptGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    console: PromptGenerationConsole
+}
+
+interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
         schema: JSONSchema,
@@ -1275,8 +1287,7 @@ interface PromptGenerationContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
-    defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptGenerationConsole
+    defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 }
 
 interface GenerationOutput {
@@ -1528,7 +1539,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends PromptGenerationContext {
+interface PromptContext extends ChatGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1751,7 +1762,7 @@ declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
  * Registers a chat participant
  * @param participant
  */
-declare function defChatParticipant(participant: ChatParticipantHandler): void
+declare function defChatParticipant(participant: ChatParticipantHandler, options?: ChatParticipantOptions): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -511,8 +511,9 @@ interface ChatFunctionCallback {
 }
 
 type ChatParticipantHandler = (
+    context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Promise<string>
+) => Awaitable<void>
 
 /**
  * A set of text extracted from the context of the prompt execution
@@ -1238,7 +1239,7 @@ interface WriteTextOptions extends ContextExpansionOptions {
     assistant?: boolean
 }
 
-type RunPromptGenerator = (ctx: RunPromptContext) => Awaitable<void>
+type PromptGenerator = (ctx: PromptGenerationContext) => Awaitable<void>
 
 interface RunPromptOptions extends ModelOptions {
     /**
@@ -1248,7 +1249,7 @@ interface RunPromptOptions extends ModelOptions {
 }
 
 // keep in sync with prompt_type.d.ts
-interface RunPromptContext {
+interface PromptGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
@@ -1264,7 +1265,7 @@ interface RunPromptContext {
         options?: DefSchemaOptions
     ): string
     runPrompt(
-        generator: string | RunPromptGenerator,
+        generator: string | PromptGenerator,
         options?: RunPromptOptions
     ): Promise<RunPromptResult>
     defImages(files: StringLike, options?: DefImagesOptions): void
@@ -1527,7 +1528,7 @@ interface ContainerHost extends ShellHost {
     readText(path: string): Promise<string>
 }
 
-interface PromptContext extends RunPromptContext {
+interface PromptContext extends PromptGenerationContext {
     script(options: PromptArgs): void
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
@@ -1736,7 +1737,7 @@ declare function cancel(reason?: string): void
  * @param generator
  */
 declare function runPrompt(
-    generator: string | RunPromptGenerator,
+    generator: string | PromptGenerator,
     options?: RunPromptOptions
 ): Promise<RunPromptResult>
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -510,6 +510,10 @@ interface ChatFunctionCallback {
     ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
 }
 
+type ChatParticipantHandler = (
+    messages: ChatCompletionMessageParam[]
+) => Promise<string>
+
 /**
  * A set of text extracted from the context of the prompt execution
  */
@@ -1269,6 +1273,7 @@ interface RunPromptContext {
         parameters: PromptParametersSchema | JSONSchema,
         fn: ChatFunctionHandler
     ): void
+    defChatParticipant(participant: ChatParticipantHandler): void
     console: PromptConsole
 }
 
@@ -1740,6 +1745,12 @@ declare function runPrompt(
  * @param fn
  */
 declare function defOutputProcessor(fn: PromptOutputProcessorHandler): void
+
+/**
+ * Registers a chat participant
+ * @param participant
+ */
+declare function defChatParticipant(participant: ChatParticipantHandler): void
 
 /**
  * @deprecated Use `defOutputProcessor` instead.

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -513,7 +513,7 @@ interface ChatFunctionCallback {
 type ChatParticipantHandler = (
     context: PromptGenerationContext,
     messages: ChatCompletionMessageParam[]
-) => Awaitable<void>
+) => Awaitable<ChatCompletionMessageParam[]>
 
 /**
  * A set of text extracted from the context of the prompt execution

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1,4 +1,4 @@
-interface PromptConsole {
+interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
     debug(...data: any[]): void
@@ -1276,7 +1276,7 @@ interface PromptGenerationContext {
         fn: ChatFunctionHandler
     ): void
     defChatParticipant(participant: ChatParticipantHandler): void
-    console: PromptConsole
+    console: PromptGenerationConsole
 }
 
 interface GenerationOutput {
@@ -1564,7 +1564,7 @@ interface PromptContext extends PromptGenerationContext {
 /**
  * Console functions
  */
-declare var console: PromptConsole
+declare var console: PromptGenerationConsole
 
 /**
  * Setup prompt title and other parameters.


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

### Library Changes
- 🆕 Added a new type `ChatParticipantHandler` which is a function that takes an array of `ChatCompletionMessageParam` and returns a `Promise<string>`.
- 🧩 Introduced `chatParticipants` as an array of `ChatParticipantHandler` in various parts of the codebase:
  - `executeChatSession` function in `chat.ts` now accepts `chatParticipants` as an additional parameter.
  - `callExpander` function in `expander.ts` now initializes and includes `chatParticipants` in its return object.
  - `expandTemplate` function in `expander.ts` now includes `chatParticipants` in its processing logic.
  - `createPromptContext` function in `promptcontext.ts` now provides a `defChatParticipant` method to define a chat participant.
  - `PromptNode` interface in `promptdom.ts` has a new type `"chatParticipant"` to represent chat participant nodes.
  - `createChatParticipant` function in `promptdom.ts` creates a new `PromptChatParticipantNode`.
  - `renderPromptNode` function in `promptdom.ts` now handles `chatParticipant` nodes and includes them in the `PromptNodeRender` interface.
  - `runTemplate` function in `promptrunner.ts` now includes `chatParticipants` in its execution flow.
  - `createRunPromptContext` function in `runpromptcontext.ts` now supports `chatParticipants` and includes them in the execution context.

### CLI Changes
- None of the changes directly affect the CLI interface; all changes are internal to the library's handling of chat participants within the code execution flow.

> generated by genaiscript [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9435044172)



<!-- genaiscript end pr-describe -->

