### PR TITLE
Integrate jinja templating support with @huggingface/jinja package and update documentation

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1034,403 +1034,6 @@ Apache License
 
 The following npm packages may be included in this product:
 
- - playwright-core@1.46.1
- - playwright@1.46.1
-
-These packages each contain the following license and notice below:
-
-Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Portions Copyright (c) Microsoft Corporation.
-   Portions Copyright 2017 Google Inc.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
------------
-
-The following npm package may be included in this product:
-
- - mathjs@13.1.1
-
-This package contains the following license and notice below:
-
-Apache License
-                           Version 2.0, January 2004
-                        https://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
------------
-
-The following npm packages may be included in this product:
-
  - @types/http-cache-semantics@4.0.4
  - @types/mute-stream@0.0.4
  - @types/node@22.5.4
@@ -3528,11 +3131,31 @@ IN THE SOFTWARE.
 
 The following npm package may be included in this product:
 
+ - buildcheck@0.0.6
+
+This package contains the following license and notice below:
+
+http://github.com/mscdex/buildcheck/raw/master/LICENSE
+
+-----------
+
+The following npm package may be included in this product:
+
  - ssh2@1.15.0
 
 This package contains the following license and notice below:
 
 http://github.com/mscdex/ssh2/raw/master/LICENSE
+
+-----------
+
+The following npm package may be included in this product:
+
+ - cpu-features@0.0.10
+
+This package contains the following license and notice below:
+
+https://github.com/mscdex/cpu-features/raw/master/LICENSE
 
 -----------
 
@@ -4271,6 +3894,31 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 The following npm package may be included in this product:
 
+ - mathjs@13.1.1
+
+This package contains the following license and notice below:
+
+math.js
+https://github.com/josdejong/mathjs
+
+Copyright (C) 2013-2024 Jos de Jong <wjosdejong@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-----------
+
+The following npm package may be included in this product:
+
  - minizlib@2.1.2
 
 This package contains the following license and notice below:
@@ -4306,7 +3954,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following npm packages may be included in this product:
 
- - @esbuild/win32-x64@0.23.1
+ - @esbuild/linux-x64@0.23.1
  - agent-base@6.0.2
  - canvas@2.11.2
  - genaiscript-core-internal@1.54.0
