### PR TITLE
Add CSV stringification functionality and remove verbose error logging

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "ajv": "^8.17.1",
     "cross-fetch": "^4.0.0",
     "csv-parse": "^5.5.6",
+    "csv-stringify": "^6.5.1",
     "dotenv": "^16.4.5",
     "esbuild": "^0.24.0",
     "fast-xml-parser": "^4.5.0",

--- a/packages/core/src/csv.test.ts
+++ b/packages/core/src/csv.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, beforeEach } from "node:test"
 import assert from "node:assert/strict"
-import { CSVParse, CSVTryParse, CSVToMarkdown } from "./csv"
+import { CSVParse, CSVTryParse, CSVToMarkdown, CSVStringify } from "./csv"
 
 describe("CSVParse", () => {
     test("Parse simple CSV data with default options", () => {
@@ -80,5 +80,35 @@ describe("CSVToMarkdown", () => {
     test("Handle empty CSV data input", () => {
         const result = CSVToMarkdown([])
         assert.equal(result, "")
+    })
+})
+describe("CSVStringify", () => {
+    test("Stringify simple CSV data with default options", () => {
+        const csv = [
+            { name: "John", age: "30" },
+            { name: "Jane", age: "25" },
+        ]
+        const result = CSVStringify(csv)
+        const expected = "John,30\nJane,25\n"
+        assert.equal(result, expected)
+    })
+    test("Stringify simple CSV data with headers", () => {
+        const csv = [
+            { name: "John", age: "30" },
+            { name: "Jane", age: "25" },
+        ]
+        const result = CSVStringify(csv, { header: true })
+        const expected = "name,age\nJohn,30\nJane,25\n"
+        assert.equal(result, expected)
+    })
+
+    test("Stringify CSV data with custom delimiter", () => {
+        const csv = [
+            { name: "John", age: "30" },
+            { name: "Jane", age: "25" },
+        ]
+        const result = CSVStringify(csv, { header: true, delimiter: "|" })
+        const expected = "name|age\nJohn|30\nJane|25\n"
+        assert.equal(result, expected)
     })
 })

--- a/packages/core/src/csv.ts
+++ b/packages/core/src/csv.ts
@@ -1,7 +1,9 @@
-// Import the CSV parsing function from the csv-parse library
+// This module provides functions for parsing and converting CSV data,
+// including error handling and conversion to Markdown table format.
+
 import { parse } from "csv-parse/sync"
-// Import the TraceOptions interface for logging trace information
 import { TraceOptions } from "./trace"
+import { stringify } from "csv-stringify/sync"
 
 /**
  * Parses a CSV string into an array of objects.
@@ -62,6 +64,18 @@ export function CSVTryParse(
 }
 
 /**
+ * Converts an array of objects into a CSV string.
+ *
+ * @param csv - An array of objects to be converted into CSV format.
+ * @param options - Optional configuration for CSV stringification.
+ * @returns A string representing the CSV formatted data.
+ */
+export function CSVStringify(csv: object[], options?: CSVStringifyOptions) {
+    // Convert objects to CSV string using the provided options
+    return stringify(csv, options)
+}
+
+/**
  * Converts an array of objects into a Markdown table format.
  *
  * @param csv - The array of objects representing CSV data.
@@ -70,7 +84,7 @@ export function CSVTryParse(
  * @returns A string representing the CSV data in Markdown table format.
  */
 export function CSVToMarkdown(csv: object[], options?: { headers?: string[] }) {
-    if (!csv?.length) return ""
+    if (!csv?.length) return "" // Return empty string if CSV is empty
 
     const { headers = Object.keys(csv[0]) } = options || {}
     const res: string[] = [
@@ -84,11 +98,11 @@ export function CSVToMarkdown(csv: object[], options?: { headers?: string[] }) {
                         const s = v === undefined || v === null ? "" : String(v)
                         // Escape special Markdown characters and format cell content
                         return s
-                            .replace(/\s+$/, "")
-                            .replace(/[\\`*_{}[\]()#+\-.!]/g, (m) => "\\" + m)
-                            .replace(/</g, "lt;")
-                            .replace(/>/g, "gt;")
-                            .replace(/\r?\n/g, "<br>")
+                            .replace(/\s+$/, "") // Trim trailing whitespace
+                            .replace(/[\\`*_{}[\]()#+\-.!]/g, (m) => "\\" + m) // Escape special characters
+                            .replace(/</g, "lt;") // Replace '<' with its HTML entity
+                            .replace(/>/g, "gt;") // Replace '>' with its HTML entity
+                            .replace(/\r?\n/g, "<br>") // Replace newlines with <br>
                     })
                     .join("|")}|` // Join columns with '|'
         ),

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/core/src/globals.ts
+++ b/packages/core/src/globals.ts
@@ -1,6 +1,6 @@
 // Import various parsing and stringifying utilities
 import { YAMLParse, YAMLStringify } from "./yaml"
-import { CSVParse, CSVToMarkdown } from "./csv"
+import { CSVParse, CSVToMarkdown, CSVStringify } from "./csv"
 import { INIParse, INIStringify } from "./ini"
 import { XMLParse } from "./xml"
 import {
@@ -46,6 +46,7 @@ export function installGlobals() {
     // Freeze CSV utilities
     glb.CSV = Object.freeze<CSV>({
         parse: CSVParse,
+        stringify: CSVStringify,
         markdownify: CSVToMarkdown,
     })
 

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -17,6 +17,8 @@ export function estimateTokens(text: string, encoder: TokenEncoder) {
         // Return the length of the encoded text plus a constant overhead
         return encoder(text).length + ESTIMATE_TOKEN_OVERHEAD
     } catch (e) {
+        // If encoding fails, log the error in verbose mode
+        logVerbose(e)
         // Fallback: Estimate token count as one-fourth of text length plus overhead
         // This provides a rough estimate in case of encoding errors
         return (text.length >> 2) + ESTIMATE_TOKEN_OVERHEAD

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -17,8 +17,6 @@ export function estimateTokens(text: string, encoder: TokenEncoder) {
         // Return the length of the encoded text plus a constant overhead
         return encoder(text).length + ESTIMATE_TOKEN_OVERHEAD
     } catch (e) {
-        // If encoding fails, log the error in verbose mode
-        logVerbose(e)
         // Fallback: Estimate token count as one-fourth of text length plus overhead
         // This provides a rough estimate in case of encoding errors
         return (text.length >> 2) + ESTIMATE_TOKEN_OVERHEAD

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1302,26 +1302,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1335,26 +1335,51 @@ interface INI {
     stringify(value: any): string
 }
 
+interface CSVStringifyOptions {
+    delimiter?: string
+    header?: boolean
+}
+
+/**
+ * Interface representing CSV operations.
+ */
 interface CSV {
     /**
-     * Parses a CSV string to an array of objects
-     * @param text
-     * @param options
+     * Parses a CSV string to an array of objects.
+     * 
+     * @param text - The CSV string to parse.
+     * @param options - Optional settings for parsing.
+     * @param options.delimiter - The delimiter used in the CSV string. Defaults to ','.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the first row.
+     * @returns An array of objects representing the parsed CSV data.
      */
     parse(
         text: string,
         options?: {
-            delimiter?: string
-            headers?: string[]
+            delimiter?: string;
+            headers?: string[];
         }
-    ): object[]
+    ): object[];
 
     /**
-     * Converts an array of object that represents a data table to a markdown table
-     * @param csv
-     * @param options
+     * Converts an array of objects to a CSV string.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for stringifying.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A CSV string representing the data.
      */
-    markdownify(csv: object[], options?: { headers?: string[] }): string
+    stringify(csv: object[], options?: CSVStringifyOptions): string;
+
+    /**
+     * Converts an array of objects that represents a data table to a markdown table.
+     * 
+     * @param csv - The array of objects to convert.
+     * @param options - Optional settings for markdown conversion.
+     * @param options.headers - An array of headers to use. If not provided, headers will be inferred from the object keys.
+     * @returns A markdown string representing the data table.
+     */
+    markdownify(csv: object[], options?: { headers?: string[] }): string;
 }
 
 interface HighlightOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,6 +2132,11 @@ csv-parse@^5.5.6:
   resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.5.6.tgz#0d726d58a60416361358eec291a9f93abe0b6b1a"
   integrity sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A==
 
+csv-stringify@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-6.5.1.tgz#a31837dd35e34787e3c248159c982a21af964d94"
+  integrity sha512-+9lpZfwpLntpTIEpFbwQyWuW/hmI/eHuJZD1XzeZpfZTqkf1fyvBbBLXTJJMsBuuS11uTShMqPwzx4A6ffXgRQ==
+
 cubic2quad@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/cubic2quad/-/cubic2quad-1.2.1.tgz#2442260b72c02ee4b6a2fe998fcc1c4073622286"


### PR DESCRIPTION
This pull request adds functionality to stringify CSV data and removes verbose error logging from the token estimation function. The CSV module now includes a `stringify` method that converts an array of objects to a CSV string. Additionally, the `estimateTokens` function no longer logs errors in verbose mode.

<!-- genaiscript begin pr-describe --><hr/>

- :sparkles: Introduced a new functionality `CSVStringify` to convert arrays of objects into CSV formatted strings. This function provides options for header inclusion and custom delimiters, enhancing the functionality of the CSV processing module. :rocket:
- :wrench: This new feature has been integrated into the global scope, making it accessible alongside existing methods like `CSVParse` and `CSVToMarkdown`.
- :fire: Removed a verbose log statement from the `estimateTokens` function in `tokens.ts`. The function now falls back to a rough estimate if encoding fails, providing a cleaner, uninterrupted user experience. 
- :hammer_and_wrench: Made updates to comments in `csv.ts` for improved code readability and understanding. This includes explaining purpose of functions and clarifying their implementations.
- :memo: Refactored the `CSV` interface in `prompt_template.d.ts` for improved developer usability. This includes better structured documentation for the `CSV.parse` and `CSV.markdownify` functions and the introduction of the new `CSV.stringify` function in the interface.
- :microscope: Performed routine package maintenance, including the addition of `csv-stringify` dependency to `core/package.json`. This helps keep dependencies up-to-date and maintain compatibility.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11039619593)



<!-- genaiscript end pr-describe -->

