### PR TITLE
Add .cursorignore file to ignore .genaiscript, node_modules, and built directories

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,3 @@
+.genaiscript/
+node_modules/
+built/

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -2091,8 +2091,8 @@ interface ShellHost {
 
     /**
      * Starts a headless browser and navigates to the page.
-     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browse).
-     * @link https://microsoft.github.io/genaiscript/reference/scripts/browse
+     * Requires to [install playwright and dependencies](https://microsoft.github.io/genaiscript/reference/scripts/browser).
+     * @link https://microsoft.github.io/genaiscript/reference/scripts/browser
      * @param url
      * @param options
      */


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- A new file `.cursorignore` is created. :star: :new:
- There are three directories added to the `.cursorignore` file, which are: 
  - `.genaiscript/` :page_facing_up:
  - `node_modules/` :package:
  - `built/` :hammer_and_wrench:
- This indicates that these directories are being ignored by the cursor actions. Essentially, any files in these directories will be ignored by some processes (like search or Git operations). :see_no_evil:
- It seems to be a way to optimize the processes by reducing the scope of files to scan or operate upon. :rocket:
- Note: There's no newline at the end of the file. End of file newlines are good to give a clear termination to the file and helps certain utilities processing them without any issue. :information_source:
  
Just to clarify, there are no changes in the user-facing API ("packages/core/src/prompt_template.d.ts" and "packages/core/src/prompt_type.ts") present in the GIT_DIFF provided. :ok_hand:

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10655039041)



<!-- genaiscript end pr-describe -->

