### PR TITLE
default to 4h for token expiration

### DIFF
--- a/packages/cli/src/azuretoken.ts
+++ b/packages/cli/src/azuretoken.ts
@@ -1,4 +1,7 @@
-import { AZURE_OPENAI_TOKEN_SCOPES } from "../../core/src/constants"
+import {
+    AZURE_OPENAI_TOKEN_EXPIRATION,
+    AZURE_OPENAI_TOKEN_SCOPES,
+} from "../../core/src/constants"
 
 export interface AuthenticationToken {
     token: string
@@ -15,6 +18,8 @@ export async function createAzureToken(
     )
     return {
         token: azureToken.token,
-        expiresOnTimestamp: azureToken.expiresOnTimestamp,
+        expiresOnTimestamp:
+            azureToken.expiresOnTimestamp ??
+            Date.now() + AZURE_OPENAI_TOKEN_EXPIRATION,
     }
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -14,6 +14,8 @@ export const AZURE_OPENAI_TOKEN_SCOPES = Object.freeze([
     "https://cognitiveservices.azure.com/.default",
     "offline_access",
 ])
+export const AZURE_OPENAI_TOKEN_EXPIRATION = 4 * 3600_000 // 4h
+
 export const TOOL_ID = "genaiscript"
 export const GENAISCRIPT_FOLDER = "." + TOOL_ID
 export const CLI_JS = TOOL_ID + ".cjs"


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- The defined constant `AZURE_OPENAI_TOKEN_EXPIRATION` has been added to `constants.ts`. It's value indicates a time period in milliseconds, specifically four hours. ⏳
- In `azuretoken.ts`, the `createAzureToken` function has been modified. Now it includes the `AZURE_OPENAI_TOKEN_EXPIRATION` constant as a part of return object.
  - Specifically, it's being utilized to decide the `expiresOnTimestamp`. If `azureToken.expiresOnTimestamp` is null, the `expiresOnTimestamp` is set to the current time plus four hours (coming from our newly defined constant). 📝💡
- Essentially, it appears the changes are concerned with implementing a set expiration time for Azure authentication tokens, and ensuring that this token expiry is maintained across the project. 🔄💼

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10482137096)



<!-- genaiscript end pr-describe -->

