### PR TITLE
Add support for Fenced type in def function and fix snippet content extraction in blog generator

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/genaisrc/blog-generator.genai.mjs
+++ b/genaisrc/blog-generator.genai.mjs
@@ -116,7 +116,7 @@ let snippet
     snippet =
         fences.find(
             ({ language }) => language === "js" || language === "javascript"
-        )?.content ?? text
+        ) ?? text
 }
 
 // generate a blog post

--- a/genaisrc/blog-generator.genai.mts
+++ b/genaisrc/blog-generator.genai.mts
@@ -53,7 +53,7 @@ Use these files to help you generate a topic for the blog post.
 }
 
 // generate a working code snippet from topic
-let snippet
+let snippet: string | Fenced
 {
     const { text, fences, error } = await runPrompt(
         (_) => {
@@ -186,7 +186,7 @@ defOutputProcessor((output) => {
     return {
         files: {
             [fn]: md,
-            [sn]: snippet,
+            [sn]: typeof snippet === "string" ? snippet : snippet?.content,
         },
     }
 })

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -109,6 +109,16 @@ export function createChatTurnGenerationContext(
                         { ...doptions, lineNumbers: false }
                     )
                 )
+            } else if (typeof body === "object" && (body as Fenced).content) {
+                const fenced = body as Fenced
+                appendChild(
+                    node,
+                    createDefNode(
+                        name,
+                        { filename: "", content: (body as Fenced).content },
+                        { language: fenced.language, ...(doptions || {}) }
+                    )
+                )
             }
 
             // TODO: support clause

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1451,7 +1451,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -51,7 +51,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1477,7 +1477,7 @@ interface ChatTurnGenerationContext {
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
-        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+        body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
         options?: DefOptions
     ): string
     defData(
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */
@@ -2291,7 +2291,7 @@ declare function fence(body: StringLike, options?: FenceOptions): void
  */
 declare function def(
     name: string,
-    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput,
+    body: string | WorkspaceFile | WorkspaceFile[] | ShellOutput | Fenced,
     options?: DefOptions
 ): string
 


### PR DESCRIPTION
This pull request adds support for the Fenced type in the `def` function and fixes the snippet content extraction in the blog generator. The changes include modifying the `def` function to accept the Fenced type as a parameter and updating the blog generator to correctly extract the content from fenced snippets. These changes improve the functionality and accuracy of the code.

<!-- genaiscript begin pr-describe -->

- In the `runpromptcontext.ts` file, a new conditional block has been added that caters to `body` objects of type `Fenced` 🚧. If `body` is an object and has a `content` property, a new `DefNode` is created and appended to the node. The language and other options are passed while creating the `DefNode` 🎨.

- For the `def` method in both `prompt_template.d.ts` and `prompt_type.d.ts` (your user-facing API files 👥), the `body` argument's type lineup has a new entrant - `Fenced` 🎟. While the function could earlier receive a string or a file or an array of files from the workspace, or a `ShellOutput`, it can now also accept an object of type `Fenced` 🔧.

Get ready to interact with `Fenced` objects in a whole new way! 🚀

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10648206309)



<!-- genaiscript end pr-describe -->

