### PR TITLE
support for system prompts in runPrompt

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
         "promptdom",
         "promptfoo",
         "stringifying",
+        "sysr",
         "treesitter",
         "typecheck",
         "vsix",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
         "millis",
         "ollama",
         "openai",
+        "promptdom",
         "promptfoo",
         "stringifying",
         "treesitter",

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -8,7 +8,7 @@ import {
     CancellationToken,
     checkCancelled,
 } from "./cancellation"
-import { assert, logError } from "./util"
+import { assert, logError, logVerbose } from "./util"
 import { extractFenced, findFirstDataFence } from "./fence"
 import {
     toStrictJSONSchema,
@@ -558,6 +558,7 @@ export async function executeChatSession(
                     if (resp.variables)
                         genVars = { ...(genVars || {}), ...resp.variables }
                 } finally {
+                    logVerbose("")
                     trace.endDetails()
                 }
 

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -17,6 +17,7 @@ import { YAMLParse, YAMLStringify } from "./yaml"
 import { createParsers } from "./parsers"
 import { readText } from "./fs"
 import {
+    PromptImage,
     PromptNode,
     appendChild,
     createFileMergeNode,
@@ -32,23 +33,34 @@ import {
 } from "./runpromptcontext"
 import { CSVParse, CSVToMarkdown } from "./csv"
 import { INIParse, INIStringify } from "./ini"
-import { CancelError, isCancelError, serializeError } from "./error"
+import {
+    CancelError,
+    isCancelError,
+    NotSupportedError,
+    serializeError,
+} from "./error"
 import { createFetch } from "./fetch"
 import { XMLParse } from "./xml"
 import { GenerationOptions } from "./generation"
 import { fuzzSearch } from "./fuzzsearch"
 import { parseModelIdentifier } from "./models"
 import { renderAICI } from "./aici"
-import { MODEL_PROVIDER_AICI } from "./constants"
+import { MODEL_PROVIDER_AICI, SYSTEM_FENCE } from "./constants"
 import { JSONLStringify, JSONLTryParse } from "./jsonl"
 import { grepSearch } from "./grep"
 import { resolveFileContents, toWorkspaceFile } from "./file"
 import { vectorSearch } from "./vectorsearch"
-import { ChatCompletionMessageParam } from "./chattypes"
+import {
+    ChatCompletionMessageParam,
+    ChatCompletionSystemMessageParam,
+} from "./chattypes"
 import { resolveModelConnectionInfo } from "./models"
 import { resolveLanguageModel } from "./lm"
+import { callExpander } from "./expander"
+import { Project } from "./ast"
 
 export async function createPromptContext(
+    prj: Project,
     vars: ExpansionVariables,
     trace: MarkdownTrace,
     options: GenerationOptions,
@@ -246,7 +258,7 @@ export async function createPromptContext(
         },
         runPrompt: async (generator, runOptions): Promise<RunPromptResult> => {
             try {
-                const { label } = runOptions || {}
+                const { label, system = [] } = runOptions || {}
                 trace.startDetails(`🎁 run prompt ${label || ""}`)
                 infoCb?.({ text: `run prompt ${label || ""}` })
 
@@ -263,6 +275,7 @@ export async function createPromptContext(
                 let tools: ToolCallback[] = undefined
                 let schemas: Record<string, JSONSchema> = undefined
                 let chatParticipants: ChatParticipant[] = undefined
+
                 // expand template
                 const { provider } = parseModelIdentifier(genOptions.model)
                 if (provider === MODEL_PROVIDER_AICI) {
@@ -289,10 +302,60 @@ export async function createPromptContext(
                         throw new Error("errors while running prompt")
                 }
 
+                const systemMessage: ChatCompletionSystemMessageParam = {
+                    role: "system",
+                    content: "",
+                }
+                for (const systemId of system) {
+                    checkCancelled(cancellationToken)
+
+                    const system = prj.getTemplate(systemId)
+                    if (!system)
+                        throw new Error(`system template ${systemId} not found`)
+                    trace.startDetails(`👾 ${system.id}`)
+                    const sysr = await callExpander(
+                        prj,
+                        system,
+                        env,
+                        trace,
+                        options
+                    )
+                    if (sysr.images) throw new NotSupportedError("images")
+                    if (sysr.schemas) Object.assign(schemas, sysr.schemas)
+                    if (sysr.functions) tools.push(...sysr.functions)
+                    if (sysr.fileMerges)
+                        throw new NotSupportedError("fileMerges")
+                    if (sysr.outputProcessors)
+                        throw new NotSupportedError("outputProcessors")
+                    if (sysr.chatParticipants)
+                        chatParticipants.push(...sysr.chatParticipants)
+                    if (sysr.fileOutputs)
+                        throw new NotSupportedError("fileOutputs")
+                    if (sysr.logs?.length)
+                        trace.details("📝 console.log", sysr.logs)
+                    if (sysr.text) {
+                        systemMessage.content +=
+                            SYSTEM_FENCE + "\n" + sysr.text + "\n"
+                        trace.fence(sysr.text, "markdown")
+                    }
+                    if (sysr.aici) {
+                        trace.fence(sysr.aici, "yaml")
+                        messages.push(sysr.aici)
+                    }
+                    trace.detailsFenced("js", system.jsSource, "js")
+                    trace.endDetails()
+                    if (sysr.status !== "success")
+                        throw new Error(
+                            `system ${system.id} failed ${sysr.status} ${sysr.statusText}`
+                        )
+                }
+                if (systemMessage.content) messages.unshift(systemMessage)
+
                 const connection = await resolveModelConnectionInfo(
                     genOptions,
                     { trace, token: true }
                 )
+                checkCancelled(cancellationToken)
                 if (!connection.configuration)
                     throw new Error(
                         "model connection error " + connection.info?.model
@@ -300,6 +363,7 @@ export async function createPromptContext(
                 const { completer } = await resolveLanguageModel(
                     connection.configuration.provider
                 )
+                checkCancelled(cancellationToken)
                 if (!completer)
                     throw new Error(
                         "model driver not found for " + connection.info

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -67,7 +67,8 @@ export async function createPromptContext(
     model: string
 ) {
     const { cancellationToken, infoCb } = options || {}
-    const env = structuredClone(vars)
+    const { generator, ...varsNoGenerator } = vars
+    const env = { generator, ...structuredClone(varsNoGenerator) }
     const parsers = await createParsers({ trace, model })
     const YAML = Object.freeze<YAML>({
         stringify: YAMLStringify,
@@ -320,16 +321,17 @@ export async function createPromptContext(
                         trace,
                         options
                     )
-                    if (sysr.images) throw new NotSupportedError("images")
+                    if (sysr.images?.length)
+                        throw new NotSupportedError("images")
                     if (sysr.schemas) Object.assign(schemas, sysr.schemas)
                     if (sysr.functions) tools.push(...sysr.functions)
-                    if (sysr.fileMerges)
+                    if (sysr.fileMerges?.length)
                         throw new NotSupportedError("fileMerges")
-                    if (sysr.outputProcessors)
+                    if (sysr.outputProcessors?.length)
                         throw new NotSupportedError("outputProcessors")
                     if (sysr.chatParticipants)
                         chatParticipants.push(...sysr.chatParticipants)
-                    if (sysr.fileOutputs)
+                    if (sysr.fileOutputs?.length)
                         throw new NotSupportedError("fileOutputs")
                     if (sysr.logs?.length)
                         trace.details("📝 console.log", sysr.logs)

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -15,7 +15,6 @@ import {
 import { MarkdownTrace } from "./trace"
 import { GenerationOptions } from "./generation"
 import { promptParametersSchemaToJSONSchema } from "./parameters"
-import { isJSONSchema } from "./schema"
 import { consoleLogFormat } from "./logging"
 import { resolveFileDataUri } from "./file"
 import { isGlobMatch } from "./glob"

--- a/packages/core/src/systems.ts
+++ b/packages/core/src/systems.ts
@@ -6,22 +6,24 @@ export function resolveSystems(prj: Project, template: PromptScript) {
     const systems = Array.from(template.system ?? []).slice(0)
 
     if (template.system === undefined) {
-        const useSchema = /defschema/i.test(jsSource)
+        const useSchema = /\Wdefschema\W/i.test(jsSource)
         if (!template.responseType) {
             systems.push("system")
             systems.push("system.explanations")
         }
         // select file expansion type
-        if (/diff/i.test(jsSource)) systems.push("system.diff")
-        else if (/changelog/i.test(jsSource)) systems.push("system.changelog")
-        else if (/file/i.test(jsSource)) {
+        if (/\Wdiff\W/i.test(jsSource)) systems.push("system.diff")
+        else if (/\Wchangelog\W/i.test(jsSource))
+            systems.push("system.changelog")
+        else if (/\Wfile\W/i.test(jsSource)) {
             systems.push("system.files")
             if (useSchema) systems.push("system.files_schema")
         }
         if (useSchema) systems.push("system.schema")
-        if (/annotation|warning|error/i.test(jsSource))
+        if (/\W(annotation|warning|error)\W/i.test(jsSource))
             systems.push("system.annotations")
-        if (/diagram|chart/i.test(jsSource)) systems.push("system.diagrams")
+        if (/\W(diagram|chart)\W/i.test(jsSource))
+            systems.push("system.diagrams")
     }
 
     if (template.tools?.length)

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1283,6 +1283,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/genaisrc/style/runprompt.genai.js
+++ b/packages/sample/genaisrc/style/runprompt.genai.js
@@ -10,6 +10,7 @@ const resPoem = await runPrompt(_ => {
     label: "generate poem",
     system: ["system"]
 })
+if (resPoem.error) throw resPoem.error
 
 const resJSON = await runPrompt(_ => {
     _.$`generate 3 random numbers between 1 and 10 and respond in JSON`
@@ -18,6 +19,7 @@ const resJSON = await runPrompt(_ => {
     label: "generate json",
     responseType: "json_object",
 })
+if (resJSON.error) throw resJSON.error
 
 $`Is this poetry? Respond yes or no.`
 fence(resPoem.text)

--- a/packages/sample/genaisrc/style/runprompt.genai.js
+++ b/packages/sample/genaisrc/style/runprompt.genai.js
@@ -3,15 +3,25 @@ script({
     tests: {}
 })
 
-const res = await runPrompt(_ => {
+const resPoem = await runPrompt(_ => {
+    _.$`write haiku poem`
+}, {
+    model: "openai:gpt-3.5-turbo",
+    label: "generate poem",
+    system: ["system"]
+})
+
+const resJSON = await runPrompt(_ => {
     _.$`generate 3 random numbers between 1 and 10 and respond in JSON`
 }, {
     model: "openai:gpt-3.5-turbo",
-    label: "Is this JSON?",
+    label: "generate json",
     responseType: "json_object",
-    system: ["system", "system.zero_shot_cot"]
 })
 
-$`Is this JSON?
+$`Is this poetry? Respond yes or no.`
+fence(resPoem.text)
 
-${res.text}`
+$`Is this JSON? Respond yes or no.`
+fence(resJSON.text)
+

--- a/packages/sample/genaisrc/style/runprompt.genai.js
+++ b/packages/sample/genaisrc/style/runprompt.genai.js
@@ -7,7 +7,9 @@ const res = await runPrompt(_ => {
     _.$`generate 3 random numbers between 1 and 10 and respond in JSON`
 }, {
     model: "openai:gpt-3.5-turbo",
-    responseType: "json_object"
+    label: "Is this JSON?",
+    responseType: "json_object",
+    system: ["system", "system.zero_shot_cot"]
 })
 
 $`Is this JSON?

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1320,6 +1320,11 @@ interface PromptGeneratorOptions extends ModelOptions {
      * Label for trace
      */
     label?: string
+
+    /**
+     * List of system prompts if any
+     */
+    system?: SystemPromptId[]
 }
 
 interface FileOutputOptions {


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- 🦚 Improved system prompt identification in `resolveSystems` method (in `systems.ts` file).
  - Refined with word boundary check to prevent partial word matches.
  - For example, earlier 'diff' could have matched 'different', but with this change it will not.
- 🧬 Adjusted handling of `system` and `model` options in the context creator (`createPromptContext` in `promptcontext.ts`).
  - Now allows a set of system prompts to be executed before the main prompt.
  - System prompts become part of the conversation with their outputs used to supplement the main prompt's output.
- 🔍 Enhanced detection of presence of schema in script source in `resolveSystems` method 
  - Additional check for separated '`defschema`' word in the source.
  - Consequential addition of 'system.schema' and 'system.files_schema' to systems if schema usage detected.
- 🔧 Modified `expandTemplate` function in `expander.ts` to call the expander for each system in the systems array. 
  - Each system's function adds its output (if any) to the overall `RunPromptResult` for the prompt.
- 🛠 Added the `system` field to the `PromptGeneratorOptions` interface in `prompt_template.d.ts` file.
  - This field is meant to allow system prompts to be specified when calling `runPrompt`.
- 🏗 Refining error handling in `expandTemplate` and `createPromptContext` by replacing some abrupt returns with throwing of descriptive error messages.
- 🖼 If a system prompt produces an image, it throws a `NotSupportedError`.
-  📄 `runprompt.genai.js` in the `package/sample/genaisrc/style/` directory has been updated to demonstrate a usage of the new `system` property. 
  - Two different `runPrompt` calls are made, one for generating a poem and another for generating JSON. The `system` option is used in the first call. Each `runPrompt` has its own label.


> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10423979223)



<!-- genaiscript end pr-describe -->

