### PR TITLE
github.getfile, searchcode

### DIFF
--- a/.github/workflows/genai-investigator.yml
+++ b/.github/workflows/genai-investigator.yml
@@ -4,6 +4,10 @@ on:
         workflows: ["build"]
         types:
             - completed
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.workflow_run.event }}-${{ github.event.workflow_run.conclusion }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
     actions: read

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/docs/src/content/docs/reference/scripts/context.md
+++ b/docs/src/content/docs/reference/scripts/context.md
@@ -70,16 +70,6 @@ const locale = env.vars.locale || "en-US"
 
 Read more about [variables](/genaiscript/reference/scripts/variables).
 
-### `env.secrets`
-
-The `secrets` property contains the secrets that have been defined in the script execution context.
-
-```javascript
-const token = env.secrets.SECRET_TOKEN
-```
-
-Read more about [secrets](/genaiscript/reference/scripts/secrets).
-
 ## Definition (`def`)
 
 The `def("FILE", file)` function is a shorthand for generating a fenced variable output.
@@ -210,3 +200,24 @@ defData("DATA", data, {
     sliceSample: 100,
 })
 ```
+
+
+## Diff Definition (`defDiff`)
+
+It is very common to compare two piece of data and ask the LLM to analyze the differences. Using diffs is a great way 
+to naturally compress the information since we only reason about differences!
+
+The `defDiff` takes care of formatting the diff in a way that helps LLM reason. It behaves similarly to `def` and assigns
+a name to the diff.
+
+```js
+// diff files
+defDiff("DIFF", env.files[0], env.files[1])
+
+// diff strings
+defDiff("DIFF", "cat", "dog")
+
+// diff objects
+defDiff("DIFF", { name: "cat" }, { name: "dog" })
+```
+

--- a/docs/src/content/docs/reference/scripts/context.md
+++ b/docs/src/content/docs/reference/scripts/context.md
@@ -94,6 +94,15 @@ The `def` function can also be used with an array of files, such as `env.files`.
 def("FILE", env.files)
 ```
 
+### Language
+
+You can specify the language of the text contained in `def`. This can help GenAIScript optimize the rendering of the text.
+
+```js 'language: "diff"'
+// hint that the output is a diff
+def("DIFF", gitdiff, { language: "diff" })
+```
+
 ### Referencing
 
 The `def` function returns a variable name that can be used in the prompt.
@@ -201,10 +210,9 @@ defData("DATA", data, {
 })
 ```
 
-
 ## Diff Definition (`defDiff`)
 
-It is very common to compare two piece of data and ask the LLM to analyze the differences. Using diffs is a great way 
+It is very common to compare two piece of data and ask the LLM to analyze the differences. Using diffs is a great way
 to naturally compress the information since we only reason about differences!
 
 The `defDiff` takes care of formatting the diff in a way that helps LLM reason. It behaves similarly to `def` and assigns
@@ -220,4 +228,3 @@ defDiff("DIFF", "cat", "dog")
 // diff objects
 defDiff("DIFF", { name: "cat" }, { name: "dog" })
 ```
-

--- a/docs/src/content/docs/reference/scripts/github.md
+++ b/docs/src/content/docs/reference/scripts/github.md
@@ -1,0 +1,99 @@
+---
+title: GitHub
+description: Support for querying GitHub
+sidebar:
+    order: 50
+---
+
+The `github` provides several helper function to query github. It also provides the connection information for more advanced usage.
+
+## Configuration
+
+The `github` configuration is automatically sniffed from the environment and git.
+
+The GitHub token is read from the `GITHUB_TOKEN` environment variable. Some queries might work without authentication for public repositories.
+
+### GitHub CodeSpaces
+
+In a GitHub CodeSpace, the `GITHUB_TOKEN` is automatically provisioned.
+
+### GitHub Actions
+
+In GitHub Actions, you might will to add permissions to the
+workspace to access workflow logs and pull requests. You also need to pass the `secret.GITHUB_TOKEN` to the genaiscript script run.
+
+```yml title="genai.yml" 'actions: read' 'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+permissions:
+    contents: read
+    actions: read
+    pull-requests: read # or write if you plan to create comments
+...
+    - run: npx --yes genaiscript ...
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ...
+```
+
+## Functions
+
+### Issues
+
+You can query issues and issue comments using `listIssues`, `listIssueComments`.
+
+```js
+const issues = await github.listIssues({ per_page: 5 })
+console.log(issues.map((i) => i.title))
+
+// use number!
+const issueComments = await github.listIssueComments(issues[0].number)
+console.log(issueComments)
+```
+
+### Pull Requests
+
+You can query pull requests and pull request reviews comments using `listPullRequests`, `listPullRequestReviewComments`.
+
+```js
+const prs = await github.listPullRequests({ pre_page: 5 })
+console.log(prs.map((i) => i.title))
+
+// use number!
+const prcs = await github.listPullRequestReviewComments(prs[0].number)
+console.log(prcs.map((i) => i.body))
+```
+
+In GitHub Actions, you need to give the `pull-request: read` permission.
+
+### Workflow runs
+
+Access the log of workflow runs to analyze failures.
+
+```js
+// list runs
+const runs = await github.listWorkflowRuns("build.yml", { per_page: 5 })
+console.log(runs.map((i) => i.status))
+
+const jobs = await github.listWorkflowJobs(runs[0].id)
+// redacted job log
+console.log(jobs[0].content)
+```
+
+In GitHub Actions, you need to give the `actions: read` permission.
+
+### Search Code
+
+Use `searchCode` for a code search on the default branch in the same repo.
+
+```js
+const res = await github.searchCode("HTMLToText")
+console.log(res)
+```
+
+### Get file content
+
+Gets the file content for a given ref, tag or commit sha.
+
+```js
+const pkg = await github.getFile("package.json", "main")
+console.log(pkg.content.slice(0, 50) + "...")
+```

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -421,11 +421,9 @@ export class GitHubClient implements GitHub {
         if (!this._client) {
             this._client = new Promise(async (resolve) => {
                 const conn = await this.connection()
-                const { owner, repo, token, apiUrl } = conn
+                const { token, apiUrl } = conn
                 const res = new Octokit({
                     userAgent: TOOL_ID,
-                    owner,
-                    repo,
                     auth: token,
                     baseUrl: apiUrl,
                 })
@@ -635,5 +633,27 @@ export class GitHubClient implements GitHub {
         } else {
             return undefined
         }
+    }
+
+    async searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]> {
+        const { client, owner, repo } = await this.client()
+        const q = query + `+repo:${owner}/${repo}`
+        const {
+            data: { items },
+        } = await client.rest.search.code({
+            q,
+            ...(options || {}),
+        })
+        return items.map(({ name, path, sha, html_url, score, repository }) => ({
+            name,
+            path,
+            sha,
+            html_url,
+            score,
+            repository: repository.full_name,
+        }))
     }
 }

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -617,18 +617,13 @@ export class GitHubClient implements GitHub {
         }
     }
 
-    async getFileRevision(
-        filename: string,
-        options?: { ref?: string }
-    ): Promise<WorkspaceFile> {
-        const { client, owner, repo, ref, commitSha } = await this.client()
-        const resolvedRef = options?.ref || commitSha || ref
-        if (!resolvedRef) throw new Error("ref or commitSha is required")
+    async getFile(filename: string, ref: string): Promise<WorkspaceFile> {
+        const { client, owner, repo } = await this.client()
         const { data: content } = await client.rest.repos.getContent({
             owner,
             repo,
             path: filename,
-            ref: resolvedRef,
+            ref,
         })
         if ("content" in content) {
             return {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1327,6 +1327,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1412,6 +1421,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1078,7 +1078,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1405,14 +1405,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1399,6 +1399,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/github.genai.mts
+++ b/packages/sample/genaisrc/github.genai.mts
@@ -1,0 +1,20 @@
+script({
+    model: "openai:gpt-3.5-turbo",
+    tests: {},
+})
+const issues = await github.listIssues()
+console.log(issues.slice(0, 5).map((i) => i.title))
+const issueComments = await github.listIssueComments(issues[0].number)
+console.log(issueComments)
+
+const prs = await github.listPullRequests()
+console.log(prs.slice(0, 5).map((i) => i.title))
+
+const prcs = await github.listPullRequestReviewComments(prs[0].number)
+console.log(prcs.map((i) => i.body))
+
+const pkg = await github.getFile("package.json", "main")
+console.log(pkg.content.slice(0, 50) + "...")
+
+const res = await github.searchCode("HTMLToText")
+console.log(res)

--- a/packages/sample/genaisrc/github.genai.mts
+++ b/packages/sample/genaisrc/github.genai.mts
@@ -2,8 +2,8 @@ script({
     model: "openai:gpt-3.5-turbo",
     tests: {},
 })
-const issues = await github.listIssues()
-console.log(issues.slice(0, 5).map((i) => i.title))
+const issues = await github.listIssues({ per_page: 5 })
+console.log(issues.map((i) => i.title))
 const issueComments = await github.listIssueComments(issues[0].number)
 console.log(issueComments)
 
@@ -18,3 +18,10 @@ console.log(pkg.content.slice(0, 50) + "...")
 
 const res = await github.searchCode("HTMLToText")
 console.log(res)
+
+const runs = await github.listWorkflowRuns("build.yml", { per_page: 5 })
+console.log(runs.map((i) => i.status))
+
+const jobs = await github.listWorkflowJobs(runs[0].id)
+// redacted job log
+console.log(jobs[0].content)

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1111,7 +1111,7 @@ interface Parsers {
     HTMLToText(
         content: string | WorkspaceFile,
         options?: HTMLToTextOptions
-    ): string
+    ): Promise<string>
 
     /**
      * Convert HTML to markdown
@@ -1438,14 +1438,12 @@ interface GitHub {
      * @param filepath
      * @param options
      */
-    getFileRevision(
+    getFile(
         filepath: string,
-        options?: {
-            /**
-             * commit sha, branch name or tag name
-             */
-            ref?: string
-        }
+        /**
+         * commit sha, branch name or tag name
+         */
+        ref: string
     ): Promise<WorkspaceFile>
 }
 

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1360,6 +1360,15 @@ interface GitHubComment {
 
 interface GitHubPullRequest extends GitHubIssue {}
 
+interface GitHubCodeSearchResult {
+    name: string
+    path: string
+    sha: string
+    html_url: string
+    score: number
+    repository: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -1445,6 +1454,14 @@ interface GitHub {
          */
         ref: string
     ): Promise<WorkspaceFile>
+
+    /**
+     * Searches code in a GitHub repository
+     */
+    searchCode(
+        query: string,
+        options?: { per_page?: number; page?: number }
+    ): Promise<GitHubCodeSearchResult[]>
 }
 
 interface MD {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -1432,6 +1432,21 @@ interface GitHub {
         pull_number: number,
         options?: { per_page?: number; page?: number }
     ): Promise<GitHubComment[]>
+
+    /**
+     * Gets the content of a file from a GitHub repository
+     * @param filepath
+     * @param options
+     */
+    getFileRevision(
+        filepath: string,
+        options?: {
+            /**
+             * commit sha, branch name or tag name
+             */
+            ref?: string
+        }
+    ): Promise<WorkspaceFile>
 }
 
 interface MD {


### PR DESCRIPTION
This pull request includes several changes. First, it adds a new method called `getFileRevision` to the `GitHubClient` class, which allows retrieving file content by ref. Second, it adds concurrency to the workflow, improving its performance. Third, it introduces code search functionality and includes a sample script for GitHub integration. Finally, it removes the `env.secrets` section and adds documentation for comparing data using the `defDiff` function.

<!-- genaiscript begin pr-describe --><hr/>

- 🩹 The `GitHubClient` class in the file `packages/core/src/github.ts` was refactored. The `client()` method now destructures `conn` to extract the `token` and `apiUrl`. The resolved object now includes all properties of `conn` along with `client`.
- 🚀 New functionalities have been added to the `GitHubClient` class: 
  - `getFile()` - retrieves a file's content from a GitHub repository
  - `searchCode()` - searches code in a GitHub repository
- 🔄 The interface `Parsers` in `packages/core/src/types/prompt_template.d.ts` has its `HTMLToText` method changed to return `Promise<string>` instead of `string`. 
- 🎊 A new interface `GitHubCodeSearchResult` has been introduced in `packages/core/src/types/prompt_template.d.ts`. 
- 😎 Additionally, the interface `GitHub` in `packages/core/src/types/prompt_template.d.ts` now includes `getFile()` and `searchCode()` methods.
- 📚 The `docs/src/content/docs/reference/scripts/context.md` documentation file underwent some changes. A section about `env.secrets` was removed, instructions on language specification in `def` were added, and a new `defDiff` function was explained.
- 🎉 A new script file `packages/sample/genaisrc/github.genai.mts` was created. It uses the `GitHubClient` class to list issues, get issue comments, list pull requests, get pull requests comments, obtain a file's content from a repo, and search code from a repo.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11076675798)



<!-- genaiscript end pr-describe -->

