### PR TITLE
do not call llm on empty prompt

### DIFF
--- a/packages/core/src/expander.ts
+++ b/packages/core/src/expander.ts
@@ -220,7 +220,7 @@ export async function expandTemplate(
     if (prompt.aici) trace.fence(prompt.aici, "yaml")
     trace.endDetails()
 
-    if (prompt.status !== "success")
+    if (prompt.status !== "success" || prompt.text === "")
         // cancelled
         return { status: prompt.status, statusText: prompt.statusText }
 


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- The updated code introduces an additional condition in a logical check within the 'expandTemplate' function, in the 'expander.ts' file of the core package. This piece of code handles responses to prompts.
- Previously, the code only checked if 'prompt.status' was not equal to "success".
- Now, it also checks whether 'prompt.text' is an empty string or not. The check will pass if either 'prompt.status' is not "success" **or** 'prompt.text' is an empty string. 
- This means the function will now return early not only when the prompt status is unsuccessful, but also when the prompt text is empty 🧐.
- This change could be handling a case where the status is successful but no prompt text is provided, avoiding subsequent operations on an empty text 👍.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10355012867)



<!-- genaiscript end pr-describe -->

