### PR TITLE
expire azure token as needed

### DIFF
--- a/packages/cli/src/azuretoken.ts
+++ b/packages/cli/src/azuretoken.ts
@@ -1,10 +1,20 @@
 import { AZURE_OPENAI_TOKEN_SCOPES } from "../../core/src/constants"
 
-export async function createAzureToken(signal: AbortSignal): Promise<string> {
+export interface AuthenticationToken {
+    token: string
+    expiresOnTimestamp: number
+}
+
+export async function createAzureToken(
+    signal: AbortSignal
+): Promise<AuthenticationToken> {
     const { DefaultAzureCredential } = await import("@azure/identity")
     const azureToken = await new DefaultAzureCredential().getToken(
         AZURE_OPENAI_TOKEN_SCOPES.slice(),
         { abortSignal: signal }
     )
-    return azureToken.token
+    return {
+        token: azureToken.token,
+        expiresOnTimestamp: azureToken.expiresOnTimestamp,
+    }
 }


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- The function `createAzureToken` in `azuretoken.ts` has been refactored to return an object of type `AuthenticationToken`. This marks a shift from the previous version where it just returned a string token, to the new version where it returns an object containing two properties, `token` (a string) and `expiresOnTimestamp` (a number). 🔄
- An interface `AuthenticationToken` was introduced into `azuretoken.ts`. 🆕
- Also, the `_azureToken` private property in `nodehost.ts` has been altered to hold an `AuthenticationToken` object as opposed to a single token string. 💾
- The `getLanguageModelConfiguration` in `nodehost.ts` has been updated to refresh the `_azureToken` if it is not set, or if its `expiresOnTimestamp` is equal to or greater than the current time. This ensures that an expired token won't be used, improving reliability and security. ⏲️🔒
- The packaging or concatenation process to make the token a Bearer token in `getLanguageModelConfiguration` now uses `_azureToken.token` as opposed to `_azureToken`. 👍

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10355868292)



<!-- genaiscript end pr-describe -->

