### PR TITLE
Add mustache template rendering support to parsers

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/core/src/mustache.ts
+++ b/packages/core/src/mustache.ts
@@ -27,3 +27,5 @@ export async function interpolateVariables(
 
     return content
 }
+
+export const mustacheRender = Mustache.render

--- a/packages/core/src/parsers.ts
+++ b/packages/core/src/parsers.ts
@@ -23,7 +23,7 @@ import { unzip } from "./zip"
 import { JSONLTryParse } from "./jsonl"
 import { resolveFileContent } from "./file"
 import { resolveTokenEncoder } from "./encoders"
-import { mustacheRender} from "./mustache"
+import { mustacheRender } from "./mustache"
 
 export async function createParsers(options: {
     trace: MarkdownTrace

--- a/packages/core/src/parsers.ts
+++ b/packages/core/src/parsers.ts
@@ -23,6 +23,7 @@ import { unzip } from "./zip"
 import { JSONLTryParse } from "./jsonl"
 import { resolveFileContent } from "./file"
 import { resolveTokenEncoder } from "./encoders"
+import { mustacheRender} from "./mustache"
 
 export async function createParsers(options: {
     trace: MarkdownTrace
@@ -105,5 +106,9 @@ export async function createParsers(options: {
             await MathTryEvaluate(expression, { trace }),
         validateJSON: (schema, content) =>
             validateJSONWithSchema(content, schema, { trace }),
+        mustache: (file, args) => {
+            const f = filenameOrFileToContent(file)
+            return mustacheRender(f, args)
+        }
     })
 }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1085,6 +1085,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1111,6 +1111,13 @@ interface Parsers {
      * @param content object to validate
      */
     validateJSON(schema: JSONSchema, content: any): JSONSchemaValidation
+
+    /**
+     * Renders a mustache template
+     * @param text 
+     * @param data 
+     */
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {


### PR DESCRIPTION
This pull request adds support for rendering mustache templates in the parsers module. It includes changes to the `parsers.ts` file, where a new `mustache` function is added. This function takes a text string or a WorkspaceFile and data as input and returns the rendered template as a string. This feature enhances the functionality of the parsers module by allowing the rendering of dynamic content using mustache templates.

<!-- genaiscript begin pr-describe -->

- 📝 A new constant, `mustacheRender`, is exported from the module located at `packages/core/src/mustache.ts`. This seems to be wrapping the render function of Mustache, a logic-less template syntax.

- 🧩 In `packages/core/src/parsers.ts`, `mustacheRender` is imported from the mustache module. This adds a new functionality to the `createParsers` function. Specifically, it introduces the ability to render mustache templates. The function utilizes `mustacheRender`, applied on the content of a file (`f`) with supplied `args`.

- 👥 From a user perspective, a new method has been defined in the public API `packages/core/src/types/prompt_template.d.ts`. The method, `mustache`, allows users to render mustache templates by passing a string or a file as a template and a record object as data. This change enhances the public API, giving more flexibility and tools to the users.

These changes show the focus on enhancing the template rendering capabilities of the system. By incorporating Mustache, template rendering becomes more flexible and powerful. 🚀

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10692035556)



<!-- genaiscript end pr-describe -->

