### PR TITLE
 Fix typo in README.md files in packages/cli and packages/vscode

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@ Scripting environment with convinient tooling for file ingestion, prompt develop
 // define the context
 def("FILE", env.files, { endsWith: ".pdf" })
 // define the data
-const chema = defSchema("DATA", 
+const schema = defSchema("DATA", 
   { type: "array", items: { type: "string" } })
 // define the task
 $`Analyze FILE and

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -12,7 +12,7 @@ Scripting environment with convinient tooling for file ingestion, prompt develop
 // define the context
 def("FILE", env.files, { endsWith: ".pdf" })
 // define the data
-const chema = defSchema("DATA", { type: "array", items: { type: "string" } })
+const schema = defSchema("DATA", { type: "array", items: { type: "string" } })
 // define the task
 $`Analyze FILE and
   extract titles to JSON compliant with ${schema}.`


### PR DESCRIPTION
**Description**:
This PR fixes a typo in the `README.md` files located in the `packages/cli` and `packages/vscode` directories. The variable `chema` has been corrected to `schema` in both files.

**Changes**:
- Corrected the typo from `chema` to `schema` in both `README.md` files.

Closes #644 