### PR TITLE
Update defImages function to support multiple file types and handle Blob conversion

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "genai:test": "node ../packages/cli/built/genaiscript.cjs test src/**/*.md",
-    "genai:frontmatter": "node ../packages/cli/built/genaiscript.cjs run frontmatter \"src/**/*.md\" --apply-edits",
+    "genai:frontmatter": "node ../packages/cli/built/genaiscript.cjs run frontmatter \"src/**/*.{md,mdx}\" --apply-edits",
     "genai:technical": "for file in \"src/**/*.md\"; do\nnode ../packages/cli/built/genaiscript.cjs run technical \"$file\" --apply-edits\ndone",
     "genai:alt-text": "node scripts/image-alt-text.mjs"
   },

--- a/docs/src/content/docs/blog/drafts/streamlining-issue-triage-with-genaiscript-harnessing-ai-to-prioritize-and-manage-github-issues.md
+++ b/docs/src/content/docs/blog/drafts/streamlining-issue-triage-with-genaiscript-harnessing-ai-to-prioritize-and-manage-github-issues.md
@@ -10,6 +10,9 @@ tags:
   - Project Management
   - Automation
   - GenAIScript
+description: Employ GenAIScript to automate GitHub issue triage with AI,
+  improving project management and issue resolution efficiency.
+keywords: GitHub issues, AI, project management, automation, issue triage
 
 ---
 

--- a/docs/src/content/docs/blog/drafts/unlock-devops-superpowers-automate-testing-and-deployment-with-genaiscript.md
+++ b/docs/src/content/docs/blog/drafts/unlock-devops-superpowers-automate-testing-and-deployment-with-genaiscript.md
@@ -9,6 +9,9 @@ tags:
   - Automation
   - Testing
   - Deployment
+description: Streamline your DevOps pipeline with GenAIScript by automating
+  testing and deployment through a tutorial script.
+keywords: DevOps, automation, testing, deployment, scripting
 
 ---
 

--- a/docs/src/content/docs/blog/drafts/unlock-the-power-of-ai-enhance-your-debugging-skills-with-genaiscript.md
+++ b/docs/src/content/docs/blog/drafts/unlock-the-power-of-ai-enhance-your-debugging-skills-with-genaiscript.md
@@ -8,6 +8,9 @@ tags:
   - Programming
   - Efficiency
 draft: true
+description: Leverage AI with GenAIScript to improve your debugging skills,
+  featuring a practical example for an efficient workflow.
+keywords: AI, debugging, programming efficiency, developer tools, GenAIScript
 
 ---
 

--- a/docs/src/content/docs/blog/drafts/unlock-the-power-of-dynamic-content-with-genaiscript.md
+++ b/docs/src/content/docs/blog/drafts/unlock-the-power-of-dynamic-content-with-genaiscript.md
@@ -8,6 +8,9 @@ tags:
   - Dynamic Content Generation
   - AI
   - Automation
+description: Discover how GenAIScript can automate dynamic content generation
+  using AI, with an easy-to-understand script example.
+keywords: dynamic content, automation, AI, content generation, scripting
 
 ---
 

--- a/docs/src/content/docs/blog/drafts/unlock-the-power-of-test-automation-mastering-genaiscript-for-streamlined-testing.md
+++ b/docs/src/content/docs/blog/drafts/unlock-the-power-of-test-automation-mastering-genaiscript-for-streamlined-testing.md
@@ -9,6 +9,10 @@ tags:
   - Test Automation
   - Software Development
   - Best Practices
+description: Explore test automation using GenAIScript to enhance and streamline
+  your testing processes with structured script breakdown.
+keywords: test automation, scripting, software testing, streamlined process,
+  developer tools
 
 ---
 

--- a/docs/src/content/docs/case-studies/release-notes.mdx
+++ b/docs/src/content/docs/case-studies/release-notes.mdx
@@ -1,7 +1,10 @@
 ---
 title: Release Notes
 sidebar:
-    order: 7
+  order: 7
+description: Generate comprehensive release notes combining commit history and code diffs
+keywords: release notes, automation, commit history, code diffs, release management
+
 ---
 import { Code } from '@astrojs/starlight/components';
 import scriptSrc from "../../../../../packages/sample/genaisrc/git-release-notes.genai?raw"

--- a/docs/src/content/docs/guides/auto-git-commit-message.mdx
+++ b/docs/src/content/docs/guides/auto-git-commit-message.mdx
@@ -1,8 +1,11 @@
 ---
-title: "Automated Git Commit Messages"
-keywords: ["GenAI", "Git", "Automation"]
+title: Automated Git Commit Messages
+keywords: Git, commit automation, software development, CLI, husky
 sidebar:
-    order: 15
+  order: 15
+description: Streamline your Git workflow with an automation script for
+  generating commit messages
+
 ---
 
 In the world of software development, making consistent and informative commit messages is crucial but often overlooked.

--- a/docs/src/content/docs/guides/images-in-azure-blob-storage.mdx
+++ b/docs/src/content/docs/guides/images-in-azure-blob-storage.mdx
@@ -1,7 +1,9 @@
 ---
 title: Images in Azure Blob Storage
 sidebar:
-    order: 55
+  order: 55
+description: Leverage Azure SDK to handle image files in Blob Storage within prompts
+keywords: Azure Blob Storage, Azure SDK, image handling, Node.js Buffer, inline prompts
 
 ---
 
