### PR TITLE
move rag tests to ollama

### DIFF
--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -40,6 +40,8 @@ jobs:
             - name: download ollama docker
               run: docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
             - name: run summarize-ollama-phi3
-              run: yarn test:summarize --model ollama:phi3 --out ./temp
+              run: yarn test:summarize --model ollama:phi3 --out ./temp/summarize-ollama-phi3
+            - name: run rag
+              run: yarn run:script rag --out ./temp/rag
             - name: test summarize-links-phi3
-              run: yarn test:scripts summarize-link --models ollama:phi3 --out ./temp
+              run: yarn test:scripts summarize-link --models ollama:phi3 --out ./temp/summarize-link

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
         "markdownify",
         "memorystream",
         "millis",
+        "nomic",
         "ollama",
         "openai",
         "promptdom",

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/docs/src/content/docs/reference/scripts/system.mdx
+++ b/docs/src/content/docs/reference/scripts/system.mdx
@@ -710,6 +710,8 @@ system({
         "Function to do a search using embeddings vector similarity distance.",
 })
 
+const embeddingsModel = env.var.embeddingsModel || undefined
+
 defTool(
     "retrieval_vector_search",
     "Search files using embeddings and similarity distance.",
@@ -737,7 +739,7 @@ defTool(
         const res = await retrieval.vectorSearch(
             q,
             files.map((filename) => ({ filename }))
-        )
+            , { embeddingsModel })
         return YAML.stringify(res.map(({ filename }) => filename))
     }
 )

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/core/src/genaisrc/system.retrieval_vector_search.genai.js
+++ b/packages/core/src/genaisrc/system.retrieval_vector_search.genai.js
@@ -4,6 +4,8 @@ system({
         "Function to do a search using embeddings vector similarity distance.",
 })
 
