### PR TITLE
Add keys method to WorkspaceFileCache

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/docs/src/content/docs/reference/scripts/cache.mdx
+++ b/docs/src/content/docs/reference/scripts/cache.mdx
@@ -77,8 +77,10 @@ You can instantiate a custom cache object to manage the cache programmatically.
 const cache = await workspace.cache("summary")
 // write entries
 await cache.set("file.txt", "...")
-// read entries
+// read value
 const content = await cache.get("file.txt")
-// list entries
-const entries = await cache.values()
+// list keys
+const keys = await cache.keys()
+// list values
+const values = await cache.values()
 ```

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -74,6 +74,7 @@ export function createFileSystem(): Omit<WorkspaceFileSystem, "grep"> {
             return <WorkspaceFileCache<any, any>>{
                 get: async (key: any) => res.get(key),
                 set: async (key: any, val: any) => res.set(key, val),
+                keys: async () => res.keys(),
                 values: async () =>
                     res.entries().then((es) => es.map((e) => e.val)),
             }

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -503,6 +503,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/genaisrc/cache.genai.mts
+++ b/packages/sample/genaisrc/cache.genai.mts
@@ -16,6 +16,9 @@ if (result !== value) throw new Error(`unexpected value: ${result}`)
 const values = await cache.values()
 if (!values.includes(value)) throw new Error(`unexpected values: ${values}`)
 
+const keys = await cache.keys()
+if (!keys.includes(key)) throw new Error(`unexpected keys: ${keys}`)
+
 console.log(`cache test passed`)
 
 $`Generate a random word.`

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -529,6 +529,11 @@ interface WorkspaceFileCache<K, V> {
     set(key: K, value: V): Promise<void>
 
     /**
+     * List of keys
+     */
+    keys(): Promise<K[]>
+
+    /**
      * List the values in the cache.
      */
     values(): Promise<V[]>


### PR DESCRIPTION
This pull request adds a `keys` method to the `WorkspaceFileCache` interface. The `keys` method returns a promise that resolves to an array of keys in the cache. This allows users to retrieve a list of keys stored in the cache. The changes also include updating the documentation to reflect the new method.

<!-- genaiscript begin pr-describe -->

- The developers have added a new method to `WorkspaceFileCache` interface, in the file "packages/core/src/types/prompt_template.d.ts". This new method allows to get all the keys from the cache. Now you can list the keys in the cache as well as the values. :key::zap:
- The changes have also been reflected in the related code files to add the keys-listing functionality. In the file "packages/core/src/filesystem.ts", the newly added `keys` method is used to fetch all the keys from the cache. :page_facing_up::arrows_counterclockwise:
- A change has been made in "docs/src/content/docs/reference/scripts/cache.mdx" to include instructions on how to use the new `keys` method. This is expected to help the users of the public API to learn how to get a list of keys from the cache memory. :book::mag:
- There is an update on a test file at "packages/sample/genaisrc/cache.genai.mts". Now they are checking if particular keys exist in the cache as part of the test case. This validates the implementation of the new method. :white_check_mark::nerd_face:

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10620614323)



<!-- genaiscript end pr-describe -->

