### PR TITLE
add prompt`...` syntax

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -231,3 +231,5 @@ export const CONSOLE_COLOR_ERROR = 91
 export const PLAYWRIGHT_DEFAULT_BROWSER = "chromium"
 export const MAX_TOKENS_ELLIPSE = "..."
 export const ESTIMATE_TOKEN_OVERHEAD = 2
+
+export const DEDENT_INSPECT_MAX_DEPTH = 3

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/core/src/importprompt.ts
+++ b/packages/core/src/importprompt.ts
@@ -24,6 +24,7 @@ export async function importPrompt(
         "env",
         "retrieval",
         "runPrompt",
+        "prompt",
     ]
 
     const oldGlb: any = {}

--- a/packages/core/src/indent.ts
+++ b/packages/core/src/indent.ts
@@ -1,4 +1,6 @@
 import tsDedent from "ts-dedent"
+import { inspect } from "./logging"
+import { DEDENT_INSPECT_MAX_DEPTH } from "./constants"
 
 export function indent(text: string, indentation: string) {
     return text
@@ -8,3 +10,23 @@ export function indent(text: string, indentation: string) {
 }
 
 export const dedent = tsDedent
+
+export async function dedentAsync(
+    strings: Awaitable<TemplateStringsArray | string>,
+    ...args: any[]
+) {
+    const template = await strings
+    const resolvedArgs: any[] = []
+    for (const arg of args) {
+        let resolvedArg = await arg
+        if (typeof resolvedArg === "function") resolvedArg = resolvedArg()
+        // render objects
+        if (typeof resolvedArg === "object" || Array.isArray(resolvedArg))
+            resolvedArg = inspect(resolvedArg, {
+                maxDepth: DEDENT_INSPECT_MAX_DEPTH,
+            })
+        resolvedArgs.push(resolvedArg ?? "")
+    }
+    const value = dedent(template, ...resolvedArgs)
+    return value
+}

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -41,7 +41,7 @@ import { callExpander } from "./expander"
 import { Project } from "./ast"
 import { resolveSystems } from "./systems"
 import { shellParse } from "./shell"
-import { dedent, dedentAsync } from "./indent"
+import { sleep } from "openai/core.mjs"
 
 export async function createPromptContext(
     prj: Project,
@@ -239,9 +239,11 @@ export async function createPromptContext(
             const p: RunPromptResultPromiseWithOptions =
                 new Promise<RunPromptResult>(async (resolve, reject) => {
                     try {
-                        const text = await dedentAsync(template, ...args)
+                        await sleep(0)
                         // data race for options
-                        const res = await runPrompt(text, options)
+                        const res = await runPrompt(async (_) => {
+                            _.$(template, ...args)
+                        }, options)
                         resolve(res)
                     } catch (e) {
                         reject(e)

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -16,7 +16,7 @@ import { toChatCompletionUserMessage } from "./chat"
 import { errorMessage } from "./error"
 import { tidyData } from "./tidy"
 import { inspect } from "./logging"
-import { dedent } from "./indent"
+import { dedent, dedentAsync } from "./indent"
 import {
     ChatCompletionAssistantMessageParam,
     ChatCompletionMessageParam,
@@ -483,24 +483,7 @@ async function resolvePromptNode(
         stringTemplate: async (n) => {
             const { strings, args } = n
             try {
-                const resolvedArgs: any[] = []
-                for (const arg of args) {
-                    let resolvedArg = await arg
-                    if (typeof resolvedArg === "function")
-                        resolvedArg = resolvedArg()
-                    // render objects
-                    if (
-                        typeof resolvedArg === "object" ||
-                        Array.isArray(resolvedArg)
-                    )
-                        resolvedArg = inspect(resolvedArg, {
-                            maxDepth: 3,
-                        })
-                    resolvedArgs.push(resolvedArg ?? "")
-                }
-                let value = dedent(strings, ...resolvedArgs)
-
-                // apply transforms
+                let value = await dedentAsync(strings, ...args)
                 if (n.transforms?.length)
                     for (const transform of n.transforms)
                         value = await transform(value)

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1544,6 +1544,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1576,6 +1580,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -203,7 +203,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -234,6 +234,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/genaisrc/nested-poets.genai.mts
+++ b/packages/sample/genaisrc/nested-poets.genai.mts
@@ -1,5 +1,5 @@
 defTool("poet", "Writes 4 line poems", {}, () =>
-    prompt`Write a ${4} line poem`.options({
+    prompt`Write a ${4} line ${"poem"}`.options({
         model: "openai:gpt-4o",
         label: "Poem writer",
     })

--- a/packages/sample/genaisrc/nested-poets.genai.mts
+++ b/packages/sample/genaisrc/nested-poets.genai.mts
@@ -1,10 +1,9 @@
-defTool("poet", "Writes 4 line poems", {}, async () => {
-    const result = await prompt`Write a ${4} line poem`.options({
+defTool("poet", "Writes 4 line poems", {}, () =>
+    prompt`Write a ${4} line poem`.options({
         model: "openai:gpt-4o",
         label: "Poem writer",
     })
-    return result.text
-})
+)
 
 script({
     description: "Writes poems using the poet tool.",

--- a/packages/sample/genaisrc/nested-poets.genai.mts
+++ b/packages/sample/genaisrc/nested-poets.genai.mts
@@ -1,5 +1,5 @@
 defTool("poet", "Writes 4 line poems", {}, async () => {
-    const result = await runPrompt(`Write a 4 line poem`, {
+    const result = await prompt`Write a ${4} line poem`.options({
         model: "openai:gpt-4o",
         label: "Poem writer",
     })

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1577,6 +1577,10 @@ interface FileUpdate {
     validation?: JSONSchemaValidation
 }
 
+interface RunPromptResultPromiseWithOptions extends Promise<RunPromptResult> {
+    options(values?: PromptGeneratorOptions): RunPromptResultPromiseWithOptions
+}
+
 interface ChatGenerationContext extends ChatTurnGenerationContext {
     defSchema(
         name: string,
@@ -1609,6 +1613,10 @@ interface ChatGenerationContext extends ChatTurnGenerationContext {
         generator: string | PromptGenerator,
         options?: PromptGeneratorOptions
     ): Promise<RunPromptResult>
+    prompt(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): RunPromptResultPromiseWithOptions
 }
 
 interface GenerationOutput {
@@ -2567,7 +2575,7 @@ declare function defSchema(
  * @param options
  */
 declare function defImages(
-    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,    
+    files: ElementOrArray<string | WorkspaceFile | Buffer | Blob>,
     options?: DefImagesOptions
 ): void
 
@@ -2598,6 +2606,14 @@ declare function runPrompt(
     generator: string | PromptGenerator,
     options?: PromptGeneratorOptions
 ): Promise<RunPromptResult>
+
+/**
+ * Expands and executes the prompt
+ */
+declare function prompt(
+    strings: TemplateStringsArray,
+    ...args: any[]
+): RunPromptResultPromiseWithOptions
 
 /**
  * Registers a callback to process the LLM output


### PR DESCRIPTION
This pull request refactors the prompt handling in the core files and adds async dedent functionality. The prompt handling in the core files is updated to remove an asynchronous call and return statement. Additionally, the `dedentAsync` function is added to the `indent.ts` file, which allows for asynchronous dedenting of strings. This functionality is then used in the `promptcontext.ts` and `promptdom.ts` files to improve the handling of prompts.

<!-- genaiscript begin pr-describe -->

- 🛠️ A new constant `DEDENT_INSPECT_MAX_DEPTH` was added in the constants file.
- 👀 In the "importprompt.ts" file, "prompt" was added to an exported object.
- 🔄 The "indent.ts" file has a significant modification. A new function `dedentAsync` has been implemented. This function asynchronously indents multi-line string templates and handles the resolution of arguments including arrays and objects.
- 🎭 In "promptcontext.ts", a new functionality is implemented in the form of a function named `prompt`. It performs asynchronous operations, handles any exceptions, and ties it together with the `runPrompt` function.
- 💼 Import of `dedentAsync` is added in "promptdom.ts" and "promptcontext.ts" file, and the function is used to reduce complexity of `stringTemplate` function in "promptdom.ts".
- 📃 Updates are made in the "prompt_template.d.ts" and "prompt_type.d.ts" files which are user-facing public API changes. A new interface `RunPromptResultPromiseWithOptions` was defined, and a new function `prompt` is included in the `ChatGenerationContext` interface.
- 🎶 Lastly, in the "nested-poets.genai.mts" file, `runPrompt` function is replaced with the newly created `prompt` function along with the usage of string templates.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10938881637)



<!-- genaiscript end pr-describe -->

