### PR TITLE
Add support for grep in find_files

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/docs/src/components/BuiltinTools.mdx
+++ b/docs/src/components/BuiltinTools.mdx
@@ -6,7 +6,7 @@ import { LinkCard } from '@astrojs/starlight/components';
 
 ### Builtin tools
 
-<LinkCard title="fs_find_files" description="Finds file matching a glob pattern." href="/genaiscript/reference/scripts/system#systemfs_find_files" />
+<LinkCard title="fs_find_files" description="Finds file matching a glob pattern. Use pattern to specify a regular expression to search for in the file content." href="/genaiscript/reference/scripts/system#systemfs_find_files" />
 <LinkCard title="fs_read_file" description="Reads a file as text from the file system." href="/genaiscript/reference/scripts/system#systemfs_read_file" />
 <LinkCard title="fs_read_summary" description="Reads a summary of a file from the file system." href="/genaiscript/reference/scripts/system#systemfs_read_summary" />
 <LinkCard title="math_eval" description="Evaluates a math expression" href="/genaiscript/reference/scripts/system#systemmath" />

--- a/docs/src/content/docs/reference/scripts/system.mdx
+++ b/docs/src/content/docs/reference/scripts/system.mdx
@@ -365,21 +365,21 @@ def(`File ${folder}/data.json`, `...`, {
 
 ### `system.fs_find_files`
 
-File Find Files
+File find files
 
-Functions to list files.
+Find files with glob and content regex.
 
--  tool `fs_find_files`: Finds file matching a glob pattern.
+-  tool `fs_find_files`: Finds file matching a glob pattern. Use pattern to specify a regular expression to search for in the file content.
 
 `````js wrap title="system.fs_find_files"
 system({
-    title: "File Find Files",
-    description: "Functions to list files.",
+    title: "File find files",
+    description: "Find files with glob and content regex.",
 })
 
 defTool(
     "fs_find_files",
-    "Finds file matching a glob pattern.",
+    "Finds file matching a glob pattern. Use pattern to specify a regular expression to search for in the file content.",
     {
         type: "object",
         properties: {
@@ -388,12 +388,18 @@ defTool(
                 description:
                     "Search path in glob format, including the relative path from the project root folder.",
             },
+            pattern: {
+                type: "string",
+                description: "Optional regular expression pattern to search for in the file content.",
+            }
         },
         required: ["glob"],
     },
     async (args) => {
-        const { glob } = args
-        const res = await workspace.findFiles(glob, { readText: false })
+        const { glob, pattern } = args
+        console.log(pattern ? `grep ${pattern} ${glob}` : `ls ${glob}`)
+        const res = pattern ? (await (workspace.grep(pattern, glob, { readText: false }))).files : await workspace.findFiles(glob, { readText: false })
+        if (!res?.length) return "No files found."
         return res.map((f) => f.filename).join("\n")
     }
 )

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/core/src/genaisrc/system.fs_find_files.genai.js
+++ b/packages/core/src/genaisrc/system.fs_find_files.genai.js
@@ -1,11 +1,11 @@
 system({
-    title: "File Find Files",
-    description: "Functions to list files.",
+    title: "File find files",
+    description: "Find files with glob and content regex.",
 })
 
 defTool(
     "fs_find_files",
-    "Finds file matching a glob pattern.",
+    "Finds file matching a glob pattern. Use pattern to specify a regular expression to search for in the file content.",
     {
         type: "object",
         properties: {
@@ -14,12 +14,18 @@ defTool(
                 description:
                     "Search path in glob format, including the relative path from the project root folder.",
             },
+            pattern: {
+                type: "string",
+                description: "Optional regular expression pattern to search for in the file content.",
+            }
         },
         required: ["glob"],
     },
     async (args) => {
-        const { glob } = args
-        const res = await workspace.findFiles(glob, { readText: false })
+        const { glob, pattern } = args
+        console.log(pattern ? `grep ${pattern} ${glob}` : `ls ${glob}`)
+        const res = pattern ? (await (workspace.grep(pattern, glob, { readText: false }))).files : await workspace.findFiles(glob, { readText: false })
+        if (!res?.length) return "No files found."
         return res.map((f) => f.filename).join("\n")
     }
 )

--- a/packages/core/src/systems.ts
+++ b/packages/core/src/systems.ts
@@ -1,5 +1,5 @@
 import { Project } from "./ast"
-import { unique } from "./util"
+import { arrayify, unique } from "./util"
 
 export function resolveSystems(prj: Project, template: PromptScript) {
     const { jsSource } = template
@@ -26,16 +26,19 @@ export function resolveSystems(prj: Project, template: PromptScript) {
             systems.push("system.diagrams")
     }
 
-    if (template.tools?.length)
-        template.tools.forEach((tool) => systems.push(resolveTool(prj, tool)))
+    if (template.tools) {
+        arrayify(template.tools).forEach((tool) =>
+            systems.push(...resolveTools(prj, tool))
+        )
+    }
 
     return unique(systems.filter((s) => !!s))
 }
 
-function resolveTool(prj: Project, tool: string) {
-    const toolsRx = new RegExp(`defTool\\s*\\(\\s*('|"|\`)${tool}('|"|\`)`)
-    const system = prj.templates.find(
+function resolveTools(prj: Project, tool: string): string[] {
+    const toolsRx = new RegExp(`defTool\\s*\\(\\s*('|"|\`)${tool}`)
+    const system = prj.templates.filter(
         (t) => t.isSystem && toolsRx.test(t.jsSource)
     )
-    return system.id
+    return system.map(({ id }) => id)
 }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -208,7 +208,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/genaisrc/fs.genai.mjs
+++ b/packages/sample/genaisrc/fs.genai.mjs
@@ -1,5 +1,7 @@
 script({
-    tools: ["fs"]
+    model: "openai:gpt-3.5-turbo",
+    tools: ["fs"],
+    tests: {}
 })
 
 $`List the cities in the src folder markdown files as a CSV table. The file should contain the word "city".`

--- a/packages/sample/genaisrc/fs.genai.mjs
+++ b/packages/sample/genaisrc/fs.genai.mjs
@@ -1,0 +1,5 @@
+script({
+    tools: ["fs"]
+})
+
+$`List the cities in the src folder files.`

--- a/packages/sample/genaisrc/fs.genai.mjs
+++ b/packages/sample/genaisrc/fs.genai.mjs
@@ -2,4 +2,4 @@ script({
     tools: ["fs"]
 })
 
-$`List the cities in the src folder files.`
+$`List the cities in the src folder markdown files as a CSV table. The file should contain the word "city".`

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/sample/src/cities.md
+++ b/packages/sample/src/cities.md
@@ -2,6 +2,7 @@
 
 ## List of cities
 
+City:
 - Brussels
 - Seattle
 - Munich

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -234,18 +234,7 @@ interface ScriptRuntimeOptions {
     /**
      * List of tools used by the prompt.
      */
-/**
-* System tool identifiers ([reference](https://microsoft.github.io/genaiscript/reference/scripts/tools/))
-* - `fs_find_files`: Finds file matching a glob pattern.
-* - `fs_read_file`: Reads a file as text from the file system.
-* - `fs_read_summary`: Reads a summary of a file from the file system.
-* - `math_eval`: Evaluates a math expression
-* - `python_code_interpreter`: Executes python 3.12 code for Data Analysis tasks in a docker container. The process output is returned. Do not generate visualizations. The only packages available are numpy, pandas, scipy. There is NO network connectivity. Do not attempt to install other packages or make web requests.
-* - `retrieval_fuzz_search`: Search for keywords using the full text of files and a fuzzy distance.
-* - `retrieval_vector_search`: Search files using embeddings and similarity distance.
-* - `retrieval_web_search`: Search the web for a user query using Bing Search.
-**/
-    tools?: SystemToolId[]
+    tools?: SystemToolId | SystemToolId[]
 
     /**
      * Secrets required by the prompt

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -213,7 +213,7 @@ interface ScriptRuntimeOptions {
 * - `system.explanations`: Explain your answers
 * - `system.files`: File generation
 * - `system.files_schema`: Apply JSON schemas to generated data.
-* - `system.fs_find_files`: File Find Files
+* - `system.fs_find_files`: File find files
 * - `system.fs_read_file`: File Read File
 * - `system.fs_read_summary`: File Read Summary
 * - `system.functions`: use functions


### PR DESCRIPTION
This pull request adds support for using a regular expression pattern to search for specific content in the files when using the `fs_find_files` tool. Previously, only glob patterns were supported. Now, users can specify a pattern to search for in the file content. This enhances the functionality of the `fs_find_files` tool and provides more flexibility in file searching.