### PR TITLE
Improve automatic CSV format detection and simplify data definition in browse-text feature

### DIFF
--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -255,6 +255,22 @@ export function createFileOutput(output: FileOutput): FileOutputNode {
     return { type: "fileOutput", output }
 }
 
+function haveSameKeysAndSimpleValues(data: object[]): boolean {
+    if (data.length === 0) return true
+    const headers = Object.entries(data[0])
+    return data.slice(1).every((obj) => {
+        const keys = Object.entries(obj)
+        return (
+            headers.length === keys.length &&
+            headers.every(
+                (h, i) =>
+                    keys[i][0] === h[0] &&
+                    /^(string|number|boolean|null|undefined)$/.test(typeof keys[i][1])
+            )
+        )
+    })
+}
+
 export function createDefData(
     name: string,
     data: object | object[],
@@ -262,7 +278,13 @@ export function createDefData(
 ) {
     if (data === undefined) return undefined
     let { format, headers, priority } = options || {}
-    if (!format && headers && Array.isArray(data)) format = "csv"
+    if (
+        !format &&
+        Array.isArray(data) &&
+        data.length &&
+        (headers?.length || haveSameKeysAndSimpleValues(data))
+    )
+        format = "csv"
     else if (!format) format = "yaml"
 
     if (Array.isArray(data)) data = tidyData(data as object[], options)

--- a/packages/sample/genaisrc/browse-text.genai.mts
+++ b/packages/sample/genaisrc/browse-text.genai.mts
@@ -9,5 +9,5 @@ const table = page.locator('table[data-testid="csv-table"]')
 const html = await table.innerHTML()
 const csv = HTML.convertTablesToJSON("<table>" + html + "</table>")[0]
 csv.forEach((row) => delete row[Object.keys(row)[0]]) // remove the first column
-defData("DATA", csv, { format: "csv" })
+defData("DATA", csv)
 $`Analyze DATA and provide a statistical summary.`


### PR DESCRIPTION
This pull request improves the automatic CSV format detection in the browse-text feature. It simplifies the data definition by checking if the data has the same keys and simple values. Additionally, it removes the need to specify the format as "csv" when using the `defData` function.