### PR TITLE
Refactor confirm prompt and enable LLM result caching

### DIFF
--- a/docs/src/content/docs/guides/auto-git-commit-message.mdx
+++ b/docs/src/content/docs/guides/auto-git-commit-message.mdx
@@ -32,15 +32,15 @@ let { stdout } = await host.exec("git", ["diff", "--cached"])
 If no changes are staged, we ask the user if they want to stage all changes. If the user confirms, we stage all changes. Otherwise, we bail out.
 
 ```ts
-    const stage = await confirm({
-        message: "No staged changes. Stage all changes?",
-        default: true,
-    })
-    if (stage) {
-        await host.exec("git", ["add", "."])
-        stdout = (await host.exec("git", ["diff", "--cached"])).stdout
-    }
-    if (!stdout) cancel("no staged changes")
+const stage = await confirm({
+    message: "No staged changes. Stage all changes?",
+    default: true,
+})
+if (stage) {
+    await host.exec("git", ["add", "."])
+    stdout = (await host.exec("git", ["diff", "--cached"])).stdout
+}
+if (!stdout) cancel("no staged changes")
 ```
 
 We generate an initial commit message using the staged changes:
@@ -109,12 +109,6 @@ Since it uses the [@inquirer/prompts](https://www.npmjs.com/package/@inquirer/pr
 
 ```bash
 npm install --save-dev @inquirer/prompts
-```
-
-If you are using [npx](https://docs.npmjs.com/cli/v10/commands/npx),
-
-```bash
-npx -p @inquirer/prompts -p genaiscript  -- genaiscript run gcm
 ```
 
 This command will run the script, and guide you through the process of generating and committing a Git message using AI, making your commits more informative and consistent.

--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -87,7 +87,7 @@ Options:
   --cli <string>                      override path to the cli
   -tp, --test-provider <string>       test provider
   -td, --test-delay <string>          delay between tests in seconds
-  -cache                              enable LLM result cache
+  --cache                             enable LLM result cache
   -v, --verbose                       verbose output
   -pv, --promptfoo-version [version]  promptfoo version, default is 0.78.0
   -os, --out-summary <file>           append output summary in file

--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -43,7 +43,7 @@ Options:
   -mtc, --max-tool-calls <number>            maximum tool calls for the run
   -se, --seed <number>                       seed for the run
   -em, --embeddings-model <string>           embeddings model for the run
-  --no-cache                                 disable LLM result cache
+  --cache                                    enable LLM result cache
   -cn, --cache-name <name>                   custom cache file name
   -cs, --csv-separator <string>              csv separator (default: "\t")
   -ae, --apply-edits                         apply file edits
@@ -87,7 +87,7 @@ Options:
   --cli <string>                      override path to the cli
   -tp, --test-provider <string>       test provider
   -td, --test-delay <string>          delay between tests in seconds
-  --no-cache                          disable LLM result cache
+  -cache                              enable LLM result cache
   -v, --verbose                       verbose output
   -pv, --promptfoo-version [version]  promptfoo version, default is 0.78.0
   -os, --out-summary <file>           append output summary in file

--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -43,6 +43,7 @@ Options:
   -mtc, --max-tool-calls <number>            maximum tool calls for the run
   -se, --seed <number>                       seed for the run
   -em, --embeddings-model <string>           embeddings model for the run
+  --no-cache                                 disable LLM result cache
   --cache                                    enable LLM result cache
   -cn, --cache-name <name>                   custom cache file name
   -cs, --csv-separator <string>              csv separator (default: "\t")
@@ -87,6 +88,7 @@ Options:
   --cli <string>                      override path to the cli
   -tp, --test-provider <string>       test provider
   -td, --test-delay <string>          delay between tests in seconds
+  --no-cache                          disable LLM result cache
   --cache                             enable LLM result cache
   -v, --verbose                       verbose output
   -pv, --promptfoo-version [version]  promptfoo version, default is 0.78.0

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -140,6 +140,7 @@ export async function cli() {
             "-em, --embeddings-model <string>",
             "embeddings model for the run"
         )
+        .option("--no-cache", "disable LLM result cache")
         .option("--cache", "enable LLM result cache")
         .option("-cn, --cache-name <name>", "custom cache file name")
         .option("-cs, --csv-separator <string>", "csv separator", "\t")
@@ -171,6 +172,7 @@ export async function cli() {
         .option("--cli <string>", "override path to the cli")
         .option("-tp, --test-provider <string>", "test provider")
         .option("-td, --test-delay <string>", "delay between tests in seconds")
+        .option("--no-cache", "disable LLM result cache")
         .option("--cache", "enable LLM result cache")
         .option("-v, --verbose", "verbose output")
         .option(

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -140,7 +140,7 @@ export async function cli() {
             "-em, --embeddings-model <string>",
             "embeddings model for the run"
         )
-        .option("--no-cache", "disable LLM result cache")
+        .option("--cache", "enable LLM result cache")
         .option("-cn, --cache-name <name>", "custom cache file name")
         .option("-cs, --csv-separator <string>", "csv separator", "\t")
         .option("-ae, --apply-edits", "apply file edits")
@@ -171,7 +171,7 @@ export async function cli() {
         .option("--cli <string>", "override path to the cli")
         .option("-tp, --test-provider <string>", "test provider")
         .option("-td, --test-delay <string>", "delay between tests in seconds")
-        .option("--no-cache", "disable LLM result cache")
+        .option("-cache", "enable LLM result cache")
         .option("-v, --verbose", "verbose output")
         .option(
             "-pv, --promptfoo-version [version]",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -171,7 +171,7 @@ export async function cli() {
         .option("--cli <string>", "override path to the cli")
         .option("-tp, --test-provider <string>", "test provider")
         .option("-td, --test-delay <string>", "delay between tests in seconds")
-        .option("-cache", "enable LLM result cache")
+        .option("--cache", "enable LLM result cache")
         .option("-v, --verbose", "verbose output")
         .option(
             "-pv, --promptfoo-version [version]",

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -150,7 +150,7 @@ export async function runPromptScriptTests(
             "1",
             "--no-progress-bar",
         ]
-        if (!options.cache) args.push("--no-cache")
+        if (options.cache) args.push("--cache")
         if (options.verbose) args.push("--verbose")
         args.push("--output", outJson)
         logVerbose(`  ${cmd} ${args.join(" ")}`)

--- a/packages/core/src/genaiscript-api-provider.mjs
+++ b/packages/core/src/genaiscript-api-provider.mjs
@@ -54,7 +54,7 @@ class GenAIScriptApiProvider {
             if (temperature !== undefined)
                 args.push("--temperature", temperature)
             if (top_p !== undefined) args.push("--top_p", top_p)
-            if (cache === false) args.push("--no-cache")
+            if (cache === true) args.push("--cache")
 
             const cmd = args
                 .map((a) =>


### PR DESCRIPTION
This pull request includes a refactoring of the confirm prompt and removes the usage instructions for the `npx` command from the auto-git-commit-message guide. Additionally, it enables LLM result caching and updates the CLI options to reflect this change.

<!-- genaiscript begin pr-describe -->

- **Indentation Change** 📏: The first change is to `auto-git-commit-message.mdx`. The indentation of a section of javascript has been reduced to be in line with good style practices for a consistent and clean codebase. 🧼

- **Removing Unneeded Info** 🗑️: The next change also to `auto-git-commit-message.mdx` removes unneeded information regarding how to use [npx](https://docs.npmjs.com/cli/v10/commands/npx) which cleans up the documentation. 📝 

- **Option Switch** 🔁: In several `.md` and `.ts` files, the `--no-cache` option has been changed to `--cache`. This alters the default behavior of cache settings, effectively enabling cache by default, which can enhance the performance of command-line interactions executed by users, thus speeding up overall execution. 🚀 

- **Cache Settings Applied** ✔️: The updated cache option has been applied to several commands in various `.ts` files. This includes adding `--cache` option in conditions where it was previously omitted if cache was disabled. 

Please note that, although these changes seem to be relatively minor, they are important for the overall efficiency, speed, and cleanliness of the codebase. This all can lead to a superior user experience. 👩‍💻👨‍💻

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10625493733)



<!-- genaiscript end pr-describe -->

