### PR TITLE
Refactor runPrompt usage and remove fetchText and cancel from import prompts

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/core/src/importprompt.ts
+++ b/packages/core/src/importprompt.ts
@@ -23,8 +23,6 @@ export async function importPrompt(
         "parsers",
         "env",
         "retrieval",
-        "fetchText",
-        "cancel",
         "runPrompt",
     ]
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1558,6 +1558,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2263,10 +2267,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/llm-as-expert.genai.mts
+++ b/packages/sample/genaisrc/llm-as-expert.genai.mts
@@ -44,7 +44,7 @@ defTool(
         },
     },
     async ({ prompt }) => {
-        const res = await runPrompt(prompt, {
+        const res = await env.generator.runPrompt(prompt, {
             model: "openai:gpt-3.5-turbo",
             label: "llm-gpt35",
         })
@@ -62,7 +62,7 @@ defTool(
         },
     },
     async ({ prompt }) => {
-        const res = await runPrompt(prompt, {
+        const res = await env.generator.runPrompt(prompt, {
             model: "openai:gpt-4o",
             label: "llm-4o",
         })

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/pr-create.genai.mts
+++ b/packages/sample/genaisrc/pr-create.genai.mts
@@ -7,7 +7,7 @@ script({
 })
 
 const defaultBranch = (env.vars.defaultBranch || "main") + ""
-const { text, finishReason, error } = await runPrompt(async (_) => {
+const { text, error } = await runPrompt(async (_) => {
     const { stdout: changes } = await host.exec("git", [
         "diff",
         defaultBranch,

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1617,6 +1617,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         description?: string,
         options?: FileOutputOptions
     ): void
+    runPrompt(
+        generator: string | PromptGenerator,
+        options?: PromptGeneratorOptions
+    ): Promise<RunPromptResult>
 }
 
 interface GenerationOutput {
@@ -2322,10 +2326,6 @@ interface PromptContext extends ChatGenerationContext {
     system(options: PromptSystemArgs): void
     defFileMerge(fn: FileMergeHandler): void
     defOutputProcessor(fn: PromptOutputProcessorHandler): void
-    runPrompt(
-        generator: string | PromptGenerator,
-        options?: PromptGeneratorOptions
-    ): Promise<RunPromptResult>
     env: ExpansionVariables
     path: Path
     parsers: Parsers


### PR DESCRIPTION
This pull request refactors the usage of the `runPrompt` function in the codebase and removes the `fetchText` and `cancel` parameters from the import prompts. This improves the code by simplifying the prompt generation process and removing unnecessary parameters.

<!-- genaiscript begin pr-describe -->

- Updates were made to `importPrompt` function in `packages/core/src/importprompt.ts`, specifically the removal of `fetchText` and `cancel` elements.
- Significant updates were made in `packages/core/src/types/prompt_template.d.ts`. The function `runPrompt()` got moved from the `PromptContext` interface to the `ChatGenerationContext` interface. This change seems to be a restructuring of the hierarchy of these interfaces. 
  - 🔄 In sum, `runPrompt()` got a new home! 🏡
- In `packages/sample/genaisrc/llm-as-expert.genai.mts`, `runPrompt()` function calls got updated to use a new instance `env.generator.runPrompt`. This implies an architectural change in the app, defining more specific origins for the runPrompt function calls.
  - 🚀 This could potentially lead to improved code clarity and maintainability in the long run!
- A similar pattern is seen in `packages/sample/genaisrc/pr-create.genai.mts`, though the `finishReason` was also removed from the destructured return of `runPrompt()`.
  - 🔧 It seems like `finishReason` may no longer be part of the return contract of `runPrompt()`, or simply isn't needed here.
- Overall, these changes seem to point towards a clear effort to refactor and tidy up the project's codebase, likely making it more understandable and manageable for future development efforts.
  - 🌟 Applause for good housekeeping!

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10773689244)



<!-- genaiscript end pr-describe -->

