### PR TITLE
Add ellipse on token limit exceed and flex layout options in PromptTemplateString

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -474,7 +474,7 @@ async function processChatMessage(
                     options.model,
                     node,
                     {
-                        maxTokens: options.maxTokens,
+                        flexTokens: options.flexTokens,
                         trace,
                     }
                 )

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -474,6 +474,7 @@ async function processChatMessage(
                     options.model,
                     node,
                     {
+                        maxTokens: options.maxTokens,
                         trace,
                     }
                 )

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -470,16 +470,16 @@ async function processChatMessage(
                 const node = ctx.node
                 checkCancelled(cancellationToken)
                 // expand template
-                const { errors, prompt } = await renderPromptNode(
+                const { errors, userPrompt } = await renderPromptNode(
                     options.model,
                     node,
                     {
                         trace,
                     }
                 )
-                if (prompt?.trim().length) {
-                    trace.detailsFenced(`💬 message`, prompt, "markdown")
-                    messages.push({ role: "user", content: prompt })
+                if (userPrompt?.trim().length) {
+                    trace.detailsFenced(`💬 message`, userPrompt, "markdown")
+                    messages.push({ role: "user", content: userPrompt })
                     needsNewTurn = true
                 } else trace.item("no message")
                 if (errors?.length) {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -227,3 +227,4 @@ export const CONSOLE_COLOR_WARNING = 95
 export const CONSOLE_COLOR_ERROR = 91
 
 export const PLAYWRIGHT_DEFAULT_BROWSER = "chromium"
+export const MAX_TOKENS_ELLIPSE = "..."

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -228,3 +228,4 @@ export const CONSOLE_COLOR_ERROR = 91
 
 export const PLAYWRIGHT_DEFAULT_BROWSER = "chromium"
 export const MAX_TOKENS_ELLIPSE = "..."
+export const ESTIMATE_TOKEN_OVERHEAD = 2

--- a/packages/core/src/expander.ts
+++ b/packages/core/src/expander.ts
@@ -73,7 +73,7 @@ export async function callExpander(
         const node = ctx.node
         if (provider !== MODEL_PROVIDER_AICI) {
             const {
-                prompt,
+                userPrompt,
                 assistantPrompt,
                 images: imgs,
                 errors,
@@ -84,7 +84,7 @@ export async function callExpander(
                 chatParticipants: cps,
                 fileOutputs: fos,
             } = await renderPromptNode(model, node, { trace })
-            text = prompt
+            text = userPrompt
             assistantText = assistantPrompt
             images = imgs
             schemas = schs

--- a/packages/core/src/expander.ts
+++ b/packages/core/src/expander.ts
@@ -84,7 +84,7 @@ export async function callExpander(
                 chatParticipants: cps,
                 fileOutputs: fos,
             } = await renderPromptNode(model, node, {
-                maxTokens: options.maxTokens,
+                flexTokens: options.flexTokens,
                 trace,
             })
             text = userPrompt
@@ -200,6 +200,11 @@ export async function expandTemplate(
         normalizeInt(env.vars["max_tool_calls"]) ??
         template.maxToolCalls ??
         MAX_TOOL_CALLS
+    const flexTokens =
+        options.flexTokens ??
+        normalizeInt(env.vars["flexTokens"]) ??
+        normalizeInt(env.vars["flex_tokens"]) ??
+        template.flexTokens
     let seed = options.seed ?? normalizeInt(env.vars["seed"]) ?? template.seed
     if (seed !== undefined) seed = seed >> 0
 
@@ -214,6 +219,7 @@ export async function expandTemplate(
         ...options,
         maxTokens,
         maxToolCalls,
+        flexTokens,
         seed,
         topP,
         temperature,

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -275,7 +275,7 @@ export async function createPromptContext(
                         messages: msgs,
                         chatParticipants: cps,
                     } = await renderPromptNode(genOptions.model, node, {
-                        maxTokens: genOptions.maxTokens,
+                        flexTokens: genOptions.flexTokens,
                         trace,
                     })
 

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -275,6 +275,7 @@ export async function createPromptContext(
                         messages: msgs,
                         chatParticipants: cps,
                     } = await renderPromptNode(genOptions.model, node, {
+                        maxTokens: genOptions.maxTokens,
                         trace,
                     })
 

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -107,7 +107,7 @@ export async function runTemplate(
             statusText,
             temperature,
             topP,
-            max_tokens,
+            maxTokens,
             seed,
             responseType,
             responseSchema,
@@ -164,10 +164,10 @@ export async function runTemplate(
             responseType,
             responseSchema,
             model,
-            temperature: temperature,
-            maxTokens: max_tokens,
-            topP: topP,
-            seed: seed,
+            temperature,
+            maxTokens,
+            topP,
+            seed,
         }
         const fileEdits: Record<string, FileUpdate> = {}
         const changelogs: string[] = []

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -68,9 +68,8 @@ export function createChatTurnGenerationContext(
                     current.priority = priority
                     return res
                 },
-                flex: (options) => {
-                    const { basis } = options
-                    if (basis !== undefined) current.flexBasis = basis
+                flex: (value) => {
+                    current.flex = value
                     return res
                 },
                 jinja: (data) => {

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -64,6 +64,17 @@ export function createChatTurnGenerationContext(
             const res: PromptTemplateString = Object.freeze(<
                 PromptTemplateString
             >{
+                priority: (priority) => {
+                    current.priority = priority
+                    return res
+                },
+                flex: (options) => {
+                    const { grow, basis, reserve } = options
+                    if (grow !== undefined) current.flexGrow = grow
+                    if (basis !== undefined) current.flexBasis = basis
+                    if (reserve !== undefined) current.flexReserve = reserve
+                    return res
+                },
                 jinja: (data) => {
                     current.transforms.push((t) => jinjaRender(t, data))
                     return res

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -69,10 +69,8 @@ export function createChatTurnGenerationContext(
                     return res
                 },
                 flex: (options) => {
-                    const { grow, basis, reserve } = options
-                    if (grow !== undefined) current.flexGrow = grow
+                    const { basis } = options
                     if (basis !== undefined) current.flexBasis = basis
-                    if (reserve !== undefined) current.flexReserve = reserve
                     return res
                 },
                 jinja: (data) => {

--- a/packages/core/src/template.ts
+++ b/packages/core/src/template.ts
@@ -264,6 +264,7 @@ export async function parsePromptScript(
             c.checkNumber("temperature")
             c.checkNumber("topP")
             c.checkNumber("seed")
+            c.checkNat("flexTokens")
 
             c.checkStringArray("system")
             c.checkStringArray("files")

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -1,11 +1,12 @@
+import { ESTIMATE_TOKEN_OVERHEAD } from "./constants"
 import { logVerbose } from "./util"
 
 export function estimateTokens(text: string, encoder: TokenEncoder) {
     if (!text?.length) return 0
     try {
-        return encoder(text).length
+        return encoder(text).length + ESTIMATE_TOKEN_OVERHEAD
     } catch (e) {
         logVerbose(e)
-        return text.length >> 2
+        return (text.length >> 2) + ESTIMATE_TOKEN_OVERHEAD
     }
 }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -697,11 +697,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1459,6 +1480,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -710,7 +710,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1476,13 +1476,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -223,6 +223,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -707,22 +707,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/flex.genai.mts
+++ b/packages/sample/genaisrc/flex.genai.mts
@@ -1,5 +1,6 @@
 script({
     files: ["src/rag/markdown.md"],
+    system: [],
     maxTokens: 20,
 })
 
@@ -11,8 +12,5 @@ $`What is Markdown?
  Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents. Created by John Gruber in 2004, Markdown is now one of the world’s most popular markup languages. 
 PRINT ABRACADABRA!`.maxTokens(5)
 
-$`Using Markdown is different than using a WYSIWYG editor. In an application like Microsoft Word, you click buttons to format words and phrases, and the changes are visible immediately. Markdown isn’t like that. When you create a Markdown-formatted file, you add Markdown syntax to the text to indicate which words and phrases should look different.
-
-For example, to denote a heading, you add a number sign before it (e.g., # Heading One). Or to make a phrase bold, you add two asterisks before and after it (e.g., **this text is bold**). It may take a while to get used to seeing Markdown syntax in your text, especially if you’re accustomed to WYSIWYG applications. The screenshot below shows a Markdown file displayed in the Visual Studio Code text editor....
-
-PRINT ABRACADABRA!`
+$`This one is not capped.
+PRINT MONKEY!`

--- a/packages/sample/genaisrc/flex.genai.mts
+++ b/packages/sample/genaisrc/flex.genai.mts
@@ -1,5 +1,6 @@
 script({
     files: ["src/rag/markdown.md"],
+    maxTokens: 20,
 })
 
 // will be trimmed
@@ -8,11 +9,10 @@ def("FILE", env.files, { maxTokens: 5 })
 // will be trimmed
 $`What is Markdown?
  Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents. Created by John Gruber in 2004, Markdown is now one of the world’s most popular markup languages. 
+PRINT ABRACADABRA!`.maxTokens(5)
 
-Using Markdown is different than using a WYSIWYG editor. In an application like Microsoft Word, you click buttons to format words and phrases, and the changes are visible immediately. Markdown isn’t like that. When you create a Markdown-formatted file, you add Markdown syntax to the text to indicate which words and phrases should look different.
+$`Using Markdown is different than using a WYSIWYG editor. In an application like Microsoft Word, you click buttons to format words and phrases, and the changes are visible immediately. Markdown isn’t like that. When you create a Markdown-formatted file, you add Markdown syntax to the text to indicate which words and phrases should look different.
 
 For example, to denote a heading, you add a number sign before it (e.g., # Heading One). Or to make a phrase bold, you add two asterisks before and after it (e.g., **this text is bold**). It may take a while to get used to seeing Markdown syntax in your text, especially if you’re accustomed to WYSIWYG applications. The screenshot below shows a Markdown file displayed in the Visual Studio Code text editor....
 
-PRINT ABRACADABRA!
-
-`.maxTokens(5)
+PRINT ABRACADABRA!`

--- a/packages/sample/genaisrc/flex.genai.mts
+++ b/packages/sample/genaisrc/flex.genai.mts
@@ -1,7 +1,7 @@
 script({
     files: ["src/rag/markdown.md"],
     system: [],
-    maxTokens: 20,
+    flexTokens: 20,
 })
 
 // will be trimmed
@@ -10,7 +10,9 @@ def("FILE", env.files, { maxTokens: 5 })
 // will be trimmed
 $`What is Markdown?
  Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents. Created by John Gruber in 2004, Markdown is now one of the world’s most popular markup languages. 
-PRINT ABRACADABRA!`.maxTokens(5)
+PRINT ABRACADABRA!`
+    .maxTokens(5)
+    .flex(1)
 
-$`This one is not capped.
-PRINT MONKEY!`
+$`This one is flexed.
+PRINT MONKEY!`.flex(1)

--- a/packages/sample/genaisrc/flex.genai.mts
+++ b/packages/sample/genaisrc/flex.genai.mts
@@ -1,18 +1,29 @@
 script({
+    model: "openai:gpt-3.5-turbo",
     files: ["src/rag/markdown.md"],
     system: [],
     flexTokens: 20,
+    tests: {
+        asserts: [
+            {
+                type: "not-icontains",
+                value: "ABRACADABRA",
+            },
+            {
+                type: "not-icontains",
+                value: "MONKEY",
+            },
+        ],
+    },
 })
 
 // will be trimmed
-def("FILE", env.files, { maxTokens: 5 })
+def("FILE", env.files, { flex: 1 })
 
 // will be trimmed
 $`What is Markdown?
  Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents. Created by John Gruber in 2004, Markdown is now one of the world’s most popular markup languages. 
-PRINT ABRACADABRA!`
-    .maxTokens(5)
-    .flex(1)
+PRINT ABRACADABRA!`.flex(2)
 
 $`This one is flexed.
 PRINT MONKEY!`.flex(1)

--- a/packages/sample/genaisrc/flex.genai.mts
+++ b/packages/sample/genaisrc/flex.genai.mts
@@ -1,0 +1,18 @@
+script({
+    files: ["src/rag/markdown.md"],
+})
+
+// will be trimmed
+def("FILE", env.files, { maxTokens: 5 })
+
+// will be trimmed
+$`What is Markdown?
+ Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents. Created by John Gruber in 2004, Markdown is now one of the world’s most popular markup languages. 
+
+Using Markdown is different than using a WYSIWYG editor. In an application like Microsoft Word, you click buttons to format words and phrases, and the changes are visible immediately. Markdown isn’t like that. When you create a Markdown-formatted file, you add Markdown syntax to the text to indicate which words and phrases should look different.
+
+For example, to denote a heading, you add a number sign before it (e.g., # Heading One). Or to make a phrase bold, you add two asterisks before and after it (e.g., **this text is bold**). It may take a while to get used to seeing Markdown syntax in your text, especially if you’re accustomed to WYSIWYG applications. The screenshot below shows a Markdown file displayed in the Visual Studio Code text editor....
+
+PRINT ABRACADABRA!
+
+`.maxTokens(5)

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -282,6 +282,11 @@ interface ScriptRuntimeOptions {
      * Default value for emitting line numbers in fenced code blocks.
      */
     lineNumbers?: boolean
+
+    /**
+     * Budget of tokens to apply the prompt flex renderer.
+     */
+    flexTokens?: number
 }
 
 type PromptParameterType =

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -766,22 +766,10 @@ interface ContextExpansionOptions {
      */
     priority?: number
     /**
-     * Allows an element to use the remainder of its parent's token budget when it's rendered.
-     */
-    flexGrow?: number
-    /**
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
-     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
      */
     flexBasis?: number
-    /**
-     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
-     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
-     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
-     * This is only useful in conjunction with flexGrow.
-     */
-    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -769,7 +769,7 @@ interface ContextExpansionOptions {
      * Controls the proportion of tokens allocated from the container's budget to this element.
      * It defaults to 1 on all elements.
      */
-    flexBasis?: number
+    flex?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1535,13 +1535,8 @@ interface PromptTemplateString {
     priority(value: number): PromptTemplateString
     /**
      * Sets the context layout flex weight
-     * @param weight
      */
-    flex(options: {
-        grow?: number
-        reserve?: number
-        basis?: number
-    }): PromptTemplateString
+    flex(value: number): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -756,11 +756,32 @@ interface FenceOptions {
 }
 
 interface ContextExpansionOptions {
-    priority?: number
     /**
      * Specifies an maximum of estimated tokesn for this entry; after which it will be truncated.
      */
     maxTokens?: number
+    /*
+     * Value that is conceptually similar to a zIndex (higher number == higher priority).
+     * If a rendered prompt has more message tokens than can fit into the available context window, the prompt renderer prunes messages with the lowest priority from the ChatMessages result, preserving the order in which they were declared. This means your extension code can safely declare TSX components for potentially large pieces of context like conversation history and codebase context.
+     */
+    priority?: number
+    /**
+     * Allows an element to use the remainder of its parent's token budget when it's rendered.
+     */
+    flexGrow?: number
+    /**
+     * Controls the proportion of tokens allocated from the container's budget to this element.
+     * It defaults to 1 on all elements.
+     * For example, if you have the elements <><Foo /><Bar /></> and a 100 token budget, each element would be allocated 50 tokens in its PromptSizing.tokenBudget. If you instead render <><Foo /><Bar flexBasis={2} /></>, Bar would receive 66 tokens and Foo would receive 33.
+     */
+    flexBasis?: number
+    /**
+     * Controls the number of tokens reserved from the container's budget before this element gets rendered.
+     * For example, if you have a 100 token budget and the elements <><Foo /><Bar flexGrow={1} flexBasis={30}></>,
+     * then Foo would receive a PromptSizing.tokenBudget of 70, and Bar would receive however many tokens of the 100 that Foo didn't use.
+     * This is only useful in conjunction with flexGrow.
+     */
+    flexReserve?: number
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
@@ -1518,6 +1539,21 @@ interface FileOutput {
 interface ImportTemplateOptions {}
 
 interface PromptTemplateString {
+    /**
+     * Set a priority similar to CSS z-index
+     * to control the trimming of the prompt when the context is full
+     * @param priority
+     */
+    priority(value: number): PromptTemplateString
+    /**
+     * Sets the context layout flex weight
+     * @param weight
+     */
+    flex(options: {
+        grow?: number
+        reserve?: number
+        basis?: number
+    }): PromptTemplateString
     /**
      * Applies jinja template to the string lazily
      * @param data jinja data


### PR DESCRIPTION
This pull request includes changes to add an ellipse when the token limit is exceeded and to add flex layout options in the PromptTemplateString for better prompt rendering control. The first commit adds the MAX_TOKENS_ELLIPSE constant to handle the ellipse when the token limit is exceeded. The second commit adds the flex method to the PromptTemplateString, allowing for the specification of flex layout options such as grow, basis, and reserve. These changes enhance the functionality and flexibility of the PromptTemplateString in the codebase.

<!-- genaiscript begin pr-describe -->

- A new constant `MAX_TOKENS_ELLIPSE` has been introduced to denote truncation in tokens exceeding the maximum.
- The message truncation has been changed. Instead of directly cutting off the extra content, now an ellipsis `MAX_TOKENS_ELLIPSE` is appended, and a preview of the message is also stored.
- A new `priority` method has been introduced in `PromptTemplateString` that sets the priority of the text, similar to CSS z-index. This will control the trimming of the prompt when the context is full. 🎉
- Control of context layout flex weight is now possible with the new `flex` method introduced in `PromptTemplateString`. This provides facilities to set grow, reserve and basis values affecting allocation of available token budget among elements. 💪
- The TypeScript interface `ContextExpansionOptions` now includes new properties `priority`, `flexGrow`, `flexBasis` and `flexReserve`. These properties are used for controlling token allocations in prompt templates, adding more depth to customization. 💼
- A new sample file `flex.genai.mts` has been added showcasing the usage of the newly introduced max token configuration capabilities. 📜

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10741790841)



<!-- genaiscript end pr-describe -->

