### PR TITLE
add playwright in github actions

### DIFF
--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -18,7 +18,7 @@ on:
             - "packages/cli/**/*"
             - "packages/samples/**/*"
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}-ollama
     cancel-in-progress: true
 jobs:
     tests:

--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -39,6 +39,8 @@ jobs:
               run: yarn compile
             - name: download ollama docker
               run: docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
+            - name: run browse-text
+              run: yarn run:script browse-text --model ollama:phi3 --out ./temp/browse-text
             - name: run summarize-ollama-phi3
               run: yarn test:summarize --model ollama:phi3 --out ./temp/summarize-ollama-phi3
             - name: run vector-search

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,7 +16,7 @@ on:
             - "packages/core/**/*"
             - "packages/cli/**/*"
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}-playwright
     cancel-in-progress: true
 jobs:
     tests:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,22 +1,20 @@
-name: ollama smoke tests
+name: playwright smoke tests
 on:
     workflow_dispatch:
     pull_request:
         paths:
             - yarn.lock
-            - ".github/workflows/ollama.yml"
+            - ".github/workflows/playwright.yml"
             - "packages/core/**/*"
             - "packages/cli/**/*"
-            - "packages/samples/**/*"
     push:
         branches:
             - main
         paths:
             - yarn.lock
-            - ".github/workflows/ollama.yml"
+            - ".github/workflows/playwright.yml"
             - "packages/core/**/*"
             - "packages/cli/**/*"
-            - "packages/samples/**/*"
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
@@ -37,9 +35,9 @@ jobs:
               run: yarn typecheck
             - name: compile
               run: yarn compile
-            - name: download ollama docker
-              run: docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
-            - name: run summarize-ollama-phi3
-              run: yarn test:summarize --model ollama:phi3 --out ./temp/summarize-ollama-phi3
-            - name: run vector-search
-              run: yarn run:script vector-search --model ollama:phi3 --out ./temp/rag
+            - name: run browse-text
+              run: yarn run:script browse-text --out ./temp/browse-text
+              env:
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                  OPENAI_API_TYPE: ${{ secrets.OPENAI_API_TYPE }}
+                  OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1458,7 +1458,7 @@ The following npm packages may be included in this product:
  - @types/http-cache-semantics@4.0.4
  - @types/jsonfile@6.1.4
  - @types/mute-stream@0.0.4
- - @types/node@22.5.0
+ - @types/node@22.5.1
  - @types/turndown@5.0.5
  - @types/yauzl@2.10.3
 
@@ -1551,7 +1551,7 @@ MIT License
 The following npm packages may be included in this product:
 
  - type-fest@2.19.0
- - type-fest@4.25.0
+ - type-fest@4.26.0
 
 These packages each contain the following license and notice below:
 

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/docs/src/content/docs/reference/scripts/browse.md
+++ b/docs/src/content/docs/reference/scripts/browse.md
@@ -26,6 +26,19 @@ but you can also do it manually using the following command:
 npx playwright install --with-deps chromium
 ```
 
+If you see this error message, you might have to install the dependencies manually.
+
+```text
+╔═════════════════════════════════════════════════════════════════════════╗
+║ Looks like Playwright Test or Playwright was just installed or updated. ║
+║ Please run the following command to download new browsers:              ║
+║                                                                         ║
+║     yarn playwright install                                             ║
+║                                                                         ║
+║ <3 Playwright Team                                                      ║
+╚═════════════════════════════════════════════════════════════════════════╝
+```
+
 ## `host.browse`
 
 This function launches a new browser instance and optionally navigates to the page.

--- a/docs/src/content/docs/reference/scripts/browse.md
+++ b/docs/src/content/docs/reference/scripts/browse.md
@@ -19,10 +19,11 @@ $`Analyze DATA.`
 
 ## Installation
 
-You will need to install Playright locally before using the `browse` function.
+Playwright needs to [install the browsers and dependencies](https://playwright.dev/docs/browsers#install-system-dependencies) before execution. GenAIScript will automatically try to install them if it fails to load the browser;
+but you can also do it manually using the following command:
 
 ```bash
-npx playwright install-deps chromium
+npx playwright install --with-deps chromium
 ```
 
 ## `host.browse`

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -81,9 +81,9 @@
     vfile "^6.0.2"
 
 "@astrojs/mdx@^3.1.3":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@astrojs/mdx/-/mdx-3.1.4.tgz#1340e1f01b8bdcbe9077ed7c148513c1bc875523"
-  integrity sha512-AcdcAlDpzTM5LHpur7A3NWoIqyfhH1gZNbTvvjiUlDEo7eJjIxl4gdWrb/kZZRfLBEuM8cptCB+Qk11ncQL4IA==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@astrojs/mdx/-/mdx-3.1.5.tgz#2968535b9ab8ec857ee5a6ae539bc1d60270aae7"
+  integrity sha512-Fu6oShqcDpi0D1b2/3Pg3ao1I+Q2YqKhFsSsuDzn0YhdGrry5oUyABUyCyGq/OayP2P/34Vwj+GCQ/n9h8FlTQ==
   dependencies:
     "@astrojs/markdown-remark" "5.2.0"
     "@mdx-js/mdx" "^3.0.1"
@@ -91,14 +91,14 @@
     es-module-lexer "^1.5.4"
     estree-util-visit "^2.0.0"
     gray-matter "^4.0.3"
-    hast-util-to-html "^9.0.1"
+    hast-util-to-html "^9.0.2"
     kleur "^4.1.5"
     rehype-raw "^7.0.0"
     remark-gfm "^4.0.0"
     remark-smartypants "^3.0.2"
     source-map "^0.7.4"
     unist-util-visit "^5.0.0"
-    vfile "^6.0.2"
+    vfile "^6.0.3"
 
 "@astrojs/prism@3.1.0":
   version "3.1.0"
@@ -205,7 +205,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.25.0", "@babel/generator@^7.25.4":
+"@babel/generator@^7.25.0", "@babel/generator@^7.25.4", "@babel/generator@^7.25.5":
   version "7.25.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.25.5.tgz#b31cf05b3fe8c32d206b6dad03bb0aacbde73450"
   integrity sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==
@@ -297,7 +297,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.25.0", "@babel/parser@^7.25.3", "@babel/parser@^7.25.4":
+"@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.25.0", "@babel/parser@^7.25.4":
   version "7.25.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.25.4.tgz#af4f2df7d02440286b7de57b1c21acfb2a6f257a"
   integrity sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==
@@ -331,7 +331,7 @@
     "@babel/parser" "^7.25.0"
     "@babel/types" "^7.25.0"
 
-"@babel/traverse@^7.24.7", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.3":
+"@babel/traverse@^7.24.7", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.4":
   version "7.25.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.4.tgz#648678046990f2957407e3086e97044f13c3e18e"
   integrity sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==
@@ -998,9 +998,9 @@
     "@types/unist" "*"
 
 "@types/node@*", "@types/node@>=20":
-  version "22.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.0.tgz#10f01fe9465166b4cab72e75f60d8b99d019f958"
-  integrity sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==
+  version "22.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.1.tgz#de01dce265f6b99ed32b295962045d10b5b99560"
+  integrity sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==
   dependencies:
     undici-types "~6.19.2"
 
@@ -1221,20 +1221,20 @@ astro-remote@0.3.2:
     ultrahtml "^1.5.3"
 
 astro@^4.14.5:
-  version "4.14.5"
-  resolved "https://registry.yarnpkg.com/astro/-/astro-4.14.5.tgz#d0e6302fdae72d31be6a916b8b30eb9bb2092b2a"
-  integrity sha512-sv47kPE6FnvyxxHHcCePNwTKpOMKBq0r1m6WZYg6ag9j3yF9m72ov64NFB7c+hAMDUKgsHfVdLKjOOqDC/c+fA==
+  version "4.14.6"
+  resolved "https://registry.yarnpkg.com/astro/-/astro-4.14.6.tgz#ff2feda4864ab103dcd5dc0b53f8104f4d4deb45"
+  integrity sha512-MIDyNhtu3L4uakHvlTprh21eQPehYOtZSuSLtd+r6xZcl3lB+mlBz/hs1W3iHEQAORyJnKArWSY/aVOBKUyflA==
   dependencies:
     "@astrojs/compiler" "^2.10.3"
     "@astrojs/internal-helpers" "0.4.1"
     "@astrojs/markdown-remark" "5.2.0"
     "@astrojs/telemetry" "3.1.0"
     "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/parser" "^7.25.3"
+    "@babel/generator" "^7.25.5"
+    "@babel/parser" "^7.25.4"
     "@babel/plugin-transform-react-jsx" "^7.25.2"
-    "@babel/traverse" "^7.25.3"
-    "@babel/types" "^7.25.2"
+    "@babel/traverse" "^7.25.4"
+    "@babel/types" "^7.25.4"
     "@oslojs/encoding" "^0.4.1"
     "@rollup/pluginutils" "^5.1.0"
     "@types/babel__core" "^7.20.5"
@@ -1267,10 +1267,10 @@ astro@^4.14.5:
     js-yaml "^4.1.0"
     kleur "^4.1.5"
     magic-string "^0.30.11"
-    micromatch "^4.0.7"
+    micromatch "^4.0.8"
     mrmime "^2.0.0"
     neotraverse "^0.6.18"
-    ora "^8.0.1"
+    ora "^8.1.0"
     p-limit "^6.1.0"
     p-queue "^8.0.1"
     path-to-regexp "^6.2.2"
@@ -1283,8 +1283,8 @@ astro@^4.14.5:
     strip-ansi "^7.1.0"
     tsconfck "^3.1.1"
     unist-util-visit "^5.0.0"
-    vfile "^6.0.2"
-    vite "^5.4.1"
+    vfile "^6.0.3"
+    vite "^5.4.2"
     vitefu "^0.2.5"
     which-pm "^3.0.0"
     xxhash-wasm "^1.0.2"
@@ -2063,7 +2063,7 @@ hast-util-to-estree@^3.0.0:
     unist-util-position "^5.0.0"
     zwitch "^2.0.0"
 
-hast-util-to-html@^9.0.0, hast-util-to-html@^9.0.1:
+hast-util-to-html@^9.0.0, hast-util-to-html@^9.0.1, hast-util-to-html@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.2.tgz#314d8c125c36cf736e4389850b4f73871965d0c3"
   integrity sha512-RP5wNpj5nm1Z8cloDv4Sl4RS8jH5HYa0v93YB6Wb4poEzgMo/dAAL0KcT4974dCjcNG5pkLqTImeFHHCwwfY3g==
@@ -3062,7 +3062,7 @@ micromark@^4.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.7:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -3155,7 +3155,7 @@ onetime@^7.0.0:
   dependencies:
     mimic-function "^5.0.0"
 
-ora@^8.0.1:
+ora@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-8.1.0.tgz#c3db2f9f83a2bec9e8ab71fe3b9ae234d65ca3a8"
   integrity sha512-GQEkNkH/GHOhPFXcqZs3IDahXEQcQxsSjEkK4KvEEST4t7eNzoMjxTzef+EZ+JluDEV+Raoi3WQ2CflnRdSVnQ==
@@ -3841,9 +3841,9 @@ style-to-object@^0.4.0:
     inline-style-parser "0.1.1"
 
 style-to-object@^1.0.0:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-1.0.6.tgz#0c28aed8be1813d166c60d962719b2907c26547b"
-  integrity sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-1.0.7.tgz#8604fb6018ac3db83e97207a4f85f579068f661c"
+  integrity sha512-uSjr59G5u6fbxUfKbb8GcqMGT3Xs9v5IbPkjb0S16GyOeBLAzSRK0CixBv5YrYvzO6TDLzIS6QCn78tkqWngPw==
   dependencies:
     inline-style-parser "0.2.3"
 
@@ -4036,7 +4036,7 @@ vfile-message@^4.0.0:
     "@types/unist" "^3.0.0"
     unist-util-stringify-position "^4.0.0"
 
-vfile@^6.0.0, vfile@^6.0.2:
+vfile@^6.0.0, vfile@^6.0.2, vfile@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
   integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
@@ -4044,7 +4044,7 @@ vfile@^6.0.0, vfile@^6.0.2:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
-vite@^5.4.1:
+vite@^5.4.2:
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.2.tgz#8acb6ec4bfab823cdfc1cb2d6c53ed311bc4e47e"
   integrity sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/cli/src/playwright.ts
+++ b/packages/cli/src/playwright.ts
@@ -5,6 +5,7 @@ import { runtimeHost } from "../../core/src/host"
 import { PLAYWRIGHT_VERSION } from "./version"
 import { ellipseUri } from "../../core/src/url"
 import { PLAYWRIGHT_DEFAULT_BROWSER } from "../../core/src/constants"
+import { log } from "node:console"
 
 export class BrowserManager {
     private _browsers: Browser[] = []
@@ -41,6 +42,7 @@ export class BrowserManager {
             const playwright = await this.init()
             return playwright[browser].launch(rest)
         } catch {
+            logVerbose("trying to install playwright...")
             await this.installDependencies(browser)
             const playwright = await this.init()
             return await playwright[browser].launch(rest)
@@ -84,6 +86,7 @@ export class BrowserManager {
 
         logVerbose(`browsing ${ellipseUri(url)}`)
         const browser = await this.launchBrowser(options)
+        logVerbose(`navigating...`)
         let page: BrowserPage
         if (incognito) {
             const context = await browser.newContext(rest)
@@ -92,6 +95,7 @@ export class BrowserManager {
             page = await browser.newPage(rest)
         }
         if (url) await page.goto(url)
+        logVerbose(`page ready`)
         return page
     }
 }

--- a/packages/cli/src/playwright.ts
+++ b/packages/cli/src/playwright.ts
@@ -6,8 +6,6 @@ import { PLAYWRIGHT_VERSION } from "./version"
 import { ellipseUri } from "../../core/src/url"
 import { PLAYWRIGHT_DEFAULT_BROWSER } from "../../core/src/constants"
 
-type PlaywrightModule = typeof import("playwright")
-
 export class BrowserManager {
     private _browsers: Browser[] = []
     private _pages: Page[] = []
@@ -21,7 +19,6 @@ export class BrowserManager {
     }
 
     private async installDependencies(vendor: string) {
-        // npx playwright install --with-deps chromium
         const res = await runtimeHost.exec(
             undefined,
             "npx",
@@ -40,10 +37,11 @@ export class BrowserManager {
 
     private async launchBrowser(options?: BrowserOptions): Promise<Browser> {
         const { browser = PLAYWRIGHT_DEFAULT_BROWSER, ...rest } = options || {}
-        const playwright = await this.init()
         try {
+            const playwright = await this.init()
             return playwright[browser].launch()
         } catch {
+            const playwright = await this.init()
             await this.installDependencies(browser)
             return await playwright[browser].launch()
         }

--- a/packages/cli/src/playwright.ts
+++ b/packages/cli/src/playwright.ts
@@ -39,11 +39,11 @@ export class BrowserManager {
         const { browser = PLAYWRIGHT_DEFAULT_BROWSER, ...rest } = options || {}
         try {
             const playwright = await this.init()
-            return playwright[browser].launch()
+            return playwright[browser].launch(rest)
         } catch {
-            const playwright = await this.init()
             await this.installDependencies(browser)
-            return await playwright[browser].launch()
+            const playwright = await this.init()
+            return await playwright[browser].launch(rest)
         }
     }
 

--- a/packages/cli/src/playwright.ts
+++ b/packages/cli/src/playwright.ts
@@ -40,7 +40,7 @@ export class BrowserManager {
         const { browser = PLAYWRIGHT_DEFAULT_BROWSER, ...rest } = options || {}
         try {
             const playwright = await this.init()
-            return playwright[browser].launch(rest)
+            return await playwright[browser].launch(rest)
         } catch {
             logVerbose("trying to install playwright...")
             await this.installDependencies(browser)

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -4,3 +4,4 @@ export const NODE_MIN_VERSION = packageJson.engines.node
 export const PROMPTFOO_VERSION = packageJson.peerDependencies.promptfoo
 export const TYPESCRIPT_VERSION = packageJson.dependencies.typescript
 export const DOCKERODE_VERSION = packageJson.dependencies.dockerode
+export const PLAYWRIGHT_VERSION = packageJson.dependencies.playwright

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -224,3 +224,5 @@ export const VSCODE_CONFIG_CLI_PATH = "cli.path"
 export const CONSOLE_COLOR_DEBUG = 34
 export const CONSOLE_COLOR_WARNING = 95
 export const CONSOLE_COLOR_ERROR = 91
+
+export const PLAYWRIGHT_DEFAULT_BROWSER = "chromium"

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1638,7 +1638,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -1,0 +1,11 @@
+export function ellipseUri(url: string) {
+    try {
+        const uri = new URL(url)
+        let res = `${uri.protocol}//${uri.hostname}${uri.pathname}`
+        if (uri.search) res += `?...`
+        if (uri.hash) res += `#...`        
+        return res
+    } catch {
+        return undefined
+    }
+}

