### PR TITLE
Refactor code and update documentation

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -36,6 +36,12 @@ import testExplorerAlt from "../../assets/vscode-test-explorer.png.txt?raw"
 
 Programmatically assemble prompts for LLMs using JavaScript.
 
+```js
+$`Analyze ${env.files} and report errors. Use emojis.`
+```
+
+Of course, things can get more complex...
+
 ```js wrap title="extract-data.genai.mjs"
 // define the context
 def("FILE", env.files, { endsWith: ".pdf" })

--- a/docs/src/content/docs/reference/scripts/context.md
+++ b/docs/src/content/docs/reference/scripts/context.md
@@ -38,11 +38,21 @@ script({
 
 -   [CLI](/genaiscript/reference/cli) files arguments.
 
+The files are stored in `env.files` which can be injected in the prompt.
+
+-   directly in a `$` call
+
+```js
+$`Summarize ${env.files}.
+```
+
+-   using `def`
+
 ```js
 def("FILE", env.files)
 ```
 
-Or filtered,
+-   filtered,
 
 ```js
 def("DOCS", env.files, { endsWith: ".md" })

--- a/packages/core/src/indent.ts
+++ b/packages/core/src/indent.ts
@@ -10,23 +10,3 @@ export function indent(text: string, indentation: string) {
 }
 
 export const dedent = tsDedent
-
-export async function dedentAsync(
-    strings: Awaitable<TemplateStringsArray | string>,
-    ...args: any[]
-) {
-    const template = await strings
-    const resolvedArgs: any[] = []
-    for (const arg of args) {
-        let resolvedArg = await arg
-        if (typeof resolvedArg === "function") resolvedArg = resolvedArg()
-        // render objects
-        if (typeof resolvedArg === "object" || Array.isArray(resolvedArg))
-            resolvedArg = inspect(resolvedArg, {
-                maxDepth: DEDENT_INSPECT_MAX_DEPTH,
-            })
-        resolvedArgs.push(resolvedArg ?? "")
-    }
-    const value = dedent(template, ...resolvedArgs)
-    return value
-}

--- a/packages/core/src/indent.ts
+++ b/packages/core/src/indent.ts
@@ -1,6 +1,4 @@
 import tsDedent from "ts-dedent"
-import { inspect } from "./logging"
-import { DEDENT_INSPECT_MAX_DEPTH } from "./constants"
 
 export function indent(text: string, indentation: string) {
     return text

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -4,7 +4,7 @@ import {
     createAssistantNode,
     createChatParticipant,
     createDefData,
-    createDefNode,
+    createDef,
     createFileOutput,
     createFunctionNode,
     createImageNode,
@@ -105,7 +105,7 @@ export function createChatTurnGenerationContext(
                     throw new Error(`def ${name} is empty`)
                 appendChild(
                     node,
-                    createDefNode(
+                    createDef(
                         name,
                         { filename: "", content: body },
                         doptions
@@ -122,14 +122,14 @@ export function createChatTurnGenerationContext(
                     if (!isGlobMatch(filename, glob)) return undefined
                 }
                 if (endsWith && !filename.endsWith(endsWith)) return undefined
-                appendChild(node, createDefNode(name, file, doptions))
+                appendChild(node, createDef(name, file, doptions))
             } else if (
                 typeof body === "object" &&
                 (body as ShellOutput).exitCode !== undefined
             ) {
                 appendChild(
                     node,
-                    createDefNode(
+                    createDef(
                         name,
                         {
                             filename: "",
@@ -142,7 +142,7 @@ export function createChatTurnGenerationContext(
                 const fenced = body as Fenced
                 appendChild(
                     node,
-                    createDefNode(
+                    createDef(
                         name,
                         { filename: "", content: (body as Fenced).content },
                         { language: fenced.language, ...(doptions || {}) }

--- a/packages/sample/genaisrc/nested-args.genai.mts
+++ b/packages/sample/genaisrc/nested-args.genai.mts
@@ -1,0 +1,13 @@
+script({
+    title: "summarize with nested arguments",
+    model: "openai:gpt-3.5-turbo",
+    files: "src/rag/markdown.md",
+    tests: [
+        {
+            files: "src/rag/markdown.md",
+            keywords: "markdown",
+        },
+    ],
+})
+
+$`Summarize ${env.files}.`


### PR DESCRIPTION
The pull request includes several commits that refactor the codebase. The `dedentAsync` function has been removed and the `createDefNode` function has been refactored to `createDef`. Unused imports have also been removed from the `indent.ts` file. Additionally, the documentation has been updated with examples for using `env.files` in prompts.

<!-- genaiscript begin pr-describe -->

- 🏗️ Adjusted how prompting for LLMs is performed in the documentation, and how files arguments (from CLI) are handled in scripts. Involved changes in `docs/src/content/docs/index.mdx` and `docs/src/content/docs/reference/scripts/context.md`.
- 💡 Introduced ways to directly inject `env.files` in a `$` call and ways to handle it using `def`.
- ⏩ Simplified code in `packages/core/src/indent.ts` by removing `dedentAsync` function, and its usage in `packages/core/src/promptdom.ts` has been replaced with asynchronous handling within the 'stringTemplate' case in `resolvePromptNode`.
- 👁️‍🗨️ The string template resolver now inspects and handles file objects specially. If an object is a file or an array of files, it creates new def nodes for them using the updated `createDef` function (renamed from `createDefNode` for consistency).
- 🔄 Revised the method of calling `createDef` function in `packages/core/src/runpromptcontext.ts`.
- ✨ A new script `packages/sample/genaisrc/nested-args.genai.mts` has been added that demonstrates the use of nested arguments for summarizing files.
- 🛠️ Changes in other files like (i.e. path changes, renamed methods) appear to be refactoring or cleanup of the codebase.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/10950517716)



<!-- genaiscript end pr-describe -->

