### PR TITLE
vscode + github models

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -192,7 +192,7 @@ export async function startServer(options: { port: string }) {
                     }
                     case "model.configuration": {
                         const { model, token } = data
-                        console.log(`model: configuration ${model}`)
+                        console.log(`model: lookup configuration ${model}`)
                         const info = await host.getLanguageModelConfiguration(
                             model,
                             { token }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -33,6 +33,7 @@ import {
     ChatStart,
     ChatChunk,
     ChatCancel,
+    LanguageModelConfigurationResponse,
 } from "../../core/src/server/messages"
 import { envInfo } from "./info"
 import { LanguageModel } from "../../core/src/chat"
@@ -187,6 +188,19 @@ export async function startServer(options: { port: string }) {
                     case "server.kill": {
                         console.log(`server: kill`)
                         process.exit(0)
+                        break
+                    }
+                    case "model.configuration": {
+                        const { model, token } = data
+                        console.log(`model: configuration ${model}`)
+                        const info = await host.getLanguageModelConfiguration(
+                            model,
+                            { token }
+                        )
+                        response = <LanguageModelConfigurationResponse>{
+                            ok: true,
+                            info,
+                        }
                         break
                     }
                     case "tests.run": {

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -107,8 +107,8 @@ export async function parseTokenFromEnv(
             ? "GITHUB_MODELS_TOKEN"
             : "GITHUB_TOKEN"
         const token = env[tokenVar]
-        // TODO: handle missing token
-        // if (!token) throw new Error("GITHUB_TOKEN must be set")
+        if (!token)
+            throw new Error("GITHUB_MODELS_TOKEN or GITHUB_TOKEN must be set")
         const type = "openai"
         const base = GITHUB_MODELS_BASE
         return {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -37,12 +37,8 @@ export const CLIENT_RECONNECT_DELAY = 3000
 export const CLIENT_RECONNECT_MAX_ATTEMPTS = 20
 export const RETRIEVAL_PERSIST_DIR = "retrieval"
 export const HIGHLIGHT_LENGTH = 4000
-export const DEFAULT_MODEL = "openai:gpt-4"
-export const DEFAULT_MODEL_CANDIDATES = [
-    "openai:gpt-4o",
-    "azure:gpt-4o",
-    "github:gpt-4o",
-]
+export const DEFAULT_MODEL = "openai:gpt-4o"
+export const DEFAULT_MODEL_CANDIDATES = ["azure:gpt-4o", "github:gpt-4o"]
 export const DEFAULT_EMBEDDINGS_MODEL = "openai:text-embedding-ada-002"
 export const DEFAULT_TEMPERATURE = 0.8
 export const BUILTIN_PREFIX = "_builtin/"

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -5,7 +5,7 @@ import {
     GITHUB_TOKEN,
 } from "./constants"
 import { createFetch } from "./fetch"
-import { host } from "./host"
+import { runtimeHost } from "./host"
 import { link, prettifyMarkdown } from "./markdown"
 import { logError, logVerbose, normalizeInt } from "./util"
 
@@ -70,7 +70,7 @@ export async function githubUpdatePullRequestDescription(
     assert(commentTag)
 
     if (!issue) return { updated: false, statusText: "missing issue number" }
-    const token = await host.readSecret(GITHUB_TOKEN)
+    const token = await runtimeHost.readSecret(GITHUB_TOKEN)
     if (!token) return { updated: false, statusText: "missing github token" }
 
     text = prettifyMarkdown(text)
@@ -169,7 +169,7 @@ export async function githubCreateIssueComment(
     const { apiUrl, repository, issue } = info
 
     if (!issue) return { created: false, statusText: "missing issue number" }
-    const token = await host.readSecret(GITHUB_TOKEN)
+    const token = await runtimeHost.readSecret(GITHUB_TOKEN)
     if (!token) return { created: false, statusText: "missing github token" }
 
     const fetch = await createFetch({ retryOn: [] })
@@ -313,7 +313,7 @@ export async function githubCreatePullRequestReviews(
         logError("missing commit sha")
         return false
     }
-    const token = await host.readSecret(GITHUB_TOKEN)
+    const token = await runtimeHost.readSecret(GITHUB_TOKEN)
     if (!token) {
         logError("missing github token")
         return false

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -97,7 +97,6 @@ export interface Host {
     resolvePath(...segments: string[]): string
 
     // read a secret from the environment or a .env file
-    readSecret(name: string): Promise<string | undefined>
     defaultModelOptions: Required<Pick<ModelOptions, "model" | "temperature">>
     defaultEmbeddingsModelOptions: Required<
         Pick<EmbeddingsModelOptions, "embeddingsModel">
@@ -130,6 +129,7 @@ export interface RuntimeHost extends Host {
     models: ModelService
     workspace: Omit<WorkspaceFileSystem, "grep">
 
+    readSecret(name: string): Promise<string | undefined>
     // executes a process
     exec(
         containerId: string,

--- a/packages/core/src/server/client.ts
+++ b/packages/core/src/server/client.ts
@@ -3,7 +3,7 @@ import { CLIENT_RECONNECT_DELAY, OPEN, RECONNECT } from "../constants"
 import { randomHex } from "../crypto"
 import { errorMessage } from "../error"
 import { GenerationResult } from "../generation"
-import { ResponseStatus, host } from "../host"
+import { LanguageModelConfiguration, ResponseStatus, host } from "../host"
 import { MarkdownTrace } from "../trace"
 import { assert, logError } from "../util"
 import {
@@ -23,6 +23,7 @@ import {
     ChatEvents,
     ChatChunk,
     ChatStart,
+    LanguageModelConfigurationRequest,
 } from "./messages"
 
 export type LanguageModelChatRequest = (
@@ -229,6 +230,18 @@ export class WebSocketClient extends EventTarget {
         const cancellers = Object.values(this.awaiters)
         this.awaiters = {}
         cancellers.forEach((a) => a.reject(reason || "cancelled"))
+    }
+
+    async getLanguageModelConfiguration(
+        modelId: string,
+        options?: { token?: boolean }
+    ): Promise<LanguageModelConfiguration | undefined> {
+        const res = await this.queue<LanguageModelConfigurationRequest>({
+            type: "model.configuration",
+            model: modelId,
+            token: options?.token,
+        })
+        return res.response?.ok ? res.response.info : undefined
     }
 
     async version(): Promise<string> {

--- a/packages/core/src/server/messages.ts
+++ b/packages/core/src/server/messages.ts
@@ -1,6 +1,6 @@
 import { ChatCompletionAssistantMessageParam } from "../chattypes"
 import { GenerationResult } from "../generation"
-import { ResponseStatus } from "../host"
+import { LanguageModelConfiguration, ResponseStatus } from "../host"
 
 export interface RequestMessage {
     type: string
@@ -128,14 +128,15 @@ export interface ShellExec extends RequestMessage {
     response?: ShellExecResponse
 }
 
-export interface LanguageModelConfiguration extends RequestMessage {
-    type: "model.configuration",
+export interface LanguageModelConfigurationRequest extends RequestMessage {
+    type: "model.configuration"
     model: string
     token?: boolean
     response?: LanguageModelConfigurationResponse
 }
 
 export interface LanguageModelConfigurationResponse extends ResponseStatus {
+    info?: LanguageModelConfiguration
 }
 
 export interface ChatStart {
@@ -173,7 +174,7 @@ export type RequestMessages =
     | PromptScriptStart
     | PromptScriptAbort
     | ChatChunk
-    | LanguageModelConfiguration
+    | LanguageModelConfigurationRequest
 
 export type PromptScriptResponseEvents =
     | PromptScriptProgressResponseEvent

--- a/packages/core/src/server/messages.ts
+++ b/packages/core/src/server/messages.ts
@@ -128,6 +128,16 @@ export interface ShellExec extends RequestMessage {
     response?: ShellExecResponse
 }
 
+export interface LanguageModelConfiguration extends RequestMessage {
+    type: "model.configuration",
+    model: string
+    token?: boolean
+    response?: LanguageModelConfigurationResponse
+}
+
+export interface LanguageModelConfigurationResponse extends ResponseStatus {
+}
+
 export interface ChatStart {
     type: "chat.start"
     chatId: string
@@ -163,6 +173,7 @@ export type RequestMessages =
     | PromptScriptStart
     | PromptScriptAbort
     | ChatChunk
+    | LanguageModelConfiguration
 
 export type PromptScriptResponseEvents =
     | PromptScriptProgressResponseEvent

--- a/packages/core/src/websearch.ts
+++ b/packages/core/src/websearch.ts
@@ -1,6 +1,6 @@
 import { BING_SEARCH_ENDPOINT } from "./constants"
 import { createFetch } from "./fetch"
-import { host } from "./host"
+import { runtimeHost } from "./host"
 import { MarkdownTrace } from "./trace"
 
 function toURLSearchParams(o: any) {
@@ -47,7 +47,7 @@ export async function bingSearch(
     } = options || {}
     if (!q) return {}
 
-    const apiKey = await host.readSecret("BING_SEARCH_API_KEY")
+    const apiKey = await runtimeHost.readSecret("BING_SEARCH_API_KEY")
     if (!apiKey)
         throw new Error(
             "BING_SEARCH_API_KEY secret is required to use bing search. See https://microsoft.github.io/genaiscript/reference/scripts/web-search/#bing-web-search-configuration."

--- a/packages/vscode/src/vshost.ts
+++ b/packages/vscode/src/vshost.ts
@@ -171,7 +171,10 @@ export class VSCodeHost extends EventTarget implements Host {
         }
 
         let files = Array.from(uris.values())
-        if (applyGitIgnore && (await checkFileExists(this.projectUri, ".gitignore"))) {
+        if (
+            applyGitIgnore &&
+            (await checkFileExists(this.projectUri, ".gitignore"))
+        ) {
             const gitignore = await readFileText(this.projectUri, ".gitignore")
             files = await filterGitIgnore(gitignore, files)
         }
@@ -184,16 +187,6 @@ export class VSCodeHost extends EventTarget implements Host {
     async deleteDirectory(name: string): Promise<void> {
         const uri = this.toProjectFileUri(name)
         await vscode.workspace.fs.delete(uri, { recursive: true })
-    }
-
-    async readSecret(name: string): Promise<string | undefined> {
-        try {
-            const dotenv = await readFileText(this.projectUri, DOT_ENV_FILENAME)
-            const env = dotEnvTryParse(dotenv)
-            return env?.[name]
-        } catch (e) {
-            return undefined
-        }
     }
 
     clientLanguageModel?: LanguageModel

--- a/packages/vscode/src/vshost.ts
+++ b/packages/vscode/src/vshost.ts
@@ -194,11 +194,11 @@ export class VSCodeHost extends EventTarget implements Host {
         modelId: string,
         options?: { token?: boolean } & AbortSignalOptions & TraceOptions
     ): Promise<LanguageModelConfiguration> {
-        const { signal, token: askToken } = options || {}
-        const dotenv = await readFileText(this.projectUri, DOT_ENV_FILENAME)
-        const env = dotEnvTryParse(dotenv) ?? {}
-        await parseDefaultsFromEnv(env)
-        const tok = await parseTokenFromEnv(env, modelId)
+        const tok = await this.server.client.getLanguageModelConfiguration(
+            modelId,
+            options
+        )
+        const { token: askToken } = options || {}
         if (
             askToken &&
             tok &&


### PR DESCRIPTION
Lookup configuration from env to support github models from vscode

<!-- genaiscript begin pr-describe -->

- The core has a new `LanguageModelConfigurationRequest` that's handled on the server side. It fetches configuration details for a specific language model. This information can be accessed through a new function in the `WebSocketClient` class. :100:
- Developers cannot forget to define a token for GitHub models anymore. They will be reminded by an error message if they do. :warning:
- If a `.env` file exists in the workspace, it no longer determines the default model and tokens for language models. These are fetched on request and when initializing the client. :recycle:
- Model defaults changed. "openai:gpt-4" is not the default model anymore but rather "openai:gpt-4o". The array of default alternative models has been updated accordingly. :leftwards_arrow_with_hook:
- Several GitHub-related changes were applied. The function `readSecret` was moved from `Host` to `RuntimeHost` and is used slightly differently. It seems to read secrets from the environment or possibly the `.env` file. :lock:
- `host` was renamed to `runtimeHost` in a few places. Like its name suggests, `runtimeHost` has additional capabilities over `host` related to the runtime environment. :running_man:
- Lastly, handling of the `.gitignore` file in the function `readFiles` was improved. Files are now filtered based on it, resulting in a more accurate behavior. :open_file_folder:

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10286607881)



<!-- genaiscript end pr-describe -->

