### PR TITLE
move models, retreival to runtimehost

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -95,40 +95,6 @@ export async function startServer(options: { port: string }) {
                         process.exit(0)
                         break
                     }
-                    case "models.pull": {
-                        console.log(`models: pull ${data.model}`)
-                        response = await runtimeHost.models.pullModel(
-                            data.model
-                        )
-                        break
-                    }
-                    case "retrieval.vectorClear":
-                        console.log(`retrieval: clear`)
-                        await runtimeHost.retrieval.init()
-                        response = await runtimeHost.retrieval.vectorClear(
-                            data.options
-                        )
-                        break
-                    case "retrieval.vectorUpsert": {
-                        console.log(`retrieval: upsert ${data.filename}`)
-                        await runtimeHost.retrieval.init()
-                        response = await runtimeHost.retrieval.vectorUpsert(
-                            data.filename,
-                            data.options
-                        )
-                        break
-                    }
-                    case "retrieval.vectorSearch": {
-                        console.log(`retrieval: search ${data.text}`)
-                        console.debug(YAMLStringify(data.options))
-                        await runtimeHost.retrieval.init()
-                        response = await runtimeHost.retrieval.vectorSearch(
-                            data.text,
-                            data.options
-                        )
-                        console.debug(YAMLStringify(response))
-                        break
-                    }
                     case "parse.pdf": {
                         console.log(`parse: pdf ${data.filename}`)
                         await runtimeHost.parser.init()
@@ -171,7 +137,7 @@ export async function startServer(options: { port: string }) {
                                     ...payload,
                                 })
                             )