@@ -14,10 +16,10 @@ and use them in the prompt. The `defImages` function support the node.js [Buffer
 
 ## Configuration
 
-Install the `@azure/storage-blob` and `@azure/identity` packages.
+Install the [@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob) and [@azure/identity](https://www.npmjs.com/package/@azure/identity) packages.
 
 ```sh
-npm install @azure/storage-blob @azure/identity
+npm install -D @azure/storage-blob @azure/identity
 ```
 
 Make sure to login with the Azure CLI and set the subscription.

--- a/docs/src/content/docs/guides/images-in-azure-blob-storage.mdx
+++ b/docs/src/content/docs/guides/images-in-azure-blob-storage.mdx
@@ -1,0 +1,98 @@
+---
+title: Images in Azure Blob Storage
+sidebar:
+    order: 55
+
+---
+
+import { Code } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components"
+import source from "../../../../../packages/sample/genaisrc/azure-blobs.genai.mts?raw"
+
+It is possible to use the Azure Node.JS SDK to download images from Azure Blog Storage
+and use them in the prompt. The `defImages` function support the node.js [Buffer] type.
+
+## Configuration
+
+Install the `@azure/storage-blob` and `@azure/identity` packages.
+
+```sh
+npm install @azure/storage-blob @azure/identity
+```
+
+Make sure to login with the Azure CLI and set the subscription.
+
+```sh
+az login
+```
+
+## Reading blobs
+
+Open a connection to the Azure Blob Storage and get a client to the container.
+We deconstruct the `account` and `container` from the `env.vars` object
+so that they can be set through the [cli](/genaiscript/reference/cli).
+
+```ts
+import { BlobServiceClient } from "@azure/storage-blob"
+import { DefaultAzureCredential } from "@azure/identity"
+
+const { account = "myblobs", container = "myimages" } = env.vars
+const blobServiceClient = new BlobServiceClient(
+    `https://${account}.blob.core.windows.net`,
+    new DefaultAzureCredential()
+)
+const containerClient = blobServiceClient.getContainerClient(container)
+```
+
+If you do not have a specific blob in mind, you can iterate through the blobs,
+and download them into a buffer (`buf`).
+
+```ts "image"
+import { buffer } from "node:stream/consumers"
+
+for await (const blob of containerClient.listBlobsFlat()) {
+    const blockBlobClient = containerClient.getBlockBlobClient(blob.name)
+    const downloadBlockBlobResponse = await blockBlobClient.download(0)
+    const body = await downloadBlockBlobResponse.readableStreamBody
+    const image = await buffer(body)
+    ...
+```
+
+## Using images in the prompt
+
+The `image` buffer can be passed in `defImages` to be used in the prompt.
+
+```ts
+    defImages(image, { detail: "low" })
+```
+
+However since images can be "heavy", you will most likely have to use
+[inline prompts](/genaiscript/reference/prompts/inline-prompts) to split into smaller queries. (Note the use of `_.`)
+
+```ts 'await runPrompt(_ =>' '_.'
+for await (const blob of containerClient.listBlobsFlat()) {
+    ...
+    const res = await runPrompt(_ => {
+        _.defImages(image, { detail: "low" })
+        _.$`Describe the image.`
+    })
+    // res contains the LLM response for the inner prompt
+    ...
+```
+
+## Summarizing results
+
+To summarize all images, we store each image summary using the `def` function and 
+add prompting to summarize the descriptions.
+
+```ts
+    ...
+    def("IMAGES_SUMMARY", { filename: blob.name, content: res.text })
+}
+$`Summarize IMAGES_SUMMARY.`
+```
+
+## Full source
+
+<Code code={source} wrap={true} lang="js" title="azure-blobs.genai.mts" />
+

--- a/docs/src/content/docs/guides/llm-as-tool.mdx
+++ b/docs/src/content/docs/guides/llm-as-tool.mdx
@@ -1,7 +1,10 @@
 ---
 title: LLM as a tool
 sidebar:
-    order: 60
+  order: 60
+description: Create tools and inline prompts using LLM models for executing various tasks
+keywords: LLM, inline prompts, tools, gpt-3.5-turbo, task automation
+
 ---
 
 It is possible [tools](/genaiscript/reference/scripts/tools)

--- a/docs/src/content/docs/guides/transformers-js.mdx
+++ b/docs/src/content/docs/guides/transformers-js.mdx
@@ -1,7 +1,12 @@
 ---
 title: Transformer.js
 sidebar:
-    order: 20
+  order: 20
+description: Implement summarization with Transformers.js and leverage local
+  hardware acceleration
+keywords: Transformers.js, summarization, onnxruntime, CPU/GPU acceleration,
+  pretrained models
+
 ---
 import { Code } from "@astrojs/starlight/components"
 import sampleSrc from "../../../../../packages/sample/genaisrc/summary-with-transformers.genai?raw"

--- a/docs/src/content/docs/guides/using-secrets.mdx
+++ b/docs/src/content/docs/guides/using-secrets.mdx
@@ -2,6 +2,9 @@
 title: Using Secrets
 sidebar:
   order: 20
+description: Utilize secrets to augment documents with TypeScript and REST APIs
+keywords: TypeScript, secrets, REST API, document augmentation, web search
+
 ---
 import { Code } from '@astrojs/starlight/components';
 import tavilyCode from "../../../../../packages/sample/genaisrc/tavily.mjs?raw"

--- a/docs/src/content/docs/guides/zod-schema.mdx
+++ b/docs/src/content/docs/guides/zod-schema.mdx
@@ -2,6 +2,9 @@
 title: Zod Schema
 sidebar:
   order: 80
+description: Learn how to define and convert TypeScript-first Zod schemas to JSON schema
+keywords: TypeScript, Zod schema, JSON schema, schema validation, type inference
+
 ---
 
 [zod](https://zod.dev/) is a TypeScript-first schema validation with static type inference. 

--- a/docs/src/content/docs/reference/scripts/chat-participants.mdx
+++ b/docs/src/content/docs/reference/scripts/chat-participants.mdx
@@ -1,7 +1,11 @@
 ---
 title: Chat Participants
 sidebar:
-    order: 50
+  order: 50
+description: Create multi-turn chats or simulate conversations with multiple
+  chat participants
+keywords: chat, multi-turn, conversation, chat participant, engagement
+
 ---
 import { Code } from '@astrojs/starlight/components';
 import scriptSource from "../../../../../../packages/sample/genaisrc/multi-turn.genai.js?raw"

--- a/docs/src/content/docs/reference/scripts/images.md
+++ b/docs/src/content/docs/reference/scripts/images.md
@@ -15,3 +15,29 @@ defImages(env.files)
 ```
 
 Read more about [OpenAI Vision](https://platform.openai.com/docs/guides/vision/limitations).
+
+## URLs
+
+Public URLs (that do not require authentication) will be passed directly to OpenAI.
+
+```js
+defImages(
+    "https://github.com/microsoft/genaiscript/blob/main/docs/public/images/logo.png?raw=true"
+)
+```
+
+Local files are loaded and encoded as a data uri.
+
+## Buffer, Blob
+
+The `defImage` function also supports [Buffer](https://nodejs.org/api/buffer.html)
+and [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
+
+
+This example takes a screenshot of bing.com and adds it to the images.
+
+```js
+const page = await host.browse("https://bing.com")
+const screenshot = await page.screenshot() // returns a node.js Buffer
+defImages(screenshot)
+```

--- a/docs/src/content/docs/reference/scripts/images.md
+++ b/docs/src/content/docs/reference/scripts/images.md
@@ -30,7 +30,7 @@ Local files are loaded and encoded as a data uri.
 
 ## Buffer, Blob
 
-The `defImage` function also supports [Buffer](https://nodejs.org/api/buffer.html)
+The `defImages` function also supports [Buffer](https://nodejs.org/api/buffer.html)
 and [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
 
 

--- a/docs/src/content/docs/reference/scripts/prompty.md
+++ b/docs/src/content/docs/reference/scripts/prompty.md
@@ -1,7 +1,11 @@
 ---
 title: Prompty
 sidebar:
-    order: 51
+  order: 51
+description: Learn about the .prompty file format for parameterized prompts and
+  its integration with GenAIScript for AI scripting.
+keywords: prompty, scripts, AI, parameterized prompts, automation
+
 ---
 
 GenAIScript supports running [.prompty](https://prompty.ai/) files as scripts (with some limitations).

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -238,7 +238,10 @@ export function createChatGenerationContext(
         return name
     }
 
-    const defImages = (files: StringLike, defOptions?: DefImagesOptions) => {
+    const defImages = (
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
+        defOptions?: DefImagesOptions
+    ) => {
         const { detail } = defOptions || {}
         if (Array.isArray(files))
             files.forEach((file) => defImages(file, defOptions))
@@ -250,6 +253,23 @@ export function createChatGenerationContext(
                 node,
                 createImageNode(
                     (async () => {
+                        const mime = await fileTypeFromBuffer(buffer)
+                        const b64 = await buffer.toString("base64")
+                        const url = `data:${mime.mime};base64,${b64}`
+                        return {
+                            url,
+                            detail,
+                        }
+                    })()
+                )
+            )
+        } else if (files instanceof Blob) {
+            const blob: Blob = files
+            appendChild(
+                node,
+                createImageNode(
+                    (async () => {
+                        const buffer = Buffer.from(await blob.arrayBuffer())
                         const mime = await fileTypeFromBuffer(buffer)
                         const b64 = await buffer.toString("base64")
                         const url = `data:${mime.mime};base64,${b64}`

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1537,7 +1539,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -203,7 +203,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/genaisrc/azure-blobs.genai.mts
+++ b/packages/sample/genaisrc/azure-blobs.genai.mts
@@ -30,9 +30,15 @@ for await (const blob of containerClient.listBlobsFlat()) {
     const blockBlobClient = containerClient.getBlockBlobClient(blob.name)
     const downloadBlockBlobResponse = await blockBlobClient.download(0)
     const body = await downloadBlockBlobResponse.readableStreamBody
-    const buf = await buffer(body)
-    console.log(`buffer: ${(buf.length / 1e3) | 0}kb`)
-    defImages(buf, { detail: "low" })
+    const image = await buffer(body)
+
+    const res = await runPrompt(_ => {
+        _.defImages(image, { detail: "low" })
+        _.$`Describe the images.`
+    })
+
+    def("IMAGES_SUMMARY", { filename: blob.name, content: res.text })
 }
 
-$`Describe the images.`
+$`Summarize IMAGES_SUMMARY.`
+

--- a/packages/sample/genaisrc/azure-blobs.genai.mts
+++ b/packages/sample/genaisrc/azure-blobs.genai.mts
@@ -1,35 +1,38 @@
 import { BlobServiceClient } from "@azure/storage-blob"
 import { DefaultAzureCredential } from "@azure/identity"
+import { buffer } from "node:stream/consumers"
 
 script({
     parameters: {
         account: {
             description: "Azure Storage Account Name",
-            default: "myaccount",
+            default: "genaiscript",
             type: "string",
         },
         container: {
             description: "Azure Storage Container Name",
-            default: "mycontainer",
+            default: "images",
             type: "string",
         },
     },
 })
 
 const { account, container } = env.vars
+const url = `https://${account}.blob.core.windows.net`
+console.log(`analyzing images in ${account}/${container} at ${url}`)
 const blobServiceClient = new BlobServiceClient(
-    `https://${account}.blob.core.windows.net`,
+    url,
     new DefaultAzureCredential()
 )
 const containerClient = blobServiceClient.getContainerClient(container)
 for await (const blob of containerClient.listBlobsFlat()) {
+    console.log(`blob: ` + blob.name)
     const blockBlobClient = containerClient.getBlockBlobClient(blob.name)
     const downloadBlockBlobResponse = await blockBlobClient.download(0)
     const body = await downloadBlockBlobResponse.readableStreamBody
-    const buffer = await body.read()
-    const res = await runPrompt((_) => {
-        _.defImages(buffer)
-        _.$`Describe the image.`
-    })
-    // do something with res?
+    const buf = await buffer(body)
+    console.log(`buffer: ${(buf.length / 1e3) | 0}kb`)
+    defImages(buf, { detail: "low" })
 }
+
+$`Describe the images.`

--- a/packages/sample/genaisrc/azure-blog-storage.genai.mts
+++ b/packages/sample/genaisrc/azure-blog-storage.genai.mts
@@ -1,0 +1,35 @@
+import { BlobServiceClient } from "@azure/storage-blob"
+import { DefaultAzureCredential } from "@azure/identity"
+
+script({
+    parameters: {
+        account: {
+            description: "Azure Storage Account Name",
+            default: "myaccount",
+            type: "string",
+        },
+        container: {
+            description: "Azure Storage Container Name",
+            default: "mycontainer",
+            type: "string",
+        },
+    },
+})
+
+const { account, container } = env.vars
+const blobServiceClient = new BlobServiceClient(
+    `https://${account}.blob.core.windows.net`,
+    new DefaultAzureCredential()
+)
+const containerClient = blobServiceClient.getContainerClient(container)
+for await (const blob of containerClient.listBlobsFlat()) {
+    const blockBlobClient = containerClient.getBlockBlobClient(blob.name)
+    const downloadBlockBlobResponse = await blockBlobClient.download(0)
+    const body = await downloadBlockBlobResponse.readableStreamBody
+    const buffer = await body.read()
+    const res = await runPrompt((_) => {
+        _.defImages(buffer)
+        _.$`Describe the image.`
+    })
+    // do something with res?
+}

--- a/packages/sample/genaisrc/front-matter.genai.mjs
+++ b/packages/sample/genaisrc/front-matter.genai.mjs
@@ -21,7 +21,7 @@ defFileMerge(function frontmatter(fn, label, before, generated) {
     return updated
 })
 
-def("FILE", env.files, { glob: "*.md*" })
+def("FILE", env.files, { glob: "**.{md,mdx}" })
 
 $`
 You are a search engine optimization expert at creating front matter for markdown document.

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -18,6 +18,8 @@
     "@agentic/calculator": "^7.0.0",
     "@agentic/core": "^7.0.0",
     "@agentic/weather": "^7.0.0",
+    "@azure/identity": "^4.4.1",
+    "@azure/storage-blob": "^12.24.0",
     "@tidyjs/tidy": "^2.5.2",
     "@xenova/transformers": "^2.17.2",
     "vectorstore": "^0.0.4",

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1,5 +1,7 @@
 type OptionsOrString<TOptions extends string> = (string & {}) | TOptions
 
+type ElementOrArray<T> = T | T[]
+
 interface PromptGenerationConsole {
     log(...data: any[]): void
     warn(...data: any[]): void
@@ -1570,7 +1572,7 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         options?: DefSchemaOptions
     ): string
     defImages(
-        files: StringLike | Buffer | Blob,
+        files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
         options?: DefImagesOptions
     ): void
     defTool(
@@ -2515,7 +2517,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: StringLike | Buffer | Blob,
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
     options?: DefImagesOptions
 ): void
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,7 +60,7 @@
     "@azure/core-util" "^1.1.0"
     tslib "^2.6.2"
 
-"@azure/core-client@^1.9.2":
+"@azure/core-client@^1.3.0", "@azure/core-client@^1.6.2", "@azure/core-client@^1.9.2":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@azure/core-client/-/core-client-1.9.2.tgz#6fc69cee2816883ab6c5cdd653ee4f2ff9774f74"
   integrity sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==
@@ -73,7 +73,33 @@
     "@azure/logger" "^1.0.0"
     tslib "^2.6.2"
 
-"@azure/core-rest-pipeline@^1.1.0", "@azure/core-rest-pipeline@^1.9.1":
+"@azure/core-http-compat@^2.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-http-compat/-/core-http-compat-2.1.2.tgz#d1585ada24ba750dc161d816169b33b35f762f0d"
+  integrity sha512-5MnV1yqzZwgNLLjlizsU3QqOeQChkIXw781Fwh1xdAqJR5AA32IUaq6xv1BICJvfbHoa+JYcaij2HFkhLbNTJQ==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-client" "^1.3.0"
+    "@azure/core-rest-pipeline" "^1.3.0"
+
+"@azure/core-lro@^2.2.0":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-lro/-/core-lro-2.7.2.tgz#787105027a20e45c77651a98b01a4d3b01b75a08"
+  integrity sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-util" "^1.2.0"
+    "@azure/logger" "^1.0.0"
+    tslib "^2.6.2"
+
+"@azure/core-paging@^1.1.1":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-paging/-/core-paging-1.6.2.tgz#40d3860dc2df7f291d66350b2cfd9171526433e7"
+  integrity sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@azure/core-rest-pipeline@^1.1.0", "@azure/core-rest-pipeline@^1.10.1", "@azure/core-rest-pipeline@^1.3.0", "@azure/core-rest-pipeline@^1.9.1":
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz#bde3bc3ebad7f885ddd9de6af5e5a8fc254b287e"
   integrity sha512-VxLk4AHLyqcHsfKe4MZ6IQ+D+ShuByy+RfStKfSjxJoL3WBWq17VNmrz8aT8etKzqc2nAeIyLxScjpzsS4fz8w==
@@ -87,19 +113,27 @@
     https-proxy-agent "^7.0.0"
     tslib "^2.6.2"
 
-"@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1":
+"@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1", "@azure/core-tracing@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.1.2.tgz#065dab4e093fb61899988a1cdbc827d9ad90b4ee"
   integrity sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==
   dependencies:
     tslib "^2.6.2"
 
-"@azure/core-util@^1.1.0", "@azure/core-util@^1.3.0", "@azure/core-util@^1.6.1", "@azure/core-util@^1.9.0":
+"@azure/core-util@^1.1.0", "@azure/core-util@^1.2.0", "@azure/core-util@^1.3.0", "@azure/core-util@^1.6.1", "@azure/core-util@^1.9.0":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.9.2.tgz#1dc37dc5b0dae34c578be62cf98905ba7c0cafe7"
   integrity sha512-l1Qrqhi4x1aekkV+OlcqsJa4AnAkj5p0JV8omgwjaV9OAbP41lvrMvs+CptfetKkeEaGRGSzby7sjPZEX7+kkQ==
   dependencies:
     "@azure/abort-controller" "^2.0.0"
+    tslib "^2.6.2"
+
+"@azure/core-xml@^1.3.2":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@azure/core-xml/-/core-xml-1.4.3.tgz#a74f37a0e584fee7e9adae19f51016d4b59e9ca2"
+  integrity sha512-D6G7FEmDiTctPKuWegX2WTrS1enKZwqYwdKTO6ZN6JMigcCehlT0/CYl+zWpI9vQ9frwwp7GQT3/owaEXgnOsA==
+  dependencies:
+    fast-xml-parser "^4.3.2"
     tslib "^2.6.2"
 
 "@azure/identity@^4.1.0", "@azure/identity@^4.4.1":
@@ -149,6 +183,25 @@
     "@azure/msal-common" "14.14.2"
     jsonwebtoken "^9.0.0"
     uuid "^8.3.0"
+
+"@azure/storage-blob@^12.24.0":
+  version "12.24.0"
+  resolved "https://registry.yarnpkg.com/@azure/storage-blob/-/storage-blob-12.24.0.tgz#d4ae1e29574b4a19d90eaf082cfde95f996d3f9b"
+  integrity sha512-l8cmWM4C7RoNCBOImoFMxhTXe1Lr+8uQ/IgnhRNMpfoA9bAFWoLG4XrWm6O5rKXortreVQuD+fc1hbzWklOZbw==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-client" "^1.6.2"
+    "@azure/core-http-compat" "^2.0.0"
+    "@azure/core-lro" "^2.2.0"
+    "@azure/core-paging" "^1.1.1"
+    "@azure/core-rest-pipeline" "^1.10.1"
+    "@azure/core-tracing" "^1.1.2"
+    "@azure/core-util" "^1.6.1"
+    "@azure/core-xml" "^1.3.2"
+    "@azure/logger" "^1.0.0"
+    events "^3.0.0"
+    tslib "^2.2.0"
 
 "@babel/code-frame@^7.0.0":
   version "7.24.7"
@@ -2227,7 +2280,7 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.1.tgz#cddd2eecfc83a71c1be2cc2ef2061331be8a7134"
   integrity sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==
 
-fast-xml-parser@^4.5.0:
+fast-xml-parser@^4.3.2, fast-xml-parser@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz#2882b7d01a6825dfdf909638f2de0256351def37"
   integrity sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==


### PR DESCRIPTION
This pull request updates the `defImages` function to support multiple file types and handle Blob conversion. The `files` parameter now accepts an array of strings, WorkspaceFiles, Buffers, or Blobs. This allows for more flexibility when passing files to the function.

<!-- genaiscript begin pr-describe -->

- The `defImages` function in `runpromptcontext.ts` has been updated to handle Blob instances 👏. Now, when a Blob instance is provided as an input file, it's converted into an 'image' node and appended to the parent node.
  
- `defImages` function parameters across various files have been made more flexible by introducing a new type, `ElementOrArray`. This means `defImages` can now handle both individual elements and arrays of elements of the types string, WorkspaceFile, Buffer, or Blob 🔄.

- These changes are reflected in the relevant type declaration files i.e. `prompt_template.d.ts` and `prompt_type.d.ts`. More specifically, the `defImages` function signatures in these files replace `StringLike | Buffer | Blob` with `ElementOrArray<string | WorkspaceFile | Buffer | Blob>`. 

- This shows clarity in the public API regarding what types of inputs `defImages` can accept, enhancing user understanding and control 🎮. The change increases the flexibility of data inputs making the system more robust and user-friendly. 

- Overall, fantastic job on improving flexibility, user compatibility, and making operations more efficient. Keep up the good work! 🚀🙌

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10817354920)



<!-- genaiscript end pr-describe -->