+const embeddingsModel = env.var.embeddingsModel || undefined
+
 defTool(
     "retrieval_vector_search",
     "Search files using embeddings and similarity distance.",
@@ -31,7 +33,7 @@ defTool(
         const res = await retrieval.vectorSearch(
             q,
             files.map((filename) => ({ filename }))
-        )
+            , { embeddingsModel })
         return YAML.stringify(res.map(({ filename }) => filename))
     }
 )

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -101,7 +101,7 @@ export async function resolveModelConnectionInfo(
             const configuration = await host.getLanguageModelConfiguration(
                 model,
                 {
-                    token: askToken,
+                    token: withToken,
                     signal,
                     trace,
                 }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/core/src/vectorsearch.ts
+++ b/packages/core/src/vectorsearch.ts
@@ -8,7 +8,7 @@ import { JSONLineCache } from "./cache"
 import { EmbeddingCreateParams, EmbeddingCreateResponse } from "./chattypes"
 import { LanguageModelConfiguration } from "./host"
 import { getConfigHeaders } from "./openai"
-import { trimTrailingSlash } from "./util"
+import { logVerbose, trimTrailingSlash } from "./util"
 import { TraceOptions } from "./trace"
 
 export interface EmbeddingsCacheKey {
@@ -72,10 +72,11 @@ class OpenAIEmbeddings implements EmbeddingsModel {
             url = `${trimTrailingSlash(base)}/${model.replace(/\./g, "")}/embeddings?api-version=${AZURE_OPENAI_API_VERSION}`
             delete body.model
         } else {
-            url = `${base}/v1/embeddings`
+            url = `${base}/embeddings`
         }
         const fetch = await createFetch({ retryOn: [429] })
         if (trace) traceFetchPost(trace, url, headers, body)
+        logVerbose(`embedding ${model}`)
         const resp = await fetch(url, {
             method: "POST",
             headers,

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/sample/genaisrc/rag.genai.js
+++ b/packages/sample/genaisrc/rag.genai.js
@@ -16,21 +16,29 @@ def(
     "MARKDOWN",
     await retrieval.vectorSearch(
         "markdown",
-        env.files.filter((f) => f.filename.endsWith(".md")), { embeddingsModel }
+        env.files.filter((f) => f.filename.endsWith(".md")),
+        { embeddingsModel }
     )
 )
 def(
     "PDF",
     await retrieval.vectorSearch(
         "lorem",
-        env.files.filter((f) => f.filename.endsWith(".pdf")), { embeddingsModel }
+        env.files.filter((f) => f.filename.endsWith(".pdf")),
+        { embeddingsModel }
     )
 )
 def(
     "WORD",
     await retrieval.vectorSearch(
         "word",
-        env.files.filter((f) => f.filename.endsWith(".docx")), { embeddingsModel }
+        env.files.filter((f) => f.filename.endsWith(".docx")),
+        { embeddingsModel }
     )
 )
-def("ALL", await retrieval.vectorSearch("lorem", env.files), { embeddingsModel })
+def(
+    "ALL",
+    await retrieval.vectorSearch("lorem", env.files, {
+        embeddingsModel,
+    })
+)

--- a/packages/sample/genaisrc/rag.genai.js
+++ b/packages/sample/genaisrc/rag.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "rag",
-    model: "openai:gpt-3.5-turbo",
+    model: "ollama:phi3",
     files: "src/rag/*",
     tests: {
         files: "src/rag/*",
@@ -8,7 +8,7 @@ script({
     },
 })
 
-$`You are a helpful assistant. Summarize the files in MARKDOWN, PDF, WORD and ALL.`
+$`Summarize MARKDOWN, PDF, WORD and ALL. Use one short sentence.`
 
 const embeddingsModel = env.vars.embeddingsModel || "ollama:nomic-embed-text"
 

--- a/packages/sample/genaisrc/rag.genai.js
+++ b/packages/sample/genaisrc/rag.genai.js
@@ -10,25 +10,27 @@ script({
 
 $`You are a helpful assistant. Summarize the files in MARKDOWN, PDF, WORD and ALL.`
 
+const embeddingsModel = env.vars.embeddingsModel || "ollama:nomic-embed-text"
+
 def(
     "MARKDOWN",
     await retrieval.vectorSearch(
         "markdown",
-        env.files.filter((f) => f.filename.endsWith(".md"))
+        env.files.filter((f) => f.filename.endsWith(".md")), { embeddingsModel }
     )
 )
 def(
     "PDF",
     await retrieval.vectorSearch(
         "lorem",
-        env.files.filter((f) => f.filename.endsWith(".pdf"))
+        env.files.filter((f) => f.filename.endsWith(".pdf")), { embeddingsModel }
     )
 )
 def(
     "WORD",
     await retrieval.vectorSearch(
         "word",
-        env.files.filter((f) => f.filename.endsWith(".docx"))
+        env.files.filter((f) => f.filename.endsWith(".docx")), { embeddingsModel }
     )
 )
-def("ALL", await retrieval.vectorSearch("lorem", env.files))
+def("ALL", await retrieval.vectorSearch("lorem", env.files), { embeddingsModel })

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/sample/genaisrc/summary-of-summary-phi3.genai.js
+++ b/packages/sample/genaisrc/summary-of-summary-phi3.genai.js
@@ -1,8 +1,9 @@
 script({
-    model: "openai:gpt-4-32k",
+    model: "ollama:phi3",
     title: "summary of summary - phi3",
+    files: ["src/rag/*.md"], 
     tests: {
-        files: ["src/rag/*"],
+        files: ["src/rag/*.md"],
         keywords: ["markdown", "lorem", "microsoft"],
     }
 })
@@ -19,4 +20,4 @@ for (const file of env.files) {
     def("FILE", { ...file, content: text })
 }
 // use summary
-$`Summarize all the FILE.`
+$`Summarize FILE with short sentence.`

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -187,7 +187,14 @@ interface EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
-    embeddingsModel?: "openai:text-embedding-ada-002" | string
+    embeddingsModel?: OptionsOrString<
+        "openai:text-embedding-3-small",
+        "openai:text-embedding-3-large",
+        "openai:text-embedding-ada-002",
+        "github:text-embedding-3-small",
+        "github:text-embedding-3-large",
+        "ollama:nomic-embed-text"
+    >
 }
 
 interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- The GIT_DIFF reflects several changes across multiple files aiming to enhance and extend the functionality of the software.

- It introduces a new variable `embeddingsModel`, which is fetched from environment variables, for use in the retrieval vector search function in several files including 'system.mdx', 'system.retrieval_vector_search.genai.js' and 'rag.genai.js'. 🆕

- Changes in 'models.ts' replaced the term 'askToken' with 'withToken', which may affect how user authorization or access control is handled. 🔄

- The most crucial changes appear to be in 'prompt_template.d.ts'. New options for embeddings models are added, expanding user choice. It means that users can now specify various text embedding models like 'openai:text-embedding-3-small', 'openai:text-embedding-3-large', 'github:text-embedding-3-small', 'github:text-embedding-3-large', 'ollama:nomic-embed-text' among others. 🚀 

- Another file 'rag.genai.js' had its model updated from 'openai:gpt-3.5-turbo' to 'ollama:phi3'. The selection of the embeddings model is also configurable in this file now. 🔄

- In the module 'vectorsearch.ts', the endpoint url for creating embeddings has been altered slightly. Verbose logging for embedding models has also been introduced improving debugging capabilities. ✨

- Changes in these files are user-facing as they primarily belong to the core functionality and directly affect how end users can interact with and use the system concerning embedding models and retrieval searches. 🧑‍💻

Please note that the comments and some other minor changes have been ignored as per the provided instructions.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10425144389)



<!-- genaiscript end pr-describe -->

