### PR TITLE
Adjust flexPromptNode logic to handle token calculation and flex checks more accurately

### DIFF
--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -30,6 +30,7 @@ import { resolveTokenEncoder } from "./encoders"
 import { expandFiles } from "./fs"
 import { interpolateVariables } from "./mustache"
 import { createDiff } from "./diff"
+import { total } from "@tidyjs/tidy"
 
 // Definition of the PromptNode interface which is an essential part of the code structure.
 export interface PromptNode extends ContextExpansionOptions {
@@ -787,7 +788,7 @@ async function flexPromptNode(
         0
     )
 
-    if (totalTokens < flexTokens) {
+    if (totalTokens <= flexTokens) {
         // No need to flex
         return
     }
@@ -799,8 +800,17 @@ async function flexPromptNode(
             (a.priority ?? PRIORITY_DEFAULT) - (b.priority ?? PRIORITY_DEFAULT)
     )
     const flexNodes = nodes.filter((n) => n.flex !== undefined)
-    const totalFlex = flexNodes.reduce((total, node) => total + node.flex, 0)
+    const totalFlexTokeens = flexNodes.reduce(
+        (total, node) => total + (node.tokens ?? 0),
+        0
+    )
 
+    // checking flexNodes sizes
+    if (totalFlexTokeens <= flexTokens) {
+        return
+    }
+
+    const totalFlex = flexNodes.reduce((total, node) => total + node.flex, 0)
     const totalReserve = 0
     const totalRemaining = Math.max(0, flexTokens - totalReserve)
     for (const node of flexNodes) {

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -800,13 +800,13 @@ async function flexPromptNode(
             (a.priority ?? PRIORITY_DEFAULT) - (b.priority ?? PRIORITY_DEFAULT)
     )
     const flexNodes = nodes.filter((n) => n.flex !== undefined)
-    const totalFlexTokeens = flexNodes.reduce(
+    const totalFlexTokens = flexNodes.reduce(
         (total, node) => total + (node.tokens ?? 0),
         0
     )
 
     // checking flexNodes sizes
-    if (totalFlexTokeens <= flexTokens) {
+    if (totalFlexTokens <= flexTokens) {
         return
     }
 

--- a/packages/sample/genaisrc/flex.genai.mts
+++ b/packages/sample/genaisrc/flex.genai.mts
@@ -21,9 +21,9 @@ script({
 def("FILE", env.files, { flex: 1 })
 
 // will be trimmed
-$`What is Markdown?
- Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents. Created by John Gruber in 2004, Markdown is now one of the world’s most popular markup languages. 
+$`(ignore What is Markdown?
+ Markdown is a lightweight markup language that you can use to add formatting elements to plaintext text documents. Created by John Gruber in 2004, Markdown is now one of the world’s most popular markup languages.)
 PRINT ABRACADABRA!`.flex(2)
 
-$`This one is flexed.
+$`(ignore This one is flexed.)
 PRINT MONKEY!`.flex(1)


### PR DESCRIPTION
This pull request adjusts the `flexPromptNode` logic to handle token calculation and flex checks more accurately. Previously, there was an issue where the flex nodes were not being properly accounted for when calculating the total tokens. This PR fixes that issue by correctly summing the tokens of the flex nodes. Additionally, the PR includes a check to skip flexing if the total flex tokens are less than or equal to the available flex tokens. Overall, these changes improve the accuracy and reliability of the `flexPromptNode` function.

<!-- genaiscript begin pr-describe --><hr/>

- A new import statement `import { total } from "@tidyjs/tidy"` has been added, indicating a new dependency or functionality that might be used in the code. :package:

- The conditional check `if (totalTokens < flexTokens)` has been modified to `if (totalTokens <= flexTokens)`. It seems the function should not proceed if totalTokens is not strictly greater than flexTokens. :arrows_counterclockwise:

- A new code block has been introduced to check whether `totalFlexTokeens` is less than or equal to `flexTokens`. If this condition is met, the function returns early. This may be a new optimization or correction. :spiral_notepad:

- The variable `totalFlex` was computed by reducing `flexNodes` initially. Now, before that calculation, a new variable `totalFlexTokeens` is evaluated by reducing `flexNodes` but with a different value (`node.tokens`). :bar_chart:

- It appears that the function 'flexPromptNode' may have enhanced its validation and conditional checks to handle different scenarios more effectively. :rocket:

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11109429136)



<!-- genaiscript end pr-describe -->

