### PR TITLE
Refactor fetchText into global function and remove from PromptContext

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -4,17 +4,10 @@ import {
     tracePromptResult,
 } from "./chat"
 import { host } from "./host"
-import {
-    HTMLEscape,
-    arrayify,
-    dotGenaiscriptPath,
-    logVerbose,
-    sha256string,
-} from "./util"
+import { HTMLEscape, arrayify, dotGenaiscriptPath, sha256string } from "./util"
 import { runtimeHost } from "./host"
 import { MarkdownTrace } from "./trace"
 import { createParsers } from "./parsers"
-import { readText } from "./fs"
 import {
     PromptNode,
     appendChild,
@@ -30,7 +23,6 @@ import {
     createChatGenerationContext,
 } from "./runpromptcontext"
 import { isCancelError, NotSupportedError, serializeError } from "./error"
-import { createFetch } from "./fetch"
 import { GenerationOptions } from "./generation"
 import { fuzzSearch } from "./fuzzsearch"
 import { parseModelIdentifier } from "./models"
@@ -358,44 +350,6 @@ export async function createPromptContext(
                 }
             } finally {
                 trace.endDetails()
-            }
-        },
-        fetchText: async (urlOrFile, fetchOptions) => {
-            if (typeof urlOrFile === "string") {
-                urlOrFile = {
-                    filename: urlOrFile,
-                    content: "",
-                }
-            }
-            const url = urlOrFile.filename
-            let ok = false
-            let status = 404
-            let text: string
-            if (/^https?:\/\//i.test(url)) {
-                const fetch = await createFetch({ cancellationToken })
-                const resp = await fetch(url, fetchOptions)
-                ok = resp.ok
-                status = resp.status
-                if (ok) text = await resp.text()
-            } else {
-                try {
-                    text = await readText("workspace://" + url)
-                    ok = true
-                } catch (e) {
-                    logVerbose(e)
-                    ok = false
-                    status = 404
-                }
-            }
-            const file: WorkspaceFile = {
-                filename: urlOrFile.filename,
-                content: text,
-            }
-            return {
-                ok,
-                status,
-                text,
-                file,
             }
         },
     }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -2267,15 +2267,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -2326,15 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
-    fetchText(
-        urlOrFile: string | WorkspaceFile,
-        options?: FetchTextOptions
-    ): Promise<{
-        ok: boolean
-        status: number
-        text?: string
-        file?: WorkspaceFile
-    }>
     env: ExpansionVariables
     path: Path
     parsers: Parsers


### PR DESCRIPTION
This pull request refactors the `fetchText` function by moving it into a global function and removing it from the `PromptContext` interface. This change improves code organization and removes unnecessary duplication.

<!-- genaiscript begin pr-describe -->

Based on the GIT_DIFF provided, here's a high-level summary of the changes:

- The `fetchText` method has been moved from `PromptContext` class in `promptcontext.ts` and inserted into `installGlobals` function in `globals.ts` file. The purpose is likely to make `fetchText` a part of backend global context which could potentially make this function globally accessible rather than having it limited to the `PromptContext` scope.
- `fetchText` function's code shows that this function fetches the text content of a file specified by URL or path. It also handles `http` and local workspace paths, fetching respective contents, encapsulating all related error handling in itself.
- The structure of `fetchText` remains the same in the new location. That is, it still takes in `urlOrFile` and optional `fetchOptions` as arguments, and returns an object containing information about the operation success status, HTTP status, text content of the file, or the `WorkspaceFile` object.
- The removal of fetchText function in `PromptContext` in `promptcontext.ts` also resulted in removal of respective imports including fetch and readText, as these were only used by the removed `fetchText` function.
- The `PromptContext` API surface, which is user-facing, has been altered due to the removal of the `fetchtext` method from it. This change is reflected in the `prompt_template.d.ts`.

These changes to the codebase do not alter the import statements, which suggests the dependencies of the project remain the same.

We can assume these modifications are aimed at enhancing the project architecture by repositioning functionality to its more logical place and changing the public API as a result of that. 🏗️💻🔄🌐

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10773406980)



<!-- genaiscript end pr-describe -->

