### PR TITLE
Cli test list

### DIFF
--- a/.github/workflows/build-genai-commit.yml
+++ b/.github/workflows/build-genai-commit.yml
@@ -4,6 +4,12 @@ on:
     workflow_dispatch:
     schedule:
         - cron: "0 7 * * *"
+    push:
+        branches: [main]
+        paths:
+            - "packages/core/**"
+            - "packages/sample/**"
+            - "packages/cli/**"
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
@@ -33,4 +39,6 @@ jobs:
             - name: download ollama docker
               run: docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
             - name: run test within scripts
-              run: yarn test:scripts --out-summary $GITHUB_STEP_SUMMARY --test-delay 10
+              run: node packages/cli/built/genaiscript.cjs run test-commit --out-summary $GITHUB_STEP_SUMMARY --test-delay 10
+            - name: run test within core
+              run: xargs -a temp/commit-tests.txt node packages/cli/built/genaiscript.cjs tests run --out-summary $GITHUB_STEP_SUMMARY --test-delay 10

--- a/.github/workflows/build-genai-commit.yml
+++ b/.github/workflows/build-genai-commit.yml
@@ -1,4 +1,4 @@
-name: build genai tests
+name: genai commit tests
 
 on:
     workflow_dispatch:

--- a/.github/workflows/build-genai.yml
+++ b/.github/workflows/build-genai.yml
@@ -1,4 +1,4 @@
-name: build genai tests
+name: genai tests
 
 on:
     workflow_dispatch:

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -62,6 +62,7 @@ Options:
 
 Commands:
   run [options] [script...]  Runs the tests for scripts