-                        trace.addEventListener(TRACE_CHUNK, (ev) =>{
+                        trace.addEventListener(TRACE_CHUNK, (ev) => {
                             const tev = ev as TraceChunkEvent
                             send({ trace: tev.chunk })
                         })

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -111,8 +111,6 @@ export interface Host {
     userState: any
 
     parser: ParseService
-    retrieval: RetrievalService
-    models: ModelService
     server: ServerManager
     path: Path
 
@@ -157,6 +155,8 @@ export interface Host {
 }
 
 export interface RuntimeHost extends Host {
+    retrieval: RetrievalService
+    models: ModelService
     workspace: Omit<WorkspaceFileSystem, "grep">
 
     // executes a process

--- a/packages/core/src/retrieval.ts
+++ b/packages/core/src/retrieval.ts
@@ -9,7 +9,7 @@ import {
     RetrievalClientOptions,
     RetrievalSearchOptions,
     RetrievalUpsertOptions,
-    host,
+    runtimeHost,
 } from "./host"
 import { lookupMime } from "./mime"
 
@@ -30,8 +30,8 @@ export async function clearVectorIndex(
     options?: RetrievalClientOptions & VectorSearchOptions
 ): Promise<void> {
     const { trace } = options || {}
-    await host.retrieval.init(trace)
-    await host.retrieval.vectorClear(options)
+    await runtimeHost.retrieval.init(trace)
+    await runtimeHost.retrieval.vectorClear(options)
 }
 
 export async function upsertVector(
@@ -41,7 +41,7 @@ export async function upsertVector(
     if (!fileOrUrls?.length) return
     const { progress, trace, token, ...rest } = options || {}
     const { llmModel, embedModel } = options || {}
-    const { retrieval, models } = host
+    const { retrieval, models } = runtimeHost
     await retrieval.init(trace)
     if (llmModel || embedModel) {
         progress?.start("pulling models")
@@ -79,8 +79,8 @@ export async function vectorSearch(
 ): Promise<RetrievalSearchResult> {
     const { trace, token, ...rest } = options || {}
     const files: WorkspaceFileWithScore[] = []
-    const retrieval = host.retrieval
-    await host.retrieval.init(trace)
+    const retrieval = runtimeHost.retrieval
+    await retrieval.init(trace)
     if (token?.isCancellationRequested) return { files, chunks: [] }
 
     const { results: chunks = [] } = await retrieval.vectorSearch(q, rest)

--- a/packages/core/src/server/client.ts
+++ b/packages/core/src/server/client.ts
@@ -4,14 +4,9 @@ import { randomHex } from "../crypto"
 import { errorMessage } from "../error"
 import { GenerationResult } from "../expander"
 import {
-    ModelService,
     ParsePdfResponse,
     ParseService,
     ResponseStatus,
-    RetrievalSearchOptions,
-    RetrievalSearchResponse,
-    RetrievalService,
-    RetrievalUpsertOptions,
     host,
 } from "../host"
 import { MarkdownTrace, TraceOptions } from "../trace"
@@ -20,13 +15,9 @@ import {
     ParsePdfMessage,
     RequestMessage,
     RequestMessages,
-    RetrievalVectorClear,
-    RetrievalSearch,
-    RetrievalVectorUpsert,
     ServerVersion,
     PromptScriptTestRun,
     PromptScriptTestRunOptions,
-    ModelsPull,
     PromptScriptTestRunResponse,
     ShellExecResponse,
     ShellExec,
@@ -39,7 +30,7 @@ import {
 
 export class WebSocketClient
     extends EventTarget
-    implements RetrievalService, ParseService, ModelService
+    implements ParseService
 {
     private awaiters: Record<
         string,
@@ -222,44 +213,8 @@ export class WebSocketClient
         return res.version
     }
 
-    async pullModel(model: string): Promise<ResponseStatus> {
-        const res = await this.queue<ModelsPull>({
-            type: "models.pull",
-            model,
-        })
-        return res.response
-    }
-
     async infoEnv(): Promise<ResponseStatus> {
         const res = await this.queue<ServerEnv>({ type: "server.env" })
-        return res.response
-    }
-
-    async vectorClear(options: VectorSearchOptions): Promise<ResponseStatus> {
-        const res = await this.queue<RetrievalVectorClear>({
-            type: "retrieval.vectorClear",
-            options,
-        })
-        return res.response
-    }
-
-    async vectorSearch(
-        text: string,
-        options?: RetrievalSearchOptions
-    ): Promise<RetrievalSearchResponse> {
-        const res = await this.queue<RetrievalSearch>({
-            type: "retrieval.vectorSearch",
-            text,
-            options,
-        })
-        return res.response
-    }
-    async vectorUpsert(filename: string, options?: RetrievalUpsertOptions) {
-        const res = await this.queue<RetrievalVectorUpsert>({
-            type: "retrieval.vectorUpsert",
-            filename,
-            options,
-        })
         return res.response
     }
 

--- a/packages/core/src/server/messages.ts
+++ b/packages/core/src/server/messages.ts
@@ -17,16 +17,6 @@ export interface ServerKill extends RequestMessage {
     type: "server.kill"
 }
 
-export interface ModelsPull extends RequestMessage {
-    type: "models.pull"
-    model: string
-}
-
-export interface RetrievalVectorClear extends RequestMessage {
-    type: "retrieval.vectorClear"
-    options?: VectorSearchOptions
-}
-
 export interface ServerVersion extends RequestMessage {
     type: "server.version"
     version?: string
@@ -34,19 +24,6 @@ export interface ServerVersion extends RequestMessage {
 
 export interface ServerEnv extends RequestMessage {
     type: "server.env"
-}
-
-export interface RetrievalVectorUpsert extends RequestMessage {
-    type: "retrieval.vectorUpsert"
-    filename: string
-    options?: RetrievalVectorUpsertOptions
-}
-
-export interface RetrievalSearch extends RequestMessage {
-    type: "retrieval.vectorSearch"
-    text: string
-    options?: RetrievalSearchOptions
-    response?: RetrievalSearchResponse
 }
 
 export interface ParsePdfMessage extends RequestMessage {
@@ -164,13 +141,9 @@ export type RequestMessages =
     | ServerKill
     | ServerVersion
     | ServerEnv
-    | RetrievalVectorClear
-    | RetrievalVectorUpsert
-    | RetrievalSearch
     | ServerVersion
     | ParsePdfMessage
     | PromptScriptTestRun
-    | ModelsPull
     | ShellExec
     | PromptScriptStart
     | PromptScriptAbort

--- a/packages/vscode/src/servermanager.ts
+++ b/packages/vscode/src/servermanager.ts
@@ -63,15 +63,7 @@ export class TerminalServerManager implements ServerManager {
         return !!this._terminal
     }
 
-    get retrieval(): RetrievalService {
-        return this.client
-    }
-
     get parser(): ParseService {
-        return this.client
-    }
-
-    get models(): ModelService {
         return this.client
     }
 

--- a/packages/vscode/src/vshost.ts
+++ b/packages/vscode/src/vshost.ts
@@ -61,14 +61,6 @@ export class VSCodeHost extends EventTarget implements Host {
         return this._azure
     }
 
-    get retrieval() {
-        return this.server.retrieval
-    }
-
-    get models() {
-        return this.server.models
-    }
-
     get context() {
         return this.state.context
     }


### PR DESCRIPTION
retreival and model messages are no longer needed; cleaning out

<!-- genaiscript begin pr-describe -->

- This GIT_DIFF represents a significant refactor of the codebase, including aspects of server behavior, vector services, and model management. :hammer_and_wrench:
- The server code is significantly refactored by removing several cases such as `models.pull`, `retrieval.vectorClear`, `retrieval.vectorUpsert`, and `retrieval.vectorSearch`. So, it appears some server-side operations related to model retrieval and vector operations are pruned. :negative_squared_cross_mark:
- The `host` interface's implementation has been altered, moving the `retrieval: RetrievalService` and `models: ModelService` to the `RuntimeHost` interface. This indicates that handling retrieval service and model service are getting a revamp, possibly consolidating these tasks under the `RuntimeHost`. :recycle:  
- The retrieval service handlers `clearVectorIndex` and `vectorSearch` are modified to use `runtimeHost` replacing the `host`. This reflects re-organization of service handling logic. :arrows_counterclockwise:
- Most of the operations, interfaces, and functionalities related to model retrieval and vector services are removed from WebSocketClient and messages. This implies a major refactor, possibly moving these responsibilities somewhere else for better management or simplification. :scissors:
- Model and retrieval services are also removed from `TerminalServerManager` indicating a broader strategy of restructuring these services in the system. :building_construction:
- Finally, the retrieval and model functionalities are removed from the `VSCodeHost` as well. Again reflecting the systematic removal of these functional aspects from different parts of the codebase. :construction_worker:
  
Overall, the changes in the codebase seem to be part of a larger refactoring task with the ultimate goal of restructuring how retrieval and model services work within the system. :rocket:

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/9901562325)



<!-- genaiscript end pr-describe -->

