### PR TITLE
Resolve model connection info and add embeddings model candidates

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -98,7 +98,7 @@ export async function startServer(options: { port: string }) {
         ): Promise<ChatCompletionResponse> => {
             const { messages, model } = req
             const { partialCb } = options
-            if (!wss.clients.size) throw new Error("no llm clients connected")
+            if (!wss.clients?.size) throw new Error("no llm clients connected")
 
             return new Promise<ChatCompletionResponse>((resolve, reject) => {
                 let responseSoFar: string = ""

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -41,8 +41,15 @@ export const HIGHLIGHT_LENGTH = 4000
 export const DEFAULT_MODEL = "openai:gpt-4o"
 export const DEFAULT_MODEL_CANDIDATES = [
     "azure:gpt-4o",
+    "openai:gpt-4o",
     "github:gpt-4o",
     "client:gpt-4",
+]
+export const DEFAULT_EMBEDDINGS_MODEL_CANDIDATES = [
+    "azure:text-embedding-3-small",
+    "openai:text-embedding-3-small",
+    "github:text-embedding-3-small",
+    "client:text-embedding-3-small",
 ]
 export const DEFAULT_EMBEDDINGS_MODEL = "openai:text-embedding-ada-002"
 export const DEFAULT_TEMPERATURE = 0.8

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -82,13 +82,25 @@ export function traceLanguageModelConnection(
 
 export async function resolveModelConnectionInfo(
     conn: ModelConnectionOptions,
-    options?: { model?: string; token?: boolean } & TraceOptions &
+    options?: {
+        model?: string
+        token?: boolean
+        candidates?: string[]
+    } & TraceOptions &
         AbortSignalOptions
 ): Promise<{
     info: ModelConnectionInfo
     configuration?: LanguageModelConfiguration
 }> {
-    const { trace, token: askToken, signal } = options || {}
+    const {
+        trace,
+        token: askToken,
+        signal,
+        candidates = [
+            host.defaultModelOptions.model,
+            ...DEFAULT_MODEL_CANDIDATES,
+        ],
+    } = options || {}
 
     const resolveModel = async (
         model: string,
@@ -136,12 +148,7 @@ export async function resolveModelConnectionInfo(
     if (m) {
         return await resolveModel(m, true)
     } else {
-        // go through various options
-        const candidates = new Set([
-            host.defaultModelOptions.model,
-            ...DEFAULT_MODEL_CANDIDATES,
-        ])
-        for (const candidate of candidates) {
+        for (const candidate of new Set(candidates || [])) {
             const res = await resolveModel(candidate, true)
             if (!res.info.error && res.info.token) return res
         }

--- a/packages/core/src/vectorsearch.ts
+++ b/packages/core/src/vectorsearch.ts
@@ -128,9 +128,12 @@ export async function vectorSearch(
             "vectra/lib/LocalDocumentIndex"
         )
         const tokenizer = { encode, decode }
-        const { info, configuration } = await resolveModelConnectionInfo({
-            model: embeddingsModel,
-        })
+        const { info, configuration } = await resolveModelConnectionInfo(
+            {
+                model: embeddingsModel,
+            },
+            { token: true }
+        )
         if (info.error) throw new Error(info.error)
         if (!configuration)
             throw new Error("No configuration found for vector search")

--- a/packages/core/src/vectorsearch.ts
+++ b/packages/core/src/vectorsearch.ts
@@ -1,7 +1,11 @@
 import { encode, decode } from "gpt-tokenizer"
 import { resolveModelConnectionInfo } from "./models"
-import { runtimeHost } from "./host"
-import { AZURE_OPENAI_API_VERSION, MODEL_PROVIDER_AZURE } from "./constants"
+import { runtimeHost, host } from "./host"
+import {
+    AZURE_OPENAI_API_VERSION,
+    DEFAULT_EMBEDDINGS_MODEL_CANDIDATES,
+    MODEL_PROVIDER_AZURE,
+} from "./constants"
 import type { EmbeddingsModel, EmbeddingsResponse } from "vectra/lib/types"
 import { createFetch, traceFetchPost } from "./fetch"
 import { JSONLineCache } from "./cache"
@@ -132,7 +136,13 @@ export async function vectorSearch(
             {
                 model: embeddingsModel,
             },
-            { token: true }
+            {
+                token: true,
+                candidates: [
+                    host.defaultEmbeddingsModelOptions.embeddingsModel,
+                    ...DEFAULT_EMBEDDINGS_MODEL_CANDIDATES,
+                ],
+            }
         )
         if (info.error) throw new Error(info.error)
         if (!configuration)

--- a/packages/sample/genaisrc/vectorstore.genai.mts
+++ b/packages/sample/genaisrc/vectorstore.genai.mts
@@ -1,0 +1,25 @@
+import { init, createDocument, search } from "vectorstore"
+script({
+    files: "src/rag/*",
+    tests: {},
+})
+
+await init((args) => process.stderr.write("."))
+
+const docs = await Promise.all(
+    env.files
+        .filter(({ content }) => content)
+        .map((file) => createDocument(file.content, file))
+)
+const res = await search(
+    docs,
+    await createDocument("what is markdown?"),
+    3,
+    "hnsw-wasm"
+)
+
+def(
+    "FILE",
+    res.map((r) => r.doc.metadata)
+)
+$`Summarize FILE in one short sentence.`

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@tidyjs/tidy": "^2.5.2",
     "@xenova/transformers": "^2.17.2",
+    "vectorstore": "^0.0.4",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -788,7 +788,7 @@
   optionalDependencies:
     keytar "^7.7.0"
 
-"@xenova/transformers@^2.17.2":
+"@xenova/transformers@^2.16.1", "@xenova/transformers@^2.17.2":
   version "2.17.2"
   resolved "https://registry.yarnpkg.com/@xenova/transformers/-/transformers-2.17.2.tgz#7448d73b90f67bced66f39fe2dd656adc891fde5"
   integrity sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==
@@ -4292,16 +4292,7 @@ streamx@^2.15.0, streamx@^2.18.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4347,14 +4338,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4833,6 +4817,13 @@ varstream@^0.3.2:
   dependencies:
     readable-stream "^1.0.33"
 
+vectorstore@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/vectorstore/-/vectorstore-0.0.4.tgz#56e6b619d938b27e6b2fb39a4d221046abc0b72f"
+  integrity sha512-KHY3kCQmtMH/PKS67v3wjgXvjA7nIYSHu6E4wEUaWj+HNeM0xKsa2wJcvi9MEA7j719IOzTj75UoCYE8wPv/Vg==
+  dependencies:
+    "@xenova/transformers" "^2.16.1"
+
 vectra@^0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/vectra/-/vectra-0.7.6.tgz#65e80a56ba8914eb73f453ed6cd659feabd91da0"
@@ -4970,16 +4961,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This pull request includes changes to resolve the model connection info, allowing for the selection of different models. It also adds a list of default embeddings model candidates to choose from. These changes improve the flexibility and customization options for the software.

<!-- genaiscript begin pr-describe -->

- A possibility for clients to be `undefined` in `startServer` function in `server.ts` is now handled by using optional chaining. 
   - Before: `if (!wss.clients.size) throw new Error("no llm clients connected")`
   - After: `if (!wss.clients?.size) throw new Error("no llm clients connected")`
  
- The list of `DEFAULT_MODEL_CANDIDATES` is expanded with `"openai:gpt-4o"` in `constants.ts`.

- New array `DEFAULT_EMBEDDINGS_MODEL_CANDIDATES` is created in `constants.ts`. The array consists of four models named after tech companies and suffixed with `"text-embedding-3-small"`.

- Modifications in `resolveModelConnectionInfo` function in `models.ts`:
  - The function parameters are updated. Besides `model` and `token`, `candidates` is also added in `options`.
  - The `candidates` parameter is initialized with a default value that contains the default model and a spread operator for `DEFAULT_MODEL_CANDIDATES`.
  - The for loop that iterates over candidates is modified to use the `candidates` parameter.

- Changes in `vectorSearch` function in `vectorSearch.ts`:
  - The function calls `resolveModelConnectionInfo` with additional parameters, where `token` value is `true` and `candidates` is a set of default settings for embedding model options.

- Addition of a new file `vectorstore.genai.mts` in the `sample` directory. This file contains functions for initializing, creating a document, and searching in a vector store.

- The `sample` package's `package.json` file is updated with a new devDependency `vectorstore`.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10426047620)



<!-- genaiscript end pr-describe -->