+  list                       List available tests in workspace
   view                       Launch test viewer
   help [command]             display help for command
 ```
@@ -93,6 +94,17 @@ Options:
   --groups <groups...>                groups to include or exclude. Use :!
                                       prefix to exclude
   -h, --help                          display help for command
+```
+
+### `test list`
+
+```
+Usage: genaiscript test list [options]
+
+List available tests in workspace
+
+Options:
+  -h, --help  display help for command
 ```
 
 ### `test view`

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,7 +17,7 @@ import {
 import { compileScript, createScript, fixScripts, listScripts } from "./scripts"
 import { codeQuery } from "./codequery"
 import { envInfo, modelInfo, systemInfo } from "./info"
-import { scriptTestsView, scriptsTest } from "./test"
+import { scriptTestList, scriptTestsView, scriptsTest } from "./test"
 import { cacheClear } from "./cache"
 import "node:console"
 import {
@@ -72,7 +72,7 @@ export async function cli() {
     program.on("option:quiet", () => setQuiet(true))
 
     program
-        .command("run", { isDefault: true })
+        .command("run")
         .description("Runs a GenAIScript against files.")
         .arguments("<script> [files...]")
         .option("-ef, --excluded-files <string...>", "excluded files")
@@ -183,6 +183,10 @@ export async function cli() {
             "groups to include or exclude. Use :! prefix to exclude"
         )
         .action(scriptsTest)
+
+    test.command("list")
+        .description("List available tests in workspace")
+        .action(scriptTestList)
 
     test.command("view")
         .description("Launch test viewer")

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -28,6 +28,7 @@ import {
     logVerbose,
     delay,
     tagFilter,
+    toStringList,
 } from "../../core/src/util"
 import { YAMLStringify } from "../../core/src/yaml"
 import {
@@ -80,11 +81,7 @@ export async function runPromptScriptTests(
         testDelay?: string
     }
 ): Promise<PromptScriptTestRunResponse> {
-    const prj = await buildProject()
-    const scripts = prj.templates
-        .filter((t) => arrayify(t.tests)?.length)
-        .filter((t) => !ids?.length || ids.includes(t.id))
-        .filter((t) => tagFilter(options?.groups, t.group))
+    const scripts = await listTests({ ids, ...(options || {}) })
     if (!scripts.length)
         return {
             ok: false,
@@ -207,6 +204,16 @@ export async function runPromptScriptTests(
     }
 }
 
+async function listTests(options: { ids?: string[]; groups?: string[] }) {
+    const { ids, groups } = options || {}
+    const prj = await buildProject()
+    const scripts = prj.templates
+        .filter((t) => arrayify(t.tests)?.length)
+        .filter((t) => !ids?.length || ids.includes(t.id))
+        .filter((t) => tagFilter(groups, t.group))
+    return scripts
+}
+
 export async function scriptsTest(
     ids: string[],
     options: PromptScriptTestRunOptions & {
@@ -230,6 +237,11 @@ export async function scriptsTest(
     for (const result of value) trace.resultItem(result.ok, result.script)
     console.log(trace.content)
     process.exit(status)
+}
+
+export async function scriptTestList(options: {}) {
+    const scripts = await listTests(options)
+    console.log(scripts.map((s) => toStringList(s.id, s.filename)).join("\n"))
 }
 
 export async function scriptTestsView(options: { promptfooVersion?: string }) {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -669,13 +669,14 @@ ${trimNewlines(schemaText)}
         },
     })
 
-    if (fileOutputs.length > 0) {
+    const fods = fileOutputs?.filter((f) => !!f.description)
+    if (fods?.length > 0) {
         prompt += `
 ## File generation rules
 
 When generating files, use the following rules which are formatted as "file glob: description":
 
-${fileOutputs.map((fo) => `   ${fo.pattern}: ${fo.description}`)}
+${fods.map((fo) => `   ${fo.pattern}: ${fo.description}`)}
 
 `
     }

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -119,6 +119,7 @@ export async function runTemplate(
         )
 
         // if the expansion failed, show the user the trace
+        // or no message generated
         if (status !== "success" || !messages.length) {
             trace.renderErrors()
             return <GenerationResult>{

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1366,7 +1366,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1408,7 +1408,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -62,7 +62,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/genaisrc/test-commit.genai.mjs
+++ b/packages/sample/genaisrc/test-commit.genai.mjs
@@ -1,0 +1,75 @@
+script({
+    model: "openai:gpt-4",
+    temperature: 0,
+    files: [],
+    title: "pull request commit review",
+    system: [
+        "system",
+        "system.files",
+        "system.typescript",
+        "system.annotations",
+    ],
+})
+
+// diff latest commit
+const { stdout: changes } = await host.exec("git", [
+    "diff",
+    "HEAD^",
+    "HEAD",
+    "--",
+    "**.ts",
+])
+
+// list of tests
+const { stdout: tests } = await host.exec("node", [
+    "packages/cli/built/genaiscript.cjs",
+    "test",
+    "list",
+])
+
+def("GIT_DIFF", changes, { language: "diff", maxTokens: 20000 })
+def(
+    "TESTS",
+    tests
+        .split(/\n/g)
+        .map((test) => test.split(/,\s*/)[1])
+        .map((filename) => ({ filename })),
+    { language: "txt", maxTokens: 20000 }
+)
+
+$`You are an expert TypeScript software developer and architect.
+
+# Task 1
+
+Review the code changes in GIT_DIFF and summarize the changes. Keep it short.
+
+# Task 2
+
+For each test in TESTS, assign a validation score between
+    - low: The test is not impacted by the changes in GIT_DIFF.
+    - medium: The test may be impacted by the changes in GIT_DIFF.
+    - high: The test is most likely impacted by the changes in GIT_DIFF.
+
+Report each test, the score and the reason for the score.
+
+# Task 3
+
+Select the most impacted 8 tests.
+Avoid duplicates.
+
+# Task 4
+
+Report the selected tests as a line-separated list of filenames 
+in file "temp/commit-tests.txt".
+Remove the .genai.js extension.
+
+    File temp/commit-tests.txt:
+    \`\`\`text
+    test filename 1
+    test filename 2
+    ...
+    \`\`\`
+
+`
+
+defFileOutput("temp/commit-tests.txt")

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1392,7 +1392,7 @@ interface FileOutputOptions {
 
 interface FileOutput {
     pattern: string
-    description: string
+    description?: string
     options?: FileOutputOptions
 }
 
@@ -1434,7 +1434,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
     ): void
     defFileOutput(
         pattern: string,
-        description: string,
+        description?: string,
         options?: FileOutputOptions
     ): void
 }
@@ -1806,7 +1806,7 @@ declare function def(
  */
 declare function defFileOutput(
     pattern: string,
-    description: string,
+    description?: string,
     options?: FileOutputOptions
 ): void
 


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- A new command `list` is added to GenAIScript CLI, which lists available tests in the workspace. This is a user facing change.📝
- Also, a function `scriptTestList` has been implemented to display the listed tests' id and filename. 📄
- Description field in `FileOutput` interface and `defFileOutput` function in "core/src/prompt_template.d.ts" and "core/src/prompt_type.ts" optional now. This is a user facing change as well. 🔄
- In "promptdom.ts", it checks if the "description" of `FileOutput` is available before displaying it. 💫  
- There's a new prompt script added, which utilizes `git diff` and test list command for commit review. 🆕


> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10530346448)



<!-- genaiscript end pr-describe -->

