### PR TITLE
Remove 'genaiscript.prompt.unbuiltin' command and add 'cmds' to settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "arrayify",
         "Automatable",
         "bitindex",
+        "cmds",
         "Codespaces",
         "demux",
         "devcontainers",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -198,10 +198,6 @@
                     "when": "false"
                 },
                 {
-                    "command": "genaiscript.prompt.unbuiltin",
-                    "when": "false"
-                },
-                {
                     "command": "genaiscript.prompt.navigate",
                     "when": "false"
                 },
@@ -235,10 +231,6 @@
                 {
                     "command": "genaiscript.prompt.fork",
                     "when": "view == genaiscript.prompts && viewItem  =~ /^prompt/"
-                },
-                {
-                    "command": "genaiscript.prompt.unbuiltin",
-                    "when": "view == genaiscript.prompts && viewItem  =~ /^prompt.builtin/"
                 }
             ],
             "explorer/context": [
@@ -329,11 +321,6 @@
                 "title": "Fork GenAiScript...",
                 "category": "GenAIScript",
                 "icon": "$(repo-forked)"
-            },
-            {
-                "command": "genaiscript.prompt.unbuiltin",
-                "title": "Move builtin to project",
-                "category": "GenAIScript"
             },
             {
                 "command": "genaiscript.request.open",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -356,6 +356,11 @@
                 "command": "genaiscript.connection.configure",
                 "title": "Configure connection...",
                 "category": "GenAIScript"
+            },
+            {
+                "command": "genaiscript.samples.download",
+                "title": "Download sample...",
+                "category": "GenAIScript"
             }
         ]
     },

--- a/packages/vscode/src/commands.ts
+++ b/packages/vscode/src/commands.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode"
 import { TOOL_NAME } from "../../core/src/constants"
 import { errorMessage } from "../../core/src/error"
-import { ExtensionState } from "./state"
 
 export function registerCommand(
     id: string,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -29,7 +29,7 @@ export async function activate(context: ExtensionContext) {
     const state = new ExtensionState(context)
     activatePromptCommands(state)
     activateFragmentCommands(state)
-    activateSamplesCommands(state)
+//    activateSamplesCommands(state)
     activateMarkdownTextDocumentContentProvider(state)
     activatePromptTreeDataProvider(state)
     activateConnectionInfoTree(state)

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -4,7 +4,7 @@ import { ExtensionState } from "./state"
 import { activateStatusBar } from "./statusbar"
 import { activateFragmentCommands } from "./fragmentcommands"
 import { activateMarkdownTextDocumentContentProvider } from "./markdowndocumentprovider"
-import { activatePrompTreeDataProvider } from "./prompttree"
+import { activatePromptTreeDataProvider } from "./prompttree"
 import { activatePromptCommands, commandButtons } from "./promptcommands"
 import { activateLLMRequestTreeDataProvider } from "./llmrequesttree"
 import { activateAIRequestTreeDataProvider } from "./airequesttree"
@@ -22,15 +22,16 @@ import MarkdownItGitHubAlerts from "markdown-it-github-alerts"
 import { activateConnectionInfoTree } from "./connectioninfotree"
 import { updateConnectionConfiguration } from "../../core/src/connection"
 import { APIType } from "../../core/src/host"
-import { openUrlInTab } from "./browser"
 import { activeTaskProvider } from "./taskprovider"
+import { activateSamplesCommands } from "./samplescommands"
 
 export async function activate(context: ExtensionContext) {
     const state = new ExtensionState(context)
     activatePromptCommands(state)
     activateFragmentCommands(state)
+    activateSamplesCommands(state)
     activateMarkdownTextDocumentContentProvider(state)
-    activatePrompTreeDataProvider(state)
+    activatePromptTreeDataProvider(state)
     activateConnectionInfoTree(state)
     activateAIRequestTreeDataProvider(state)
     activateLLMRequestTreeDataProvider(state)

--- a/packages/vscode/src/promptcommands.ts
+++ b/packages/vscode/src/promptcommands.ts
@@ -62,13 +62,6 @@ export function activatePromptCommands(state: ExtensionState) {
             }
         ),
         registerCommand(
-            "genaiscript.prompt.unbuiltin",
-            async (template: PromptScript) => {
-                if (!template) return
-                await showPrompt(await copyPrompt(template, { fork: false }))
-            }
-        ),
-        registerCommand(
             "genaiscript.prompt.navigate",
             async (prompt: PromptScript) => {
                 const uri = prompt.filename

--- a/packages/vscode/src/prompttree.ts
+++ b/packages/vscode/src/prompttree.ts
@@ -92,7 +92,7 @@ ${description}
     }
 }
 
-export function activatePrompTreeDataProvider(state: ExtensionState) {
+export function activatePromptTreeDataProvider(state: ExtensionState) {
     const { context } = state
     const { subscriptions } = context
     const treeDataProvider = new PromptTreeDataProvider(state)

--- a/packages/vscode/src/samplescommands.ts
+++ b/packages/vscode/src/samplescommands.ts
@@ -1,0 +1,52 @@
+import * as vscode from "vscode"
+import { ExtensionState } from "./state"
+import { registerCommand } from "./commands"
+import { Utils } from "vscode-uri"
+import { GENAI_SRC } from "../../core/src/constants"
+import { parsePromptScriptMeta } from "../../core/src/template"
+import { writeFile } from "./fs"
+
+export function activateSamplesCommands(state: ExtensionState) {
+    const { context, host } = state
+
+    registerCommand("genaiscript.samples.download", async () => {
+        const dir = Utils.joinPath(context.extensionUri, GENAI_SRC)
+        const files = await vscode.workspace.fs.readDirectory(
+            Utils.joinPath(context.extensionUri, GENAI_SRC)
+        )
+        const utf8 = host.createUTF8Decoder()
+        const samples = (
+            await Promise.all(
+                files
+                    .map((f) => f[0])
+                    .filter((f) => f.endsWith(".genai.mts"))
+                    .map(async (filename) => ({
+                        filename,
+                        jsSource: utf8.decode(
+                            await vscode.workspace.fs.readFile(
+                                Utils.joinPath(dir, filename)
+                            )
+                        ),
+                    }))
+            )
+        ).map((s) => ({ ...s, meta: parsePromptScriptMeta(s.jsSource) }))
+
+        const res = await vscode.window.showQuickPick<
+            vscode.QuickPickItem & { filename: string; jsSource: string }
+        >(
+            samples.map((s) => ({
+                label: s.meta.title,
+                detail: s.meta.description,
+                ...s,
+            })),
+            { title: "Pick a sample to download" }
+        )
+        if (res === undefined) return
+
+        const { jsSource, filename } = res
+        await writeFile(host.toUri(GENAI_SRC), filename, jsSource, {
+            open: true,
+        })
+        await state.parseWorkspace()
+    })
+}


### PR DESCRIPTION
This pull request removes the 'genaiscript.prompt.unbuiltin' command and adds the 'cmds' setting to settings.json. It also includes a new feature for downloading samples.