### PR TITLE
support shelloutput from tools

### DIFF
--- a/demo/genaisrc/genaiscript.d.ts
+++ b/demo/genaisrc/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -160,7 +160,11 @@ export class DockerManager {
             trace?.itemValue(`host path`, hostPath)
             trace?.itemValue(`container path`, containerPath)
 
-            const exec: ShellHost["exec"] = async (command, args, options) => {
+            const exec: ShellHost["exec"] = async (
+                command,
+                args,
+                options
+            ): Promise<ShellOutput> => {
                 const { cwd = containerPath, label } = options || {}
                 try {
                     trace?.startDetails(
@@ -188,17 +192,18 @@ export class DockerManager {
                     const inspect = await exec.inspect()
                     const exitCode = inspect.ExitCode
 
-                    const sres = {
+                    const sres: ShellOutput = {
                         exitCode,
                         stdout: stdout.toString(),
                         stderr: stderr.toString(),
+                        failed: exitCode !== 0,
                     }
                     trace?.resultItem(
                         exitCode === 0,
                         `exit code: ${sres.exitCode}`
                     )
-                    if (sres.stdout) trace?.detailsFenced(`output`, sres.stdout)
-                    if (sres.stderr) trace?.detailsFenced(`error`, sres.stderr)
+                    if (sres.stdout) trace?.detailsFenced(`stdout`, sres.stdout)
+                    if (sres.stderr) trace?.detailsFenced(`stderr`, sres.stderr)
 
                     return sres
                 } finally {

--- a/packages/core/src/expander.ts
+++ b/packages/core/src/expander.ts
@@ -105,7 +105,7 @@ async function callExpander(
     let assistantText = ""
     let images: PromptImage[] = []
     let schemas: Record<string, JSONSchema> = {}
-    let functions: ChatFunctionCallback[] = []
+    let functions: ToolCallback[] = []
     let fileMerges: FileMergeHandler[] = []
     let outputProcessors: PromptOutputProcessorHandler[] = []
     let chatParticipants: ChatParticipant[] = []

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -186,7 +186,7 @@ export interface Host {
         command: string,
         args: string[],
         options: ShellOptions & TraceOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 
     /**
      * Starts a container to execute sandboxed code

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -233,7 +233,7 @@ export function createPromptContext(
                 checkCancelled(cancellationToken)
 
                 let messages: ChatCompletionMessageParam[] = []
-                let functions: ChatFunctionCallback[] = undefined
+                let tools: ToolCallback[] = undefined
                 let schemas: Record<string, JSONSchema> = undefined
                 let chatParticipants: ChatParticipant[] = undefined
                 // expand template
@@ -254,7 +254,7 @@ export function createPromptContext(
                     })
 
                     schemas = scs
-                    functions = fns
+                    tools = fns
                     chatParticipants = cps
                     messages.push(...msgs)
 
@@ -281,7 +281,7 @@ export function createPromptContext(
                     cancellationToken,
                     messages,
                     vars,
-                    functions,
+                    tools,
                     schemas,
                     completer,
                     chatParticipants,

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -349,7 +349,7 @@ export interface PromptNodeRender {
     images: PromptImage[]
     errors: unknown[]
     schemas: Record<string, JSONSchema>
-    functions: ChatFunctionCallback[]
+    functions: ToolCallback[]
     fileMerges: FileMergeHandler[]
     outputProcessors: PromptOutputProcessorHandler[]
     chatParticipants: ChatParticipant[]
@@ -533,7 +533,7 @@ export async function renderPromptNode(
     const images: PromptImage[] = []
     const errors: unknown[] = []
     const schemas: Record<string, JSONSchema> = {}
-    const functions: ChatFunctionCallback[] = []
+    const functions: ToolCallback[] = []
     const fileMerges: FileMergeHandler[] = []
     const outputProcessors: PromptOutputProcessorHandler[] = []
     const chatParticipants: ChatParticipant[] = []

--- a/packages/core/src/testhost.ts
+++ b/packages/core/src/testhost.ts
@@ -109,7 +109,7 @@ export class TestHost implements Host {
         command: string,
         args: string[],
         options: ShellOptions
-    ): Promise<Partial<ShellOutput>> {
+    ): Promise<ShellOutput> {
         throw new Error("Method not implemented.")
     }
     container(

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -17,7 +17,7 @@ import { estimateTokens } from "./tokens"
 
 export class MarkdownTrace
     extends EventTarget
-    implements ChatFunctionCallTrace
+    implements ToolCallTrace
 {
     readonly errors: { message: string; error: SerializedError }[] = []
     private detailsDepth = 0

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -353,7 +353,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -378,7 +378,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -432,13 +432,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -469,15 +469,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1231,8 +1231,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1459,7 +1459,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/genaisrc/clang-container.genai.js
+++ b/packages/sample/genaisrc/clang-container.genai.js
@@ -1,0 +1,24 @@
+script({
+    model: "openai:gpt-3.5-turbo",
+})
+const container = await host.container({
+    image: "chainguard/clang",
+})
+let sourceIndex = 0
+defTool(
+    "clang",
+    "C compiler",
+    {
+        source: "",
+    },
+    async (args) => {
+        const { source } = args
+
+        const cwd = `tmp/${sourceIndex++}`
+        const fn = `main.c`
+        await container.writeText(fn, source)
+        return await container.exec("clang", [fn], { cwd })
+    }
+)
+
+$`Generate a valid C program that prints "Hello, World!"`

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {

--- a/packages/vscode/src/vshost.ts
+++ b/packages/vscode/src/vshost.ts
@@ -321,7 +321,7 @@ export class VSCodeHost extends EventTarget implements Host {
         command: string,
         args: string[],
         options: ShellOptions
-    ): Promise<Partial<ShellOutput>> {
+    ): Promise<ShellOutput> {
         const res = await this.server.client.exec(
             containerId,
             command,

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -387,7 +387,7 @@ interface WorkspaceFileWithScore extends WorkspaceFile {
     score?: number
 }
 
-interface ChatFunctionDefinition {
+interface ToolDefinition {
     /**
      * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
      * underscores and dashes, with a maximum length of 64.
@@ -412,7 +412,7 @@ interface ChatFunctionDefinition {
     parameters?: JSONSchema
 }
 
-interface ChatFunctionCallTrace {
+interface ToolCallTrace {
     log(message: string): void
     item(message: string): void
     tip(message: string): void
@@ -466,13 +466,13 @@ interface CreateFileEdit extends FileEdit {
 
 type Edits = InsertEdit | ReplaceEdit | DeleteEdit | CreateFileEdit
 
-interface ChatFunctionCallContent {
+interface ToolCallContent {
     type?: "content"
     content: string
     edits?: Edits[]
 }
 
-type ChatFunctionCallOutput = string | ChatFunctionCallContent
+type ToolCallOutput = string | ToolCallContent | ShellOutput
 
 interface WorkspaceFileSystem {
     /**
@@ -503,15 +503,15 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 }
 
-interface ChatFunctionCallContext {
-    trace: ChatFunctionCallTrace
+interface ToolCallContext {
+    trace: ToolCallTrace
 }
 
-interface ChatFunctionCallback {
-    definition: ChatFunctionDefinition
+interface ToolCallback {
+    definition: ToolDefinition
     fn: (
-        args: { context: ChatFunctionCallContext } & Record<string, any>
-    ) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+        args: { context: ToolCallContext } & Record<string, any>
+    ) => ToolCallOutput | Promise<ToolCallOutput>
 }
 
 type ChatParticipantHandler = (
@@ -1265,8 +1265,8 @@ interface DefSchemaOptions {
 }
 
 type ChatFunctionHandler = (
-    args: { context: ChatFunctionCallContext } & Record<string, any>
-) => ChatFunctionCallOutput | Promise<ChatFunctionCallOutput>
+    args: { context: ToolCallContext } & Record<string, any>
+) => ToolCallOutput | Promise<ToolCallOutput>
 
 interface WriteTextOptions extends ContextExpansionOptions {
     /**
@@ -1493,7 +1493,7 @@ interface ShellHost {
         command: string,
         args: string[],
         options?: ShellOptions
-    ): Promise<Partial<ShellOutput>>
+    ): Promise<ShellOutput>
 }
 
 interface ContainerOptions {


### PR DESCRIPTION
Allow to return of 'exec' from a tool without processing.

<!-- genaiscript begin pr-describe -->

- 👷‍♀️ The main theme of the changes is refactoring and renaming to improve code clarity and consistency. 

- ⚙️ In several parts of the code, the term "ChatFunction" has been replaced with the term "Tool" to better reflect the purpose of these structures and calls. This includes renaming classes, interfaces, and variables that previously had "ChatFunction" in their names. 

- 📝 In few cases, the output or return values of certain functions have been explicitly defined and/or given more descriptive names.

- 🔄 In `packages/cli/src/docker.ts`, the structure of the `exec` function was expanded for better readability and the addition of a new property `failed` to `ShellOutput`.

- 🖼️ There are also updates in the handling of output content. For example, in `packages/core/src/chat.ts`, the output is checked to see if it's a `ShellOutput` object and if so, it's stringified into YAML format. 

- 🐞 Some error handling and logging related changes have been made. The error and output logs have been renamed to `stderr` and `stdout` respectively for better clarity.

- 🚀 In `packages/sample/genaisrc/clang-container.genai.js`, a new tool "clang" is defined, it seems to compile C code in a created container.

- 📦 Overall, these changes seem to be aimed at improving the clarity, consistency, and robustness of the code.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9586063737)



<!-- genaiscript end pr-describe -->