--- a/packages/sample/genaisrc/browse-text.genai.mts
+++ b/packages/sample/genaisrc/browse-text.genai.mts
@@ -1,5 +1,7 @@
 script({
+    model: "gpt-3.5-turbo",
     group: "browser",
+    tests: {},
 })
 const page = await host.browse(
     "https://github.com/microsoft/genaiscript/blob/main/packages/sample/src/penguins.csv"

--- a/packages/sample/genaisrc/browse-text.genai.mts
+++ b/packages/sample/genaisrc/browse-text.genai.mts
@@ -1,9 +1,6 @@
 script({
     model: "gpt-3.5-turbo",
     group: "browser",
-    tests: {
-        keywords: ["bill"],
-    },
 })
 const page = await host.browse(
     "https://github.com/microsoft/genaiscript/blob/main/packages/sample/src/penguins.csv"
@@ -11,7 +8,7 @@ const page = await host.browse(
 const table = page.locator('table[data-testid="csv-table"]')
 const html = await table.innerHTML()
 console.log(`HTML:` + html)
-const csv = HTML.convertToMarkdown(html)
-console.log(`MD: ` + csv)
+const csv = HTML.convertToText(html)
+console.log(`TEXT: ` + csv)
 def("DATA", csv)
 $`Analyze DATA.`

--- a/packages/sample/genaisrc/browse-text.genai.mts
+++ b/packages/sample/genaisrc/browse-text.genai.mts
@@ -1,12 +1,17 @@
 script({
     model: "gpt-3.5-turbo",
     group: "browser",
-    tests: {},
+    tests: {
+        keywords: ["bill"],
+    },
 })
 const page = await host.browse(
     "https://github.com/microsoft/genaiscript/blob/main/packages/sample/src/penguins.csv"
 )
 const table = page.locator('table[data-testid="csv-table"]')
-const csv = HTML.convertToMarkdown(await table.innerHTML())
+const html = await table.innerHTML()
+console.log(`HTML:` + html)
+const csv = HTML.convertToMarkdown(html)
+console.log(`MD: ` + csv)
 def("DATA", csv)
 $`Analyze DATA.`

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1664,7 +1664,15 @@ interface ShellOutput {
     failed: boolean
 }
 
-interface BrowseSessionOptions {
+interface BrowserOptions {
+    /**
+     * Browser engine for this page. Defaults to chromium
+     *
+     */
+    browser?: "chromium" | "firefox" | "webkit"
+}
+
+interface BrowseSessionOptions extends BrowserOptions {
     /**
      * Creates a new context for the browser session
      */

--- a/slides/yarn.lock
+++ b/slides/yarn.lock
@@ -1207,16 +1207,16 @@
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
 "@types/node@*", "@types/node@>=20":
-  version "22.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.0.tgz#10f01fe9465166b4cab72e75f60d8b99d019f958"
-  integrity sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==
+  version "22.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.1.tgz#de01dce265f6b99ed32b295962045d10b5b99560"
+  integrity sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==
   dependencies:
     undici-types "~6.19.2"
 
 "@types/node@^18.7.3":
-  version "18.19.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.46.tgz#51801396c01153e0626e36f43386e83bc768b072"
-  integrity sha512-vnRgMS7W6cKa1/0G3/DTtQYpVrZ8c0Xm6UkLaVFrb9jtcVC3okokW09Ki1Qdrj9ISokszD69nY4WDLRlvHlhAA==
+  version "18.19.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.47.tgz#18076201ad7dd3445046df6ce9ead5fe5abd9387"
+  integrity sha512-1f7dB3BL/bpd9tnDJrrHb66Y+cVrhxSOTGorRNdHwYTUlTay3HuTDPKo9a/4vX9pMQkhYBcAbL4jQdNlhCFP9A==
   dependencies:
     undici-types "~5.26.4"
 
@@ -3178,7 +3178,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-"jiti-v1@npm:jiti@^1":
+"jiti-v1@npm:jiti@^1", jiti@^1.21.0, jiti@^1.21.6:
   version "1.21.6"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
   integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
@@ -3187,11 +3187,6 @@ jiti@2.0.0-beta.2:
   version "2.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.0.0-beta.2.tgz#5316b4adaa6f2e7ced330ab475bc6f35cfe51aaa"
   integrity sha512-c+PHQZakiQuMKbnhvrjZUvrK6E/AfmTOf4P+E3Y4FNVHcNMX9e/XrnbEvO+m4wS6ZjsvhHh/POQTlfy8uXFc0A==
-
-jiti@^1.21.0, jiti@^1.21.6:
-  version "1.21.6"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
-  integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
 
 js-tokens@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,23 +801,23 @@
     form-data "^4.0.0"
 
 "@types/node@*", "@types/node@>=13.7.0", "@types/node@>=20", "@types/node@^22.1.0":
-  version "22.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.0.tgz#10f01fe9465166b4cab72e75f60d8b99d019f958"
-  integrity sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==
+  version "22.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.1.tgz#de01dce265f6b99ed32b295962045d10b5b99560"
+  integrity sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==
   dependencies:
     undici-types "~6.19.2"
 
 "@types/node@^18.11.18":
-  version "18.19.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.46.tgz#51801396c01153e0626e36f43386e83bc768b072"
-  integrity sha512-vnRgMS7W6cKa1/0G3/DTtQYpVrZ8c0Xm6UkLaVFrb9jtcVC3okokW09Ki1Qdrj9ISokszD69nY4WDLRlvHlhAA==
+  version "18.19.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.47.tgz#18076201ad7dd3445046df6ce9ead5fe5abd9387"
+  integrity sha512-1f7dB3BL/bpd9tnDJrrHb66Y+cVrhxSOTGorRNdHwYTUlTay3HuTDPKo9a/4vX9pMQkhYBcAbL4jQdNlhCFP9A==
   dependencies:
     undici-types "~5.26.4"
 
 "@types/node@^20.14.12":
-  version "20.16.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.1.tgz#0b44b15271d0e2191ca68faf1fbe506e06aed732"
-  integrity sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==
+  version "20.16.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.2.tgz#9e388f503a5af306e8c63319334887390966a11e"
+  integrity sha512-91s/n4qUPV/wg8eE9KHYW1kouTfDk2FPGjXbBMfRWP/2vg1rCXNQL1OCabwGs0XSdukuK+MwCDXE30QpSeMUhQ==
   dependencies:
     undici-types "~6.19.2"
 
@@ -3618,9 +3618,9 @@ node-fetch@^2.6.12, node-fetch@^2.6.7:
     whatwg-url "^5.0.0"
 
 node-gyp-build@^4.3.0:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.1.tgz#976d3ad905e71b76086f4f0b0d3637fe79b6cda5"
-  integrity sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.2.tgz#4f802b71c1ab2ca16af830e6c1ea7dd1ad9496fa"
+  integrity sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==
 
 node-sarif-builder@^3.2.0:
   version "3.2.0"
@@ -4591,16 +4591,7 @@ streamx@^2.15.0, streamx@^2.18.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4637,14 +4628,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4998,9 +4982,9 @@ type-fest@^2.12.2:
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-fest@^4.19.0, type-fest@^4.21.0, type-fest@^4.6.0:
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.25.0.tgz#b190374f969631866889bbdb01ece17ca424ee60"
-  integrity sha512-bRkIGlXsnGBRBQRAY56UXBm//9qH4bmJfFvq83gSz41N282df+fjy8ofcEgc1sM8geNt5cl6mC2g9Fht1cs8Aw==
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.26.0.tgz#703f263af10c093cd6277d079e26b9e17d517c4b"
+  integrity sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==
 
 type@^2.7.2:
   version "2.7.3"
@@ -5279,7 +5263,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5292,15 +5276,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- 🔄The `playwright.ts` file in `packages/cli/src/` has been updated:

  - 🚀A try-catch block has been added to the `init()` method inside `BrowserManager` class. It will attempt to import the `playwright` module and throw an error if the module cannot be imported. This can happen if the `playwright` installation isn't completed.
  
  - 🚑In the event of any errors, it will trigger Playwright's installation process using `runtimeHost.exec()` function with `playwright` and its dependencies.
  
- 📈A new constant `PLAYWRIGHT_VERSION` has also been added to the `version.ts` file in the same directory, which seems to be related to the `playwright` installation process in above point.

- 🆕In the `browse-text.genai.mts` file located in `packages/sample/genaisrc/`, two new properties are added to the `script` configuration object: `model` and `tests`. These changes suggest some form of model configuration and testing strategy being integrated into the script execution.

Remember, this summary does not focus on import statements or non-user-facing changes that are not in "packages/core/src/prompt_template.d.ts" and "packages/core/src/prompt_type.ts".

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10603995893)



<!-- genaiscript end pr-describe -->

