### PR TITLE
make defOutputProcessor more flexible

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -196,7 +196,7 @@ ${this.toResultIcon(success, "")}${title}
                 error: serializeError(error),
             }
             this.errors.push(err)
-            this.renderError(err, { details: false })
+            this.renderError(err, { details: true })
         })
     }
 
@@ -226,7 +226,7 @@ ${this.toResultIcon(success, "")}${title}
     ) {
         const { message, error } = e
         const emsg = errorMessage(error)
-        const msg = message || emsg
+        const msg = [message, emsg].filter((m) => m).join(", ")
         this.disableChange(() => {
             this.item(msg)
             if (options.details && error?.stack) {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/genaisrc/output.genai.js
+++ b/packages/sample/genaisrc/output.genai.js
@@ -1,16 +1,24 @@
 script({
+    model: "openai:gpt-3.5-turbo",
     title: "custom output",
+    files: "src/rag/markdown.md", tests: { files: "src/rag/markdown.md" },
     system: [],
 })
 const output = env.files[0].filename + ".txt"
 def("FILE", env.files)
 $`Summarize all the files. Respond as raw text.`
 
-defOutputProcessor((o) => {
+defOutputProcessor(async (o) => {
     console.log(`writing to ${output}`)
     return {
         files: {
             [output]: o.text,
         },
     }
+})
+
+defOutputProcessor(o => {
+    const { text } = o
+    console.log(`doing something with text`)
+    console.log(text)
 })

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -101,6 +101,8 @@ type PromptOutputProcessorHandler = (
     | Promise<PromptOutputProcessorResult>
     | undefined
     | Promise<undefined>
+    | void
+    | Promise<void>
 
 type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- A change in the way errors are logged was made in `packages/core/src/trace.ts` file 💼
  - The `renderError` function now always details errors, a change from the previous value of false.
  - The error message string now incorporates both `message` & `emsg` as a single string separated by a comma, unlike previously, it was one or the other.

- Adjustments were implemented in `packages/core/src/types/prompt_template.d.ts` 🧾
  - Introduced the possibility of the `PromptOutputProcessorHandler` type to be `void` or `Promise<void>`. This is potentially user-facing as it alters the public API.

- A substantial change was made to `packages/sample/genaisrc/output.genai.js` 🔄
  - Added a `model` field and updated the `files` and `tests` fields.
  - Changed `defOutputProcessor` function to be async.
  - Added another `defOutputProcessor` function block that logs out a text.
  
By the look of it, the main objective of these changes appears to be the enhancement of error logging and improvements in the tasks undertaken by output processors.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10478507291)



<!-- genaiscript end pr-describe -->

