### PR TITLE
Refactor tracing logic and add summarize-concurrent script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,3 @@ jobs:
               run: yarn test:core
             - name: unit tests
               run: yarn test:samples
-            - name: slides
-              run: yarn build:slides
-            - name: docs
-              run: yarn build:docs

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -30,6 +30,7 @@ import {
     RUNS_DIR_NAME,
     CONSOLE_COLOR_DEBUG,
     DOCS_CONFIGURATION_URL,
+    TRACE_DETAILS,
 } from "../../core/src/constants"
 import { isCancelError, errorMessage } from "../../core/src/error"
 import { Fragment, GenerationResult } from "../../core/src/generation"
@@ -65,6 +66,7 @@ import {
 } from "../../core/src/azuredevops"
 import { resolveTokenEncoder } from "../../core/src/encoders"
 import { writeFile } from "fs/promises"
+import { writeFileSync } from "node:fs"
 
 async function setupTraceWriting(trace: MarkdownTrace, filename: string) {
     logVerbose(`trace: ${filename}`)
@@ -78,6 +80,10 @@ async function setupTraceWriting(trace: MarkdownTrace, filename: string) {
         },
         false
     )
+    trace.addEventListener(TRACE_DETAILS, (ev) => {
+        const content = trace.content
+        writeFileSync(filename, content, { encoding: "utf-8" })
+    })
 }
 
 export async function runScriptWithExitCode(

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,5 +1,6 @@
 export const CHANGE = "change"
 export const TRACE_CHUNK = "traceChunk"
+export const TRACE_DETAILS = "traceDetails"
 export const RECONNECT = "reconnect"
 export const OPEN = "open"
 export const MAX_TOOL_CALLS = 10000

--- a/packages/core/src/openai.ts
+++ b/packages/core/src/openai.ts
@@ -144,13 +144,14 @@ export const OpenAIChatCompletion: ChatCompletionHandler = async (
         throw e
     }
 
-    trace.itemValue(`response`, `${r.status} ${r.statusText}`)
+    trace.itemValue(`status`, `${r.status} ${r.statusText}`)
     if (r.status !== 200) {
-        let body: string
+        let responseBody: string
         try {
-            body = await r.text()
+            responseBody = await r.text()
         } catch (e) {}
-        const { error, message } = JSON5TryParse(body, {}) as {
+        trace.detailsFenced(`response`, responseBody, "json")
+        const { error, message } = JSON5TryParse(responseBody, {}) as {
             error: any
             message: string
         }
@@ -165,12 +166,10 @@ export const OpenAIChatCompletion: ChatCompletionHandler = async (
             r.status,
             message ?? error?.message ?? r.statusText,
             error,
-            body,
+            responseBody,
             normalizeInt(r.headers.get("retry-after"))
         )
     }
-
-    trace.appendContent("\n\n")
 
     let done = false
     let finishReason: ChatCompletionResponse["finishReason"] = undefined

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -70,8 +70,7 @@ export async function createPromptContext(
             return res
         },
         grep: async (query, globs, options) => {
-            const grepTrace = trace.appendTrace()
-            grepTrace.startDetails(
+            const grepTrace = trace.startTraceDetails(
                 `🌐 grep <code>${HTMLEscape(typeof query === "string" ? query : query.source)}</code>`
             )
             try {
@@ -110,8 +109,7 @@ export async function createPromptContext(
         fuzzSearch: async (q, files_, searchOptions) => {
             const files = arrayify(files_)
             searchOptions = searchOptions || {}
-            const fuzzTrace = trace.appendTrace()
-            fuzzTrace.startDetails(
+            const fuzzTrace = trace.startTraceDetails(
                 `🧐 fuzz search <code>${HTMLEscape(q)}</code>`
             )
             try {
@@ -137,8 +135,7 @@ export async function createPromptContext(
         vectorSearch: async (q, files_, searchOptions) => {
             const files = arrayify(files_).map(toWorkspaceFile)
             searchOptions = { ...(searchOptions || {}) }
-            const vecTrace = trace.appendTrace()
-            vecTrace.startDetails(
+            const vecTrace = trace.startTraceDetails(
                 `🔍 vector search <code>${HTMLEscape(q)}</code>`
             )
             try {
@@ -241,8 +238,9 @@ export async function createPromptContext(
         },
         runPrompt: async (generator, runOptions): Promise<RunPromptResult> => {
             const { label } = runOptions || {}
-            const runTrace = trace.appendTrace()
-            runTrace.startDetails(`🎁 run prompt ${label || ""}`)
+            const runTrace = trace.startTraceDetails(
+                `🎁 run prompt ${label || ""}`
+            )
             try {
                 infoCb?.({ text: `run prompt ${label || ""}` })
 

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -22,9 +22,9 @@ export class TraceChunkEvent extends Event {
 }
 
 export class MarkdownTrace extends EventTarget implements ToolCallTrace {
-    readonly errors: { message: string; error: SerializedError }[] = []
+    readonly _errors: { message: string; error: SerializedError }[] = []
     private detailsDepth = 0
-    private _content: string = ""
+    private _content: (string | MarkdownTrace)[] = []
     private _tree: TraceTree
 
     constructor(
@@ -42,17 +42,25 @@ export class MarkdownTrace extends EventTarget implements ToolCallTrace {
     }
 
     get tree() {
-        if (!this._tree) this._tree = parseTraceTree(this._content)
+        if (!this._tree) this._tree = parseTraceTree(this.content)
         return this._tree
     }
 
-    get content() {
+    get content(): string {
         return this._content
+            .map((c) => (typeof c === "string" ? c : c.content))
+            .join("")
+    }
+
+    appendTrace() {
+        const trace = new MarkdownTrace(this.options)
+        this._content.push(trace)
+        return trace
     }
 
     appendContent(value: string) {
         if (value !== undefined && value !== null && value !== "") {
-            this._content = this._content + value
+            this._content.push(value)
             this._tree = undefined
             this.dispatchChange()
             this.dispatchEvent(new TraceChunkEvent(value))
@@ -162,7 +170,8 @@ ${this.toResultIcon(success, "")}${title}
     }
 
     append(trace: MarkdownTrace) {
-        this.appendContent("\n" + trace.content)
+        this._content.push("\n")
+        this._content.push(trace)
     }
 
     tip(message: string) {
@@ -195,9 +204,16 @@ ${this.toResultIcon(success, "")}${title}
                 message,
                 error: serializeError(error),
             }
-            this.errors.push(err)
+            this._errors.push(err)
             this.renderError(err, { details: true })
         })
+    }
+
+    get errors(): { message: string; error: SerializedError }[] {
+        const traces = this._content.filter(
+            (c) => typeof c !== "string"
+        ) as MarkdownTrace[]
+        return this._errors.concat(...traces.map((t) => t.errors))
     }
 
     renderErrors(): void {

--- a/packages/sample/genaisrc/summarize-concurrent.genai.mjs
+++ b/packages/sample/genaisrc/summarize-concurrent.genai.mjs
@@ -1,0 +1,21 @@
+script({
+    title: "summarize concurrently",
+    model: "openai:gpt-3.5-turbo",
+    files: "src/rag/*",
+})
+
+const summaries = await Promise.all(
+    env.files.map((file) =>
+        runPrompt(
+            (_) => {
+                _.def("FILE", file)
+                _.$`Summarize FILE with one paragraph.`
+            },
+            { label: file.filename }
+        )
+    )
+)
+
+summaries.forEach((s) => def("FILE", s.text))
+
+$`Summarize FILE.`


### PR DESCRIPTION
This pull request includes a refactoring of the tracing logic and the addition of a new script called `summarize-concurrent`. The refactoring improves the tracing functionality, making it more efficient and easier to use. The `summarize-concurrent` script allows for concurrent file summarization using the OpenAI GPT-3.5 Turbo model. This script takes a list of files in the `src/rag` directory and generates summaries for each file using one paragraph. The summaries are then stored in the `summaries` array. Finally, the pull request includes updates to the MarkdownTrace class to handle errors and render them properly.

<!-- genaiscript begin pr-describe -->

The changes focused on the tracing functionality and the chat generation context in the code. Here's what was changed:

- 🔄 A major refactor was done on `createPromptContext` function. A more granular control for the trace context lifecycle was introduced for different search types (`grep`, `fuzzSearch`, `vectorSearch`), and `runPrompt`. This involved creation of individual trace contexts (`grepTrace`, `fuzzTrace`, `vecTrace`, `runTrace`) for each action.

- 🛠 Each of the above mentioned individual chunks of work now maintains it's own trace allowing for better tracking and handling of errors and events within those contexts. 

- ℹ️ In `runPrompt`, the trace context is now being directly passed to functions dealing with chat generation context (`createChatGenerationContext`) and model connection resolution (`resolveModelConnectionInfo`), which enhances the granularity of the tracing further.

- 👀 There's been a significant change to the `MarkdownTrace` class. The `content` property now stores an array of `string | MarkdownTrace`. This change allows for a hierarchical representation of the trace.

- ➕ A new method `appendTrace` has been added to `MarkdownTrace` which allows for appending a trace to another, maintaining the hierarchy.

- 🚥 The error handling in `MarkdownTrace` class has been updated too. The `errors` getter now includes errors from all child traces.

- 📜 In addition to this, a new genai script `summarize-concurrent.genai.mjs` was added. This script seems to be aimed at concurrent summaries of multiple files.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10939374218)



<!-- genaiscript end pr-describe -->

