### PR TITLE
Update handling of outputs in `runToolCalls` and streamline `runPrompt` usage in tools

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -218,6 +218,12 @@ async function runToolCalls(
                     toolContent = `FILENAME: ${filename}
 ${fenceMD(content, " ")}
 `
+                } else if (
+                    typeof output === "object" &&
+                    (output as RunPromptResult).text
+                ) {
+                    const { text } = output as RunPromptResult
+                    toolContent = text
                 } else {
                     toolContent = YAMLStringify(output)
                 }

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -496,6 +496,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/genaisrc/nested-agents.genai.mts
+++ b/packages/sample/genaisrc/nested-agents.genai.mts
@@ -13,8 +13,8 @@ defTool(
             description: "the prompt to be executed by the LLM",
         },
     },
-    async ({ prompt }) => {
-        const res = await env.generator.runPrompt(
+    async ({ prompt }) =>
+        await env.generator.runPrompt(
             (_) => {
                 _.$`You are an AI assistant that can help with file system tasks.
 
@@ -31,8 +31,6 @@ defTool(
                 tools: "fs",
             }
         )
-        return res.text
-    }
 )
 
 /**
@@ -47,14 +45,12 @@ defTool(
             description: "the python to be executed by the LLM",
         },
     },
-    async ({ code }) => {
-        const res = await env.generator.runPrompt(code, {
+    async ({ code }) =>
+        await env.generator.runPrompt(code, {
             model: "openai:gpt-4o",
             label: "llm-4o agent_fs",
             tools: "python",
         })
-        return res.text
-    }
 )
 
 // now as a question about the file system

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -529,6 +529,8 @@ type ToolCallOutput =
     | ToolCallContent
     | ShellOutput
     | WorkspaceFile
+    | RunPromptResult
+    | undefined
 
 interface WorkspaceFileCache<K, V> {
     /**


### PR DESCRIPTION
This pull request updates the handling of outputs in the `runToolCalls` function and streamlines the usage of `runPrompt` in tools. It introduces a new output type `RunPromptResult` and modifies the logic in `runToolCalls` to handle this new output type. Additionally, it removes unnecessary code and refactors the `defTool` function to simplify the usage of `runPrompt`. These changes improve the overall efficiency and readability of the code.

<!-- genaiscript begin pr-describe -->

- The function `runToolCalls` in the `chat.ts` file has been enhanced :zap: to handle a case where the output of a tool is of object type and has the property "text". This property is now being assigned to `toolContent`. 

- A user-facing change :eyes: is made in `prompt_template.d.ts`. A new type of output - `RunPromptResult` - is now acceptable in the `ToolCallOutput` type union. This aligns with the change in `chat.ts` and broadens the range of outputs a tool can produce. 

- There's been a simplification :hammer_and_wrench: in `nested-agents.genai.mts` as well. The anonymous functions inside `defTool` have been reduced from multi-line to single line, eliminating the need for explicit return statements. 

- This change affects two functions, one which receives "prompt" and another which receives "code" as arguments. Both now directly return the result of calling `env.generator.runPrompt`.

:bulb: Hence, the changes broadly encompass enhanced output handling and code simplification.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10777189796)



<!-- genaiscript end pr-describe -->

