### PR TITLE
def tool output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,15 @@ yarn slides [slides file name]
 
 Learn more about Slidev on [documentations](https://sli.dev/). For diagrams, leverage [mermaid](https://sli.dev/guide/syntax#diagrams) or use draw.io, tldraw.
 
+## GenAI Script
+
+- Commit with aut-generated message
+
+```sh
+yarn gcm
+```
+
+
 ## Packaging
 
 To compile and package the Visual Studio Code extension, run the `package` script.

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/docs/src/content/docs/reference/scripts/system.mdx
+++ b/docs/src/content/docs/reference/scripts/system.mdx
@@ -727,7 +727,7 @@ system({
         "Function to do a search using embeddings vector similarity distance.",
 })
 
-const embeddingsModel = env.var.embeddingsModel || undefined
+const embeddingsModel = env.vars.embeddingsModel || undefined
 
 defTool(
     "retrieval_vector_search",

--- a/genaisrc/gcm.genai.mts
+++ b/genaisrc/gcm.genai.mts
@@ -1,28 +1,26 @@
 import { select, input, confirm } from "@inquirer/prompts"
 
 // Check for staged changes and stage all changes if none are staged
-let { stdout } = await host.exec("git", ["diff", "--cached"])
-if (!stdout) {
+let diff = await host.exec("git", ["diff", "--cached"])
+if (!diff.stdout) {
     const stage = await confirm({
         message: "No staged changes. Stage all changes?",
         default: true,
     })
     if (stage) {
         await host.exec("git", ["add", "."])
-        stdout = (
-            await host.exec("git", [
-                "diff",
-                "--cached",
-                "--",
-                ".",
-                ":!**/genaiscript.d.ts",
-            ])
-        ).stdout
+        diff = await host.exec("git", [
+            "diff",
+            "--cached",
+            "--",
+            ".",
+            ":!**/genaiscript.d.ts",
+        ])
     }
-    if (!stdout) cancel("no staged changes")
+    if (!diff.stdout) cancel("no staged changes")
 }
 
-console.log(stdout)
+console.log(diff.stdout)
 
 let choice
 let message
@@ -31,7 +29,7 @@ do {
     message = (
         await runPrompt(
             (_) => {
-                _.def("GIT_DIFF", stdout, { maxTokens: 20000 })
+                _.def("GIT_DIFF", diff, { maxTokens: 20000 })
                 _.$`GIT_DIFF is a diff of all staged changes, coming from the command:
 \`\`\`
 git diff --cached

--- a/genaisrc/gcm.genai.mts
+++ b/genaisrc/gcm.genai.mts
@@ -9,7 +9,15 @@ if (!stdout) {
     })
     if (stage) {
         await host.exec("git", ["add", "."])
-        stdout = (await host.exec("git", ["diff", "--cached"])).stdout
+        stdout = (
+            await host.exec("git", [
+                "diff",
+                "--cached",
+                "--",
+                ".",
+                ":!**/genaiscript.d.ts",
+            ])
+        ).stdout
     }
     if (!stdout) cancel("no staged changes")
 }

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -31,7 +31,11 @@ import {
     ChatCompletionUserMessageParam,
     CreateChatCompletionRequest,
 } from "./chattypes"
-import { renderMessageContent, renderMessagesToMarkdown } from "./chatrender"
+import {
+    renderMessageContent,
+    renderMessagesToMarkdown,
+    renderShellOutput,
+} from "./chatrender"
 import { promptParametersSchemaToJSONSchema } from "./parameters"
 import { fenceMD } from "./markdown"
 import { YAMLStringify } from "./yaml"
@@ -204,14 +208,7 @@ async function runToolCalls(
                     typeof output === "object" &&
                     (output as ShellOutput).exitCode !== undefined
                 ) {
-                    const { stdout, stderr, exitCode } = output as ShellOutput
-                    toolContent = `EXIT_CODE: ${exitCode}
-
-STDOUT:
-${stdout || ""}
-
-STDERR:
-${stderr || ""}`
+                    toolContent = renderShellOutput(output as ShellOutput)
                 } else if (
                     typeof output === "object" &&
                     (output as WorkspaceFile).filename &&

--- a/packages/core/src/chatrender.ts
+++ b/packages/core/src/chatrender.ts
@@ -11,7 +11,7 @@ import { YAMLStringify } from "./yaml"
 export function renderShellOutput(output: ShellOutput) {
     const { exitCode, stdout, stderr } = output
     return [
-        `EXIT_CODE: ${exitCode}`,
+        exitCode !== 0 ? `EXIT_CODE: ${exitCode}` : undefined,
         stdout ? `STDOUT:${fenceMD(stdout, "text")}` : undefined,
         stderr ? `STDERR:${fenceMD(stderr, "text")}` : undefined,
     ]

--- a/packages/core/src/chatrender.ts
+++ b/packages/core/src/chatrender.ts
@@ -8,6 +8,17 @@ import { JSON5TryParse } from "./json5"
 import { details, fenceMD } from "./markdown"
 import { YAMLStringify } from "./yaml"
 
+export function renderShellOutput(output: ShellOutput) {
+    const { exitCode, stdout, stderr } = output
+    return [
+        `EXIT_CODE: ${exitCode}`,
+        stdout ? `STDOUT:${fenceMD(stdout, "text")}` : undefined,
+        stderr ? `STDERR:${fenceMD(stderr, "text")}` : undefined,
+    ]
+        .filter((s) => s)
+        .join("\n\n")
+}
+
 export function renderMessageContent(
     msg:
         | ChatCompletionAssistantMessageParam

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/core/src/genaisrc/system.retrieval_vector_search.genai.js
+++ b/packages/core/src/genaisrc/system.retrieval_vector_search.genai.js
@@ -4,7 +4,7 @@ system({
         "Function to do a search using embeddings vector similarity distance.",
 })
 
-const embeddingsModel = env.var.embeddingsModel || undefined
+const embeddingsModel = env.vars.embeddingsModel || undefined
 
 defTool(
     "retrieval_vector_search",

--- a/packages/core/src/grep.ts
+++ b/packages/core/src/grep.ts
@@ -7,7 +7,7 @@ import { resolveFileContent } from "./file"
 export async function grepSearch(
     query: string | RegExp,
     globs: string[],
-    options?: TraceOptions
+    options?: TraceOptions & { readText?: boolean }
 ): Promise<{ files: WorkspaceFile[] }> {
     const { rgPath } = await import("@lvce-editor/ripgrep")
     const args: string[] = ["--json", "--multiline", "--context", "3"]
@@ -37,6 +37,7 @@ export async function grepSearch(
             .filter(({ type }) => type === "match")
             .map(({ data }) => data.path.text)
     ).map((filename) => <WorkspaceFile>{ filename })
-    for (const file of files) await resolveFileContent(file)
+    if (options?.readText !== false)
+        for (const file of files) await resolveFileContent(file)
     return { files }
 }

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -90,13 +90,14 @@ export async function createPromptContext(
             })
             return res
         },
-        grep: async (query, globs) => {
+        grep: async (query, globs, options) => {
             trace.startDetails(
                 `🌐 grep <code>${HTMLEscape(typeof query === "string" ? query : query.source)}</code>`
             )
             try {
                 const { files } = await grepSearch(query, arrayify(globs), {
                     trace,
+                    ...options,
                 })
                 trace.files(files, { model, secrets: env.secrets })
                 return { files }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -531,7 +531,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1392,7 +1392,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1414,7 +1418,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1599,7 +1599,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -51,7 +51,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/exec.genai.mjs
+++ b/packages/sample/genaisrc/exec.genai.mjs
@@ -7,6 +7,7 @@ script({
 const version = await host.exec("python", ["--version"])
 if (!/^python \d/i.test(version.stdout))
     throw new Error("python --version failed")
+def("VERSION", version)
 defTool(
     "python_version",
     "determines the version of python on this system",

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/sample/genaisrc/modelname.genai.mjs
+++ b/packages/sample/genaisrc/modelname.genai.mjs
@@ -1,0 +1,6 @@
+script({ title: "test1", 
+    model: "gpt-4", 
+    group: "text", 
+    system: ["system"]})
+    
+$`What city is Abbey Delray in?`

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1418,7 +1418,11 @@ interface ChatTurnGenerationContext {
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
     $(strings: TemplateStringsArray, ...args: any[]): void
     fence(body: StringLike, options?: FenceOptions): void
-    def(name: string, body: StringLike, options?: DefOptions): string
+    def(
+        name: string,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        options?: DefOptions
+    ): string
     defData(
         name: string,
         data: object[] | object,
@@ -1440,7 +1444,9 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(files: StringLike, options?: DefImagesOptions): void
-    defTool(tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback): void
+    defTool(
+        tool: ToolCallback | AgenticToolCallback | AgenticToolProviderCallback
+    ): void
     defTool(
         name: string,
         description: string,
@@ -1806,7 +1812,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: StringLike,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
     options?: DefOptions
 ): string
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -557,7 +557,13 @@ interface WorkspaceFileSystem {
      */
     grep(
         query: string | RegExp,
-        globs: string | string[]
+        globs: string | string[],
+        options?: {
+            /**
+             * Set to false to skip read text content. True by default
+             */
+            readText?: boolean
+        }
     ): Promise<{ files: WorkspaceFile[] }>
 
     /**

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1625,7 +1625,6 @@ interface ShellOptions {
 interface ShellOutput {
     stdout?: string
     stderr?: string
-    output?: string
     exitCode: number
     failed: boolean
 }


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- 🎁 A new script `yarn gcm` has been added to auto generate commit messages. For more details, check `CONTRIBUTING.md`.
- 👍 Enhanced logging in `packages/cli/src/scripts.ts` for directory compilation - now providing info on successful compilations and possible errors.
- 💥 Error handling has been improved in `packages/cli/src/scripts.ts`. If any errors occur during the script compilation process, the process will exit with a runtime error code.
- 🔄 Changes in `packages/core/src/chat.ts` now handle tool output differently. If the output resembles shell output (exit code, stdout, stderr), a new method `renderShellOutput` from `packages/core/src/chatrender.ts` will be used to format the output content.
- ✨ Introduction of a new function `renderShellOutput` in `packages/core/src/chatrender.ts`, which provides a standardized way to format Shell output.
- 🔧 Some tweaks in `packages/core/src/runpromptcontext.ts`. The handling of definition `def` is refactored for different types of bodies (strings, WorkspaceFiles, ShellOutput), providing more granularity.
- 👀 Updates in public API (`packages/core/src/types/prompt_template.d.ts`, `packages/core/src/types/prompt_type.d.ts`). The argument `body` in function `def` now accepts string, WorkspaceFile, WorkspaceFile[], or ShellOutput, giving more flexibility in use-cases.
- 🧮 The python version is now captured and defined with `def("VERSION", version)` in `packages/sample/genaisrc/exec.genai.mjs`. Now Python version information can be accessed directly.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10580852497)



<!-- genaiscript end pr-describe -->

