### PR TITLE
defDiff

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "promptfoo": "0.89.3"
   },
   "devDependencies": {
+    "@types/diff": "^5.2.2",
     "@types/dockerode": "^3.3.31",
     "@types/fs-extra": "^11.0.4",
     "@types/memorystream": "^0.3.4",
@@ -65,6 +66,7 @@
     "@types/replace-ext": "^2.0.2",
     "@types/ws": "^8.5.12",
     "commander": "^12.1.0",
+    "diff": "^7.0.0",
     "dotenv": "^16.4.5",
     "esbuild": "^0.24.0",
     "execa": "^9.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "@azure/identity": "^4.4.1",
     "@huggingface/jinja": "^0.3.1",
     "@tidyjs/tidy": "^2.5.2",
+    "@types/diff": "^5.2.2",
     "@types/html-escaper": "^3.0.2",
     "@types/html-to-text": "^9.0.4",
     "@types/inflection": "^1.13.2",

--- a/packages/core/src/diff.test.ts
+++ b/packages/core/src/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from "node:test"
 import assert from "node:assert/strict"
-import { parseLLMDiffs } from "./diff"
+import { createDiff, parseLLMDiffs } from "./diff"
 
 describe("diff", () => {
     test("is_valid_email", () => {
@@ -286,4 +286,34 @@ describe("diff", () => {
         const chunks = parseLLMDiffs(source)
         assert.notEqual(chunks.length, 0)
     })
+})
+test("createDiff with context", () => {
+    const left = {
+        filename: "file1.txt",
+        content: "line1\nline2\nline3\nline4\nline5\n",
+    }
+    const right = {
+        filename: "file1.txt",
+        content: "line1\nline2\nline3\nline4 modified\nline5\n",
+    }
+    const diff = createDiff(left, right, { context: 2 })
+    assert(diff.includes("@@ -2,4 +2,4 @@"))
+    assert(diff.includes("-line4"))
+    assert(diff.includes("+line4 modified"))
+})
+
+test("createDiff without context", () => {
+    const left = {
+        filename: "file1.txt",
+        content: "line1\nline2\nline3\nline4\nline5\n",
+    }
+    const right = {
+        filename: "file1.txt",
+        content: "line1\nline2\nline3\nline4 modified\nline5\n",
+    }
+    const diff = createDiff(left, right)
+    console.log(diff)
+    assert(diff.includes("@@ -1,5 +1,5 @@"))
+    assert(diff.includes("-line4"))
+    assert(diff.includes("+line4 modified"))
 })

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -1,5 +1,6 @@
 import { assert } from "./util"
 import parseDiff from "parse-diff"
+import { createTwoFilesPatch } from "diff"
 
 export interface Chunk {
     state: "existing" | "deleted" | "added"
@@ -282,4 +283,25 @@ export function llmifyDiff(diff: string) {
     }
 
     return result
+}
+
+export function createDiff(
+    left: WorkspaceFile,
+    right: WorkspaceFile,
+    options?: { context?: number }
+) {
+    const res = createTwoFilesPatch(
+        left.filename,
+        right.filename,
+        left.content,
+        right.content,
+        undefined,
+        undefined,
+        {
+            ignoreCase: true,
+            ignoreWhitespace: true,
+            ...(options ?? {}),
+        }
+    )
+    return res
 }

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -303,5 +303,5 @@ export function createDiff(
             ...(options ?? {}),
         }
     )
-    return res
+    return res.replace(/^[^=]*={10,}\n/, "")
 }

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -4,6 +4,7 @@ import {
     createAssistantNode,
     createChatParticipant,
     createDefData,
+    createDefDiff,
     createDef,
     createFileOutput,
     createFunctionNode,
@@ -167,6 +168,10 @@ export function createChatTurnGenerationContext(
         },
         defData: (name, data, defOptions) => {
             appendChild(node, createDefData(name, data, defOptions))
+            return name
+        },
+        defDiff: (name, left, right, defDiffOptions) => {
+            appendChild(node, createDefDiff(name, left, right, defDiffOptions))
             return name
         },
         fence(body, options?: DefOptions) {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -748,6 +748,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1576,6 +1583,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -688,7 +688,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -702,11 +709,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -751,7 +753,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -227,6 +227,19 @@ declare function defData(
 ): string
 
 /**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
+): string
+
+/**
  * Cancels the current prompt generation/execution with the given reason.
  * @param reason
  */

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/genaisrc/defdiff.genai.mts
+++ b/packages/sample/genaisrc/defdiff.genai.mts
@@ -1,0 +1,9 @@
+script({
+    files: "src/rag/*.md",
+    tests: {},
+})
+
+defDiff("DIFF", "monkey", "donkey")
+defDiff("DIFF", env.files[0], env.files[1])
+
+$`Analyze the content of DIFF`

--- a/packages/sample/genaisrc/gai.genai.mts
+++ b/packages/sample/genaisrc/gai.genai.mts
@@ -78,8 +78,7 @@ def("GIT_DIFF", gitDiff, {
     maxTokens: 10000,
     lineNumbers: true,
 })
-def("LOG_DIFF", logDiff, {
-    language: "diff",
+defDiff("LOG_DIFF", parseJobLog(lslog), parseJobLog(fflog), {
     maxTokens: 20000,
     lineNumbers: false,
 })
@@ -171,32 +170,6 @@ async function downloadRunLog(run_id: number) {
     return res
 }
 
-function diffJobLogs(firstLog: string, otherLog: string) {
-    let firsts = parseJobLog(firstLog)
-    let others = parseJobLog(otherLog)
-
-    // assumption: the list of steps has not changed
-    const n = Math.min(firsts.length, others.length)
-    firsts = firsts.slice(0, n)
-    others = others.slice(0, n)
-
-    // now do a regular diff
-    const f = firsts
-        .map((f) =>
-            f.title ? `##[group]${f.title}\n${f.text}\n##[endgroup]` : f.text
-        )
-        .join("\n")
-    const l = others
-        .map((f) =>
-            f.title ? `##[group]${f.title}\n${f.text}\n##[endgroup]` : f.text
-        )
-        .join("\n")
-    const d = createPatch("log.txt", f, l, undefined, undefined, {
-        ignoreCase: true,
-        ignoreWhitespace: true,
-    })
-    return d
-}
 
 function parseJobLog(text: string) {
     const lines = cleanLog(text).split(/\r?\n/g)
@@ -226,7 +199,12 @@ function parseJobLog(text: string) {
         "Determining the checkout info",
         "Persisting credentials for submodules",
     ]
-    return groups.filter(({ title }) => !ignoreSteps.includes(title))
+    return groups
+        .filter(({ title }) => !ignoreSteps.includes(title))
+        .map((f) =>
+            f.title ? `##[group]${f.title}\n${f.text}\n##[endgroup]` : f.text
+        )
+        .join("\n")
 }
 
 function cleanLog(text: string) {

--- a/packages/sample/genaisrc/gai.genai.mts
+++ b/packages/sample/genaisrc/gai.genai.mts
@@ -97,8 +97,9 @@ Generate a diff with suggested fixes. Use a diff format.
 writeText(
     `## Investigator report
 - [run failure](${ff.html_url})
-- [run last success](${ls.html_url})
-- [commit diff](https://github.com/${owner}/${repo}/compare/${ls.head_sha}...${ff.head_sha})
+, [run last success](${ls.html_url})
+, [${ff.head_sha.slice(0, 7)}](${ff.html_url})
+, [diff ${ls.head_sha.slice(0, 7)}...${ff.head_sha.slice(0, 7)}](https://github.com/${owner}/${repo}/compare/${ls.head_sha}...${ff.head_sha})
 
 `,
     { assistant: true }

--- a/packages/sample/genaisrc/gai.genai.mts
+++ b/packages/sample/genaisrc/gai.genai.mts
@@ -69,9 +69,6 @@ console.log(
     `> last success log: ${(lslog.length / 1000) | 0}kb ${lsjob.logUrl}`
 )
 
-const logDiff = diffJobLogs(lslog, fflog)
-console.log(`> log diff: ${(logDiff.length / 1000) | 0}kb`)
-
 // include difss
 def("GIT_DIFF", gitDiff, {
     language: "diff",
@@ -169,7 +166,6 @@ async function downloadRunLog(run_id: number) {
     }
     return res
 }
-
 
 function parseJobLog(text: string) {
     const lines = cleanLog(text).split(/\r?\n/g)

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -781,6 +781,13 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     ignoreEmpty?: boolean
 }
 
+/**
+ * Options for the `defDiff` command.
+ */
+interface DefDiffOptions extends ContextExpansionOptions {
+
+}
+
 interface DefImagesOptions {
     detail?: "high" | "low"
     /**
@@ -1609,6 +1616,7 @@ interface ChatTurnGenerationContext {
         data: object[] | object,
         options?: DefDataOptions
     ): string
+    defDiff<T extends string | WorkspaceFile>(name: string, left: T, right: T, options?: DefDiffOptions): string
     console: PromptGenerationConsole
 }
 
@@ -2670,6 +2678,19 @@ declare function defData(
     name: string,
     data: object[] | object,
     options?: DefDataOptions
+): string
+
+/**
+ * Renders a diff of the two given values
+ * @param left
+ * @param right
+ * @param options
+ */
+declare function defDiff<T extends string | WorkspaceFile>(
+    name: string,
+    left: T,
+    right: T,
+    options?: DefDiffOptions
 ): string
 
 /**

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -721,7 +721,14 @@ type PromptSystemArgs = Omit<
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]
 
-interface FenceOptions {
+interface LineNumberingOptions {
+    /**
+     * Prepend each line with a line numbers. Helps with generating diffs.
+     */
+    lineNumbers?: boolean
+}
+
+interface FenceOptions extends LineNumberingOptions{
     /**
      * Language of the fenced code block. Defaults to "markdown".
      */
@@ -735,11 +742,6 @@ interface FenceOptions {
         | "shell"
         | "toml"
         | string
-
-    /**
-     * Prepend each line with a line numbers. Helps with generating diffs.
-     */
-    lineNumbers?: boolean
 
     /**
      * JSON schema identifier
@@ -784,7 +786,7 @@ interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
 /**
  * Options for the `defDiff` command.
  */
-interface DefDiffOptions extends ContextExpansionOptions {
+interface DefDiffOptions extends ContextExpansionOptions, LineNumberingOptions {
 
 }
 


### PR DESCRIPTION
#730

<!-- genaiscript begin pr-describe --><hr/>

- The `GIT_DIFF` represents additions to the `packages/cli/package.json` and `packages/core/package.json` files. Specifically, new dependencies were added in both files.
- In `packages/cli/package.json`:
  - 🚀 The '@types/diff' dependency got introduced with version '^5.2.2'.
  - 🔄 A new package 'diff' also made its way into the devDependencies with version '^7.0.0'.
- Meanwhile, in `packages/core/package.json`:
  - 🔔 The '@types/diff' made its appearance with version '^5.2.2'. 

It seems the changes are primarily focused around introducing 'diff' related dependencies in both packages. This could likely be for comparing files or strings within the software, a common feature utilized in many places from code management to UI changes previews. It's also noteworthy that these changes aren't user-facing as they didn't affect the public API files: "packages/core/src/prompt_template.d.ts" and "packages/core/src/prompt_type.ts".


> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11064139206)



<!-- genaiscript end pr-describe -->

