### PR TITLE
Move cancel function implementation from promptcontext to globals

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/core/src/globals.ts
+++ b/packages/core/src/globals.ts
@@ -9,6 +9,7 @@ import {
 } from "./frontmatter"
 import { JSONLStringify, JSONLTryParse } from "./jsonl"
 import { HTMLTablesToJSON, HTMLToMarkdown, HTMLToText } from "./html"
+import { CancelError } from "./error"
 
 export function resolveGlobal(): any {
     if (typeof window !== "undefined")
@@ -62,4 +63,7 @@ export function installGlobals() {
         convertToMarkdown: HTMLToMarkdown,
         convertToText: HTMLToText,
     })
+    glb.cancel = (reason?: string) => {
+        throw new CancelError(reason || "user cancelled")
+    }
 }

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -13,7 +13,6 @@ import {
 } from "./util"
 import { runtimeHost } from "./host"
 import { MarkdownTrace } from "./trace"
-import { YAMLParse, YAMLStringify } from "./yaml"
 import { createParsers } from "./parsers"
 import { readText } from "./fs"
 import {
@@ -30,22 +29,13 @@ import {
     RunPromptContextNode,
     createChatGenerationContext,
 } from "./runpromptcontext"
-import { CSVParse, CSVToMarkdown } from "./csv"
-import { INIParse, INIStringify } from "./ini"
-import {
-    CancelError,
-    isCancelError,
-    NotSupportedError,
-    serializeError,
-} from "./error"
+import { isCancelError, NotSupportedError, serializeError } from "./error"
 import { createFetch } from "./fetch"
-import { XMLParse } from "./xml"
 import { GenerationOptions } from "./generation"
 import { fuzzSearch } from "./fuzzsearch"
 import { parseModelIdentifier } from "./models"
 import { renderAICI } from "./aici"
 import { MODEL_PROVIDER_AICI, SYSTEM_FENCE } from "./constants"
-import { JSONLStringify, JSONLTryParse } from "./jsonl"
 import { grepSearch } from "./grep"
 import { resolveFileContents, toWorkspaceFile } from "./file"
 import { vectorSearch } from "./vectorsearch"
@@ -57,12 +47,6 @@ import { resolveModelConnectionInfo } from "./models"
 import { resolveLanguageModel } from "./lm"
 import { callExpander } from "./expander"
 import { Project } from "./ast"
-import {
-    frontmatterTryParse,
-    splitMarkdown,
-    updateFrontmatter,
-} from "./frontmatter"
-import { url } from "node:inspector"
 
 export async function createPromptContext(
     prj: Project,
@@ -236,9 +220,6 @@ export async function createPromptContext(
         defOutputProcessor,
         defFileMerge: (fn) => {
             appendPromptChild(createFileMerge(fn))
-        },
-        cancel: (reason?: string) => {
-            throw new CancelError(reason || "user cancelled")
         },
         runPrompt: async (generator, runOptions): Promise<RunPromptResult> => {
             try {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -2276,7 +2276,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -2335,7 +2335,6 @@ interface PromptContext extends ChatGenerationContext {
         text?: string
         file?: WorkspaceFile
     }>
-    cancel(reason?: string): void
     env: ExpansionVariables
     path: Path
     parsers: Parsers


### PR DESCRIPTION


<!-- genaiscript begin pr-describe -->

- The `cancel` method has been moved from the `PromptContext` object to the global scope of the application. This is evident from the changes in 'packages/core/src/globals.ts' and 'packages/core/src/promptcontext.ts' files. This could be to make `cancel` functionality universally accessible. :earth_americas:
- Consequently, the `cancel` method was removed from the `PromptContext` interface definition in the 'packages/core/src/types/prompt_template.d.ts' file. This is a user facing change as it modifies how users interact with the 'PromptContext' interface. :warning:
- The `createPromptContext` function no longer throws a `CancelError` exception; this responsibility seems to have been shifted to the moved `cancel` method. Therefore, the code might be becoming more modular or adhering to separation of concerns principle. :straight_ruler:
- Note, no other functions or methods were introduced or significantly altered, indicating the primary purpose of these changes was around organizing handling of cancel operations. :recycle:

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10752091401)



<!-- genaiscript end pr-describe -->

