### PR TITLE
curl escape

### DIFF
--- a/docs/src/content/docs/guides/pull-request-reviewer.mdx
+++ b/docs/src/content/docs/guides/pull-request-reviewer.mdx
@@ -14,7 +14,9 @@ The reviewer can also suggest changes to the code, documentation, or other files
 
 The output of the LLM is inserted as a comment in the pull request conversation 
 (and updated as needed to avoid duplicates). 
-Here is an [example](https://github.com/microsoft/genaiscript/pull/504#issuecomment-2145273728) in the GenAIScript repository.
+
+Here is an [pull request](https://github.com/microsoft/genaiscript/pull/534) in the GenAIScript repository
+with genai-generated description, comments and reviews.
 
 ## Step 1: The script
 

--- a/packages/core/src/openai.ts
+++ b/packages/core/src/openai.ts
@@ -130,12 +130,12 @@ export const OpenAIChatCompletion: ChatCompletionHandler = async (
 
     trace.detailsFenced(
         `✉️ fetch`,
-        `curl ${url} \\
+        `curl -X POST ${url} \\
 -H "Content-Type: application/json" \\
 ${Object.entries(cfg.curlHeaders || {})
     .map(([k, v]) => `-H "${k}: ${v}" \\`)
     .join("\n")}
--d '${JSON.stringify(postReq, null, 2)}' 
+-d '${JSON.stringify(postReq).replace(/'/g, "'\\''")}' 
 `,
         "bash"
     )

--- a/packages/vscode/src/vshost.ts
+++ b/packages/vscode/src/vshost.ts
@@ -254,6 +254,9 @@ export class VSCodeHost extends EventTarget implements Host {
             })
             if (!azureToken) throw new Error("Azure token not available")
             tok.token = "Bearer " + azureToken
+            tok.curlHeaders = {
+                Authorization: "Bearer ***",
+            }
         }
         return tok
     }


### PR DESCRIPTION
Fix JSON escaping of curl commands

<!-- genaiscript begin pr-describe -->

- 🔄 The `curl` command in the script has been modified to explicitly use the `POST` method by adding `-X POST`.
- 🛠️ The JSON data passed to the `-d` option of `curl` is now being sanitized to escape single quotes properly, ensuring that the JSON string is correctly formatted for the shell command.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9469413952)



<!-- genaiscript end pr-describe -->

