### PR TITLE
cache

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/core/src/chatcache.ts
+++ b/packages/core/src/chatcache.ts
@@ -20,11 +20,9 @@ export type ChatCompletationRequestCache = JSONLineCache<
     ChatCompletationRequestCacheValue
 >
 
-export function getChatCompletionCache(
-    name?: string
-): ChatCompletationRequestCache {
+export function getChatCompletionCache(): ChatCompletationRequestCache {
     return JSONLineCache.byName<
         ChatCompletionRequestCacheKey,
         ChatCompletationRequestCacheValue
-    >(name || CHAT_CACHE)
+    >(CHAT_CACHE)
 }

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/core/src/openai.ts
+++ b/packages/core/src/openai.ts
@@ -57,7 +57,6 @@ export const OpenAIChatCompletion: ChatCompletionHandler = async (
         maxCachedTemperature = MAX_CACHED_TEMPERATURE,
         maxCachedTopP = MAX_CACHED_TOP_P,
         cache: useCache,
-        cacheName,
         retry,
         retryDelay,
         maxDelay,
@@ -68,7 +67,7 @@ export const OpenAIChatCompletion: ChatCompletionHandler = async (
     const { model } = parseModelIdentifier(req.model)
     const encoder = await resolveTokenEncoder(model)
 
-    const cache = getChatCompletionCache(cacheName)
+    const cache = getChatCompletionCache()
     const caching =
         useCache === true || // always use cache
         (useCache !== false && // never use cache

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -1,7 +1,7 @@
 import { executeChatSession, tracePromptResult } from "./chat"
 import { Project, PromptScript } from "./ast"
 import { stringToPos } from "./parser"
-import { arrayify, assert, logVerbose, relativePath } from "./util"
+import { arrayify, assert, logError, logVerbose, relativePath } from "./util"
 import { runtimeHost } from "./host"
 import { applyLLMDiff, applyLLMPatch, parseLLMDiffs } from "./diff"
 import { MarkdownTrace } from "./trace"
@@ -327,6 +327,7 @@ export async function runTemplate(
                     if (oannotations) annotations = oannotations.slice(0)
                 }
             } catch (e) {
+                logError(e)
                 trace.error(`output processor failed`, e)
             } finally {
                 trace.endDetails()

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -618,7 +618,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -643,7 +643,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation", "cacheName">
 
 type PromptSystemArgs = Omit<
     PromptArgs,


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- 🎯 Removed `name` parameter from `getChatCompletionCache()`. Now it always uses `CHAT_CACHE`. The public API is simplified! 🧪 (TO CHECK: does this change affect any users?)
- 🔄 Updated `OpenAIChatCompletion()` function to adapt to changes in `getChatCompletionCache()`, eliminated `cacheName` from its body. It has fewer parameters now, which may improve usage! 🪄
- 📝 Added a logging function `logError(e)` in `runTemplate()`. If an error occurs, it doesn't just remain silent, instead logs it! 🔍
- 🛠 Adjusted `PromptArgs` type in the public API by omitting `cacheName` from `PromptScript`. This makes the API less cluttered! 😺 (TO CHECK: does this change affect any users?) 

These code changes tend to streamline function calls, enhance error logging, and simplify the public API. All these modifications lead to more maintainable code and potentially improve user experience with the API.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10482172892)



<!-- genaiscript end pr-describe -->

