### PR TITLE
Fix trace writing and update .gitignore

### DIFF
--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -89,7 +89,7 @@ export async function runScriptWithExitCode(
     let exitCode = -1
     for (let r = 0; r < runRetry; ++r) {
         let outTrace = options.outTrace
-        if (!outTrace && outTrace !== "false")
+        if (!outTrace)
             outTrace = dotGenaiscriptPath(
                 RUNS_DIR_NAME,
                 `${new Date().toISOString().replace(/[:.]/g, "-")}.trace.md`
@@ -163,7 +163,8 @@ export async function runScript(
         if (removeOut) await emptyDir(out)
         await ensureDir(out)
     }
-    if (outTrace && trace) await setupTraceWriting(trace, outTrace)
+    if (outTrace && /^false$/i.test(outTrace) && trace)
+        await setupTraceWriting(trace, outTrace)
     if (out && trace) {
         const ofn = join(out, "res.trace.md")
         if (ofn !== outTrace) {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -27,6 +27,7 @@ import {
     TRACE_CHUNK,
     UNRECOVERABLE_ERROR_CODES,
     SUCCESS_ERROR_CODE,
+    RUNS_DIR_NAME,
 } from "../../core/src/constants"
 import { isCancelError, errorMessage } from "../../core/src/error"
 import { Fragment, GenerationResult } from "../../core/src/generation"
@@ -88,9 +89,9 @@ export async function runScriptWithExitCode(
     let exitCode = -1
     for (let r = 0; r < runRetry; ++r) {
         let outTrace = options.outTrace
-        if (!outTrace)
+        if (!outTrace && outTrace !== "false")
             outTrace = dotGenaiscriptPath(
-                "runs",
+                RUNS_DIR_NAME,
                 `${new Date().toISOString().replace(/[:.]/g, "-")}.trace.md`
             )
         const res = await runScript(scriptId, files, { ...options, outTrace })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -107,6 +107,8 @@ export const PROMPTFOO_CACHE_PATH = ".genaiscript/cache/tests"
 export const PROMPTFOO_CONFIG_DIR = ".genaiscript/config/tests"
 export const PROMPTFOO_REMOTE_API_PORT = 15500
 
+export const RUNS_DIR_NAME = "runs"
+
 export const EMOJI_SUCCESS = "✅"
 export const EMOJI_FAIL = "❌"
 export const EMOJI_UNDEFINED = "?"

--- a/packages/sample/genaisrc/rag.genai.js
+++ b/packages/sample/genaisrc/rag.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "rag",
-    model: "ollama:phi3",
+    model: "openai:gpt-3.5-turbo",
     files: "src/rag/*",
     tests: {
         files: "src/rag/*",

--- a/packages/sample/genaisrc/summarize-files-function.genai.js
+++ b/packages/sample/genaisrc/summarize-files-function.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "summarize-files-function",
-    system: ["system", "system.fs_read_summary"],
+    tools: ["fs"],
     model: "openai:gpt-3.5-turbo",
     tests: {
         files: ["src/rag/*"],

--- a/packages/sample/genaisrc/summary-of-summary-phi3.genai.js
+++ b/packages/sample/genaisrc/summary-of-summary-phi3.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "ollama:phi3",
+    model: "openai:gpt-3.5-turbo",
     title: "summary of summary - phi3",
     files: ["src/rag/*.md"],
     tests: {

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -178,7 +178,8 @@ export class ExtensionState extends EventTarget {
         await writeFile(
             dir,
             ".gitignore",
-            `cache/
+            `runs/
+cache/
 retrieval/
 containers/
 temp/


### PR DESCRIPTION
The commit "always drop a trace from the cli" fixes the trace writing by ensuring that the trace is written to the correct file. Additionally, the .gitignore file is updated to include the "runs/" directory.

<!-- genaiscript begin pr-describe -->

- A new feature has been added for logging trace output in the `runScriptWithExitCode` function located in `packages/cli/src/run.ts` file. 📝
    - If `outTrace` option is not provided, a new file path is generated using `dotGenaiscriptPath` function, using current timestamp for a unique file name.
    - The resultant `outTrace` is passed as part of the options in the `runScript` call.
  
- Another noteworthy change is in the `.gitignore` file within the `packages/vscode/src/state.ts` file. 📁
    - A new line `runs/` is added to the ignore list.
    - This possibly corresponds to the trace output files generated by the `dotGenaiscriptPath` function. Ignoring this directory in git prevents versioning of temporary files.

Overall, these enhancements seem aimed at improving debugging experience with better trace logging options and clean git history by excluding temporary run files. 💻🚀

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10494004627)



<!-- genaiscript end pr-describe -->

