### PR TITLE
allow responsechema as example

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/docs/src/content/docs/reference/scripts/json-mode.md
+++ b/docs/src/content/docs/reference/scripts/json-mode.md
@@ -39,7 +39,7 @@ You can also provide an example of object and GenAIScript will generate the sche
 ```js "responseSchema"
 script({
     responseType: "json_object",
-    responseSchema: { name: "neo", age: 30 },
+    responseSchema: { characters: [{ name: "neo", age: 30 }] },
 })
 ```
 

--- a/docs/src/content/docs/reference/scripts/json-mode.md
+++ b/docs/src/content/docs/reference/scripts/json-mode.md
@@ -34,6 +34,15 @@ script({
 })
 ```
 
+You can also provide an example of object and GenAIScript will generate the schema for you.
+
+```js "responseSchema"
+script({
+    responseType: "json_object",
+    responseSchema: { name: "neo", age: 30 },
+})
+```
+
 ## Inline schemas
 
 You can also specify the [schema inline](/genaiscript/reference/scripts/schemas) in the script and use a mixed markdown/data that GenAIScript will parse.

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/core/src/expander.ts
+++ b/packages/core/src/expander.ts
@@ -25,6 +25,7 @@ import {
     ChatCompletionMessageParam,
     ChatCompletionSystemMessageParam,
 } from "./chattypes"
+import { promptParametersSchemaToJSONSchema } from "./parameters"
 
 async function callExpander(
     r: PromptScript,
@@ -279,7 +280,11 @@ export async function expandTemplate(
             return { status: sysr.status, statusText: sysr.statusText }
     }
 
-    const responseSchema: JSONSchema = template.responseSchema
+    const responseSchema = promptParametersSchemaToJSONSchema(
+        template.responseSchema
+    ) as JSONSchemaObject
+    if (responseSchema)
+        trace.detailsFenced("📜 response schema", responseSchema)
     let responseType = template.responseType
     if (responseSchema && responseType !== "json_schema") {
         responseType = "json_object"

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/core/src/genaisrc/system.fs_read_summary.genai.js
+++ b/packages/core/src/genaisrc/system.fs_read_summary.genai.js
@@ -28,7 +28,7 @@ defTool(
         const { filename } = args
         if (!filename) return ""
         const { content } = await workspace.readText(filename)
-        const model = env.vars["system.fs_read_summary.model"] || "gpt-35-turbo"
+        const model = (env.vars["system.fs_read_summary.model"] || "gpt-35-turbo") + ""
         const cacheName = `fs_read_summary_${model}`
         const summary = await runPrompt(
             (_) => {

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -28,7 +28,7 @@ async function resolveExpansionVars(
     trace: MarkdownTrace,
     template: PromptScript,
     frag: Fragment,
-    vars: Record<string, string>
+    vars: Record<string, string | number | boolean | object>
 ) {
     const root = runtimeHost.projectFolder()
 

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -122,14 +122,10 @@ export function createChatGenerationContext(
     const defTool: (
         name: string,
         description: string,
-        parameters: PromptParametersSchema | JSONSchema,
+        parameters: PromptParametersSchema | JSONSchemaObject,
         fn: ChatFunctionHandler
     ) => void = (name, description, parameters, fn) => {
-        const parameterSchema = isJSONSchema(parameters)
-            ? (parameters as JSONSchema)
-            : promptParametersSchemaToJSONSchema(
-                  parameters as PromptParametersSchema
-              )
+        const parameterSchema = promptParametersSchemaToJSONSchema(parameters)
         appendChild(
             node,
             createFunctionNode(name, description, parameterSchema, fn)

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -3,6 +3,7 @@ import { MarkdownTrace } from "./trace"
 import Ajv from "ajv"
 import { YAMLParse } from "./yaml"
 import { errorMessage } from "./error"
+import { promptParametersSchemaToJSONSchema } from "./parameters"
 
 export function isJSONSchema(obj: any) {
     if (typeof obj === "object" && obj.type === "object") return true
@@ -206,9 +207,16 @@ export function JSONSchemaStringify(schema: JSONSchema) {
 }
 
 // https://platform.openai.com/docs/guides/structured-outputs/supported-schemas
-export function toStrictJSONSchema(schema: JSONSchema): any {
-    const clone = structuredClone(schema)
+export function toStrictJSONSchema(
+    schema: PromptParametersSchema | JSONSchema
+): any {
+    const clone: JSONSchema = structuredClone(
+        promptParametersSchemaToJSONSchema(schema)
+    )
     visit(clone)
+
+    if (clone.type !== "object")
+        throw new Error("top level schema must be object")
 
     function visit(node: JSONSchemaType): void {
         const { type } = node

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -216,11 +216,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -220,7 +220,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -288,7 +291,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -556,7 +559,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -212,28 +212,31 @@ export function groupBy<T>(
     return r
 }
 
-export function normalizeString(s: string | number | boolean): string {
+export function normalizeString(s: string | number | boolean | object): string {
     if (typeof s === "string") return s
     else if (typeof s === "number") return s.toLocaleString()
     else if (typeof s === "boolean") return s ? "true" : "false"
+    else if (typeof s === "object") throw new Error("object not supported")
     else return undefined
 }
 
-export function normalizeFloat(s: string | number | boolean): number {
+export function normalizeFloat(s: string | number | boolean | object): number {
     if (typeof s === "string") {
         const f = parseFloat(s)
         return isNaN(f) ? undefined : f
     } else if (typeof s === "number") return s
     else if (typeof s === "boolean") return s ? 1 : 0
+    else if (typeof s === "object") throw new Error("object not supported")
     else return undefined
 }
 
-export function normalizeInt(s: string | number | boolean): number {
+export function normalizeInt(s: string | number | boolean | object): number {
     if (typeof s === "string") {
         const f = parseInt(s)
         return isNaN(f) ? undefined : f
     } else if (typeof s === "number") return s
     else if (typeof s === "boolean") return s ? 1 : 0
+    else if (typeof s === "object") throw new Error("object not supported")
     else return undefined
 }
 

--- a/packages/sample/genaisrc/fuzz-search.genai.js
+++ b/packages/sample/genaisrc/fuzz-search.genai.js
@@ -3,8 +3,7 @@ script({
     model: "gpt-3.5-turbo",
     tests: {},
 })
-
-const kw = env.vars.keyword || "defdata"
+const kw = (env.vars.keyword || "defdata") + ""
 const allFiles = await workspace.findFiles("**/*.genai.{js,mjs}")
 const files = await retrieval.fuzzSearch(kw, allFiles)
 def("FILE", files, { maxTokens: 1000 })

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/sample/genaisrc/git-history.genai.mts
+++ b/packages/sample/genaisrc/git-history.genai.mts
@@ -2,8 +2,8 @@ script({
     model: "openai:gpt-3.5-turbo",
     title: "git-history", tests: {} })
 
-const author = env.vars.author || "pelikhan"
-const until = env.vars.until || "2023-11-15"
+const author = env.vars.author as string || "pelikhan"
+const until = env.vars.until as string || "2023-11-15"
 
 const { stdout: commits } = await host.exec("git", [
     "log",

--- a/packages/sample/genaisrc/json_object_ex.genai.mjs
+++ b/packages/sample/genaisrc/json_object_ex.genai.mjs
@@ -1,0 +1,7 @@
+script({
+    //  model: "openai:gpt-3.5-turbo",
+    responseType: "json_object",
+    responseSchema: { characters: [{ name: "neo", age: 30 }] },
+    tests: {},
+})
+$`Generate a characters.`

--- a/packages/sample/genaisrc/json_object_ex.genai.mjs
+++ b/packages/sample/genaisrc/json_object_ex.genai.mjs
@@ -1,7 +1,7 @@
 script({
-    //  model: "openai:gpt-3.5-turbo",
+    model: "openai:gpt-3.5-turbo",
     responseType: "json_object",
     responseSchema: { characters: [{ name: "neo", age: 30 }] },
     tests: {},
 })
-$`Generate a characters.`
+$`Generate 2 characters.`

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/sample/genaisrc/pr-describe.genai.js
+++ b/packages/sample/genaisrc/pr-describe.genai.js
@@ -6,7 +6,7 @@ script({
     system: ["system", "system.fs_find_files", "system.fs_read_file"],
 })
 
-const defaultBranch = env.vars.defaultBranch || "main"
+const defaultBranch = (env.vars.defaultBranch || "main") + ""
 const { stdout: changes } = await host.exec("git", [
     "diff",
     defaultBranch,

--- a/packages/sample/genaisrc/pr-docs-review-commit.genai.js
+++ b/packages/sample/genaisrc/pr-docs-review-commit.genai.js
@@ -7,7 +7,7 @@ script({
     tools: ["fs_find_files", "fs_read_file"],
 })
 
-const defaultBranch = env.vars.defaultBranch || "main"
+const defaultBranch = (env.vars.defaultBranch || "main") + ""
 const { stdout: diff } = await host.exec("git", [
     "diff",
     defaultBranch,

--- a/packages/sample/genaisrc/pr-review.genai.js
+++ b/packages/sample/genaisrc/pr-review.genai.js
@@ -6,7 +6,7 @@ script({
     tools: ["fs_find_files", "fs_read_file"],
 })
 
-const defaultBranch = env.vars.defaultBranch || "main"
+const defaultBranch = (env.vars.defaultBranch || "main") + ""
 const { stdout: diff } = await host.exec("git", [
     "diff",
     defaultBranch,

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -255,7 +255,10 @@ type PromptParameterType =
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParametersSchema = Record<
+    string,
+    PromptParameterType | PromptParameterType[]
+>
 type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
@@ -323,7 +326,7 @@ interface PromptTest {
     /**
      * Extra set of variables for this scenario
      */
-    vars?: PromptParameters
+    vars?: Record<string, string | boolean | number>
     /**
      * LLM output matches a given rubric, using a Language Model to grade output.
      */
@@ -591,7 +594,7 @@ interface ExpansionVariables {
     /**
      * User defined variables
      */
-    vars: PromptParameters
+    vars?: Record<string, string | boolean | number | object>
 
     /**
      * List of secrets used by the prompt, must be registered in `genaiscript`.

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -139,7 +139,7 @@ interface ModelOptions extends ModelConnectionOptions {
     /**
      * JSON object schema for the output. Enables the `JSON` output mode by default.
      */
-    responseSchema?: JSONSchemaObject
+    responseSchema?: PromptParametersSchema | JSONSchemaObject
 
     /**
      * “Top_p” or nucleus sampling is a setting that decides how many possible words to consider.
@@ -251,11 +251,12 @@ type PromptParameterType =
     | string
     | number
     | boolean
+    | object
     | JSONSchemaNumber
     | JSONSchemaString
     | JSONSchemaBoolean
-type PromptParametersSchema = Record<string, PromptParameterType>
-type PromptParameters = Record<string, string | number | boolean | any>
+type PromptParametersSchema = Record<string, PromptParameterType | PromptParameterType[]>
+type PromptParameters = Record<string, string | number | boolean | object>
 
 type PromptAssertion = {
     // How heavily to weigh the assertion. Defaults to 1.0


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- The `PromptParameterType` type definition now supports object types. This enables complex parameter structures like nested objects and arrays. Your API has leveled up! 🎉

- The `responseSchema` property in `ModelOptions` can now accept `PromptParametersSchema` or `JSONSchemaObject`. This allows users to define the response structure at a higher level. More freedom for you! 🦅 

- Added a new function `promptParametersSchemaToJSONSchema` to convert a `PromptParametersSchema` to a `JSONSchema`. This function is now used in various parts of the codebase, wherever a `JSONSchema` was needed from parameters. Stay DRY! 💦 

- In the functions `applyRepairs` and `structurifyChatSession`, the `responseSchema` is now converted to a `JSONSchema` before being passed to the `validateJSONWithSchema` function. 🔐

- The `callExpander` function has been updated to use `responseSchema` in its `JSONSchemaObject` form. This way, it uses the high-level schema defined in templates. Consistency is key! 🔑 

- Updated the `toStrictJSONSchema` function to convert `PromptParametersSchema` to `JSONSchema` before applying transformations. This ensures the schema is always treated in its JSON form.🔄 

- There has been a modification in the file `json_object_ex.genai.mjs`, specifying a new `responseSchema` format that includes complex nested objects. 📁

Overall, these changes provide better utility to users, allowing them to use more complex and nested parameters and schemas. The codebase is also more DRY and consistent as higher level schemas are always transformed to `JSONSchema` before use. Amazing upgrades! 🥳

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10287371573)



<!-- genaiscript end pr-describe -->

