### PR TITLE
configurable max data repairs

### DIFF
--- a/demo/genaisrc/genaiscript.d.ts
+++ b/demo/genaisrc/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1219,6 +1224,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -147,6 +147,11 @@ interface ModelOptions extends ModelConnectionOptions {
     maxToolCalls?: number
 
     /**
+     * Maximum number of data repairs to attempt.
+     */
+    maxDataRepairs?: number
+
+    /**
      * A deterministic integer seed to use for the model.
      */
     seed?: number
@@ -1253,6 +1258,9 @@ interface DefDataOptions
 }
 
 interface DefSchemaOptions {
+    /**
+     * Output format in the prompt.
+     */
     format?: "typescript" | "json" | "yaml"
 }
 


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- The code change primarily involves modifications to functions `applyRepairs` and `processChatMessage` in `chat.ts`.
- The trace message has been updated in the `applyRepairs` function to say "data repairs" instead of just "repair" 🔧.
- The formatting of the repair message constructed in the `applyRepairs` function has been changed, with more emphasis on the importance of repairing formatting issues 🧹.
- The `processChatMessage` function now directly utilizes the `maxDataRepairs` option from the function's arguments, instead of reassigning it to a local variable. This may help reduce memory usage and increase efficiency 🚀.
- A throw error in `processChatMessage` has been restructured for better readability 📖. 
- The `maxDataRepairs` option has been added to the `ModelOptions` interface in `prompt_template.d.ts`. This could be to limit the number of data repairs a model can attempt, adding a control mechanism ⚙️.
- Added a comment to the `DefSchemaOptions` interface describing the `format` field 📝.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9576377465)



<!-- genaiscript end pr-describe -->