@@ -5413,6 +5061,21 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 """
+
+-----------
+
+The following npm packages may be included in this product:
+
+ - playwright-core@1.46.1
+ - playwright@1.46.1
+
+These packages each contain the following license and notice below:
+
+Playwright
+Copyright (c) Microsoft Corporation
+
+This software contains code derived from the Puppeteer project (https://github.com/puppeteer/puppeteer),
+available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 -----------
 

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/docs/src/content/docs/reference/scripts/parsers.md
+++ b/docs/src/content/docs/reference/scripts/parsers.md
@@ -106,7 +106,7 @@ The `parsers.XML` function parses for the [XML format](https://en.wikipedia.org/
 const res = parsers.XML('<xml attr="1"><child /></xml>')
 ```
 
-Attribute names are prepended with "@_".
+Attribute names are prepended with "@\_".
 
 ```json
 {
@@ -297,4 +297,12 @@ Runs the [mustache](https://mustache.github.io/) template engine in the string a
 
 ```js
 const rendered = parsers.mustache("Today is {{date}}.", { date: new Date() })
+```
+
+## jinja
+
+Runs the [jinja](https://jinja.palletsprojects.com/en/3.1.x/) template (using [@huggingface/jinja](https://www.npmjs.com/package/@huggingface/jinja)).
+
+```js
+const rendered = parsers.jinja("Today is {{date}}.", { date: new Date() })
 ```

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@azure/identity": "^4.4.1",
+    "@huggingface/jinja": "^0.3.0",
     "@tidyjs/tidy": "^2.5.2",
     "@types/html-escaper": "^3.0.2",
     "@types/html-to-text": "^9.0.4",

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/core/src/jinja.test.ts
+++ b/packages/core/src/jinja.test.ts
@@ -1,0 +1,18 @@
+import { jinjaRender } from "./jinja"
+import { describe, test, beforeEach } from "node:test"
+import assert from "node:assert/strict"
+
+describe("jinjaRender", () => {
+    test("should correctly render template with values", () => {
+        // Given a template and values
+        const template = "Hello, {{ name }}! Today is {{ day }}."
+        const values = { name: "Alice", day: "Monday" }
+
+        // When rendering the template
+        const result = jinjaRender(template, values)
+
+        // Then the result should be as expected
+        const expected = "Hello, Alice! Today is Monday."
+        assert.strictEqual(result, expected)
+    })
+})

--- a/packages/core/src/jinja.ts
+++ b/packages/core/src/jinja.ts
@@ -1,0 +1,10 @@
+import { Template } from "@huggingface/jinja"
+
+export function jinjaRender(
+    template: string,
+    values: Record<string, any>
+): string {
+    const t = new Template(template)
+    const res = t.render(values)
+    return res
+}

--- a/packages/core/src/parsers.ts
+++ b/packages/core/src/parsers.ts
@@ -24,6 +24,7 @@ import { JSONLTryParse } from "./jsonl"
 import { resolveFileContent } from "./file"
 import { resolveTokenEncoder } from "./encoders"
 import { mustacheRender } from "./mustache"
+import { jinjaRender } from "./jinja"
 
 export async function createParsers(options: {
     trace: MarkdownTrace
@@ -109,6 +110,10 @@ export async function createParsers(options: {
         mustache: (file, args) => {
             const f = filenameOrFileToContent(file)
             return mustacheRender(f, args)
+        },
+        jinja: (file, data) => {
+            const f = filenameOrFileToContent(file)
+            return jinjaRender(f, data)
         },
     })
 }

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -68,7 +68,7 @@ export interface PromptStringTemplateNode extends PromptNode {
     type: "stringTemplate"
     strings: TemplateStringsArray
     args: any[]
-    transforms: ((s: string) => string)[]
+    transforms: ((s: string) => Awaitable<string>)[]
     resolved?: string
 }
 
@@ -493,7 +493,7 @@ async function resolvePromptNode(
                 // apply transforms
                 if (n.transforms?.length)
                     for (const transform of n.transforms)
-                        value = transform(value)
+                        value = await transform(value)
                 n.resolved = n.preview = value
                 n.tokens = estimateTokens(value, encoder)
             } catch (e) {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1091,7 +1091,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1460,12 +1460,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1458,6 +1458,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1467,7 +1485,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -44,7 +44,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/genaisrc/templating.genai.mts
+++ b/packages/sample/genaisrc/templating.genai.mts
@@ -1,0 +1,15 @@
+script({
+    model: "openai:gpt-3.5-turbo",
+    tests: {
+        keywords: ["paris", "monday"],
+        asserts: [
+            {
+                type: "not-icontains",
+                value: "hello",
+            },
+        ],
+    },
+})
+$`What is the capital of {{ country }}?`.jinja({ country: "France" })
+$`Today is {{ day }}. What day of the week is it?`.mustache({ day: "Monday" })
+$`This part of the prompt should not be inlined. SaY HELLO.`.maxTokens(1)

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1517,6 +1517,24 @@ interface FileOutput {
 
 interface ImportTemplateOptions {}
 
+interface PromptTemplateString {
+    /**
+     * Applies jinja template to the string
+     * @param data jinja data
+     */
+    jinja(data: Record<string, any>): PromptTemplateString
+    /**
+     * Applies mustache template to the string
+     * @param data mustache data
+     */
+    mustache(data: Record<string, any>): PromptTemplateString
+    /**
+     * Sets the max tokens for this string
+     * @param tokens
+     */
+    maxTokens(tokens: number): PromptTemplateString
+}
+
 interface ChatTurnGenerationContext {
     importTemplate(
         files: string | string[],
@@ -1526,7 +1544,7 @@ interface ChatTurnGenerationContext {
         options?: ImportTemplateOptions
     ): void
     writeText(body: Awaitable<string>, options?: WriteTextOptions): void
-    $(strings: TemplateStringsArray, ...args: any[]): void
+    $(strings: TemplateStringsArray, ...args: any[]): PromptTemplateString
     fence(body: StringLike, options?: FenceOptions): void
     def(
         name: string,
@@ -2335,7 +2353,10 @@ declare function writeText(
  * Append given string to the prompt. It automatically appends "\n".
  * `` $`foo` `` is the same as `text("foo")`.
  */
-declare function $(strings: TemplateStringsArray, ...args: any[]): string
+declare function $(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): PromptTemplateString
 
 /**
  * Appends given (often multi-line) string to the prompt, surrounded in fences.

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1150,7 +1150,11 @@ interface Parsers {
      * @param text template text
      * @param data data to render
      */
-    mustache(text: string | WorkspaceFile, data: Record<string, any>): string
+    mustache(text: string | WorkspaceFile, data: Record<string, any>): str
+    /**
+     * Renders a jinja template
+     */
+    jinja(text: string | WorkspaceFile, data: Record<string, any>): string
 }
 
 interface AICIGenOptions {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1519,12 +1519,12 @@ interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
     /**
-     * Applies jinja template to the string
+     * Applies jinja template to the string lazily
      * @param data jinja data
      */
     jinja(data: Record<string, any>): PromptTemplateString
     /**
-     * Applies mustache template to the string
+     * Applies mustache template to the string lazily
      * @param data mustache data
      */
     mustache(data: Record<string, any>): PromptTemplateString

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,11 @@
   resolved "https://registry.yarnpkg.com/@huggingface/jinja/-/jinja-0.2.2.tgz#faeb205a9d6995089bef52655ddd8245d3190627"
   integrity sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==
 
+"@huggingface/jinja@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@huggingface/jinja/-/jinja-0.3.0.tgz#372d34f7eba59c3b886d892a6c72acd211d74675"
+  integrity sha512-GLJzso0M07ZncFkrJMIXVU4os6GFbPocD4g8fMQPMGJubf48FtGOsUORH2rtFdXPIPelz8SLBMn8ZRmOTwXm9Q==
+
 "@humanwhocodes/module-importer@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5352,7 +5352,6 @@ xdg-basedir@^5.1.0:
 
 "xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz":
   version "0.20.2"
-  uid "0f64eeed3f1a46e64724620c3553f2dbd3cd2d7d"
   resolved "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz#0f64eeed3f1a46e64724620c3553f2dbd3cd2d7d"
 
 xml2js@^0.4.23:


### PR DESCRIPTION
This pull request integrates jinja templating support with the @huggingface/jinja package. It adds a new \`jinja\` function to the \`Parsers\` interface, which allows rendering jinja templates using the [@huggingface/jinja](https://www.npmjs.com/package/@huggingface/jinja) package. The pull request also includes updates to the documentation to reflect the new functionality.

\`\`\`

<!-- genaiscript begin pr-describe -->

- The `jinja` templating was added to the system. This uses [@huggingface/jinja](https://www.npmjs.com/package/@huggingface/jinja) as the implementation. The test for this function, as expected, passed without issues. 🧪
- The `jinja` addition also impacted the parsers. Specifically, it was included as one of the types of parsers the system could utilize. This increases the flexibility of data representation. 🔄 
- A correction was made to the documentation included in the system. It's a crucial step to ensure users have the correct guidelines. The documentation was improved to reflect better how an XML attribute name is represented. 📝
- The `jinja` rendering function was also reflected in the public API, as seen in the changes to "packages/core/src/prompt_template.d.ts". This essentially makes the new function accessible to end-users. 🔑

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10720959117)



<!-- genaiscript end pr-describe -->

