### PR TITLE
Refactor imports and update changelog formatting

### DIFF
--- a/docs/src/content/docs/reference/scripts/system.mdx
+++ b/docs/src/content/docs/reference/scripts/system.mdx
@@ -160,7 +160,7 @@ index N in the above snippets, and then be prefixed with exactly the same whites
 the original snippets above. See also the following examples of the expected response format.
 
 CHANGELOG:
-\`\`\`changelog
+\`\`\`\`\`changelog
 ChangeLog:1@<file>
 Description: <summary>.
 OriginalCode@4-6:
@@ -190,7 +190,7 @@ OriginalCode@23-23:
 [23] <white space> <original code line>
 ChangedCode@23-23:
 [23] <white space> <changed code line>
-\`\`\`
+\`\`\`\`\`
 `
 `````
 

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -54,7 +54,6 @@ import {
     normalizeInt,
     logVerbose,
     logError,
-    delay,
     dotGenaiscriptPath,
 } from "../../core/src/util"
 import { YAMLStringify } from "../../core/src/yaml"
@@ -70,6 +69,7 @@ import { resolveTokenEncoder } from "../../core/src/encoders"
 import { writeFile } from "fs/promises"
 import { writeFileSync } from "node:fs"
 import { prettifyMarkdown } from "../../core/src/markdown"
+import { delay } from "es-toolkit"
 
 async function setupTraceWriting(trace: MarkdownTrace, filename: string) {
     logVerbose(`trace: ${filename}`)

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -29,7 +29,6 @@ import {
     normalizeInt,
     logInfo,
     logVerbose,
-    delay,
     tagFilter,
     toStringList,
 } from "../../core/src/util"
@@ -40,6 +39,7 @@ import {
     PromptScriptTestResult,
 } from "../../core/src/server/messages"
 import { generatePromptFooConfiguration } from "../../core/src/test"
+import { delay } from "es-toolkit"
 
 /**
  * Parses model specifications from a string and returns a ModelOptions object.

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -8,10 +8,6 @@ export function trimNewlines(s: string) {
     return s?.replace(/^\n*/, "").replace(/\n*$/, "")
 }
 
-export function delay<T>(millis: number, value?: T): Promise<T | undefined> {
-    return new Promise((resolve) => setTimeout(() => resolve(value), millis))
-}
-
 export function strcmp(a: string, b: string) {
     if (a == b) return 0
     if (a < b) return -1
@@ -195,14 +191,6 @@ export function logError(msg: string | Error | SerializedError) {
 export function concatArrays<T>(...arrays: T[][]): T[] {
     if (arrays.length == 0) return []
     return arrays[0].concat(...arrays.slice(1))
-}
-
-export function randomRange(min: number, max: number) {
-    return Math.round(Math.random() * (max - min) + min)
-}
-
-export function last<T>(a: ArrayLike<T>) {
-    return a[a.length - 1]
 }
 
 export function groupBy<T>(

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -28,7 +28,6 @@ import { MarkdownTrace } from "../../core/src/trace"
 import {
     dotGenaiscriptPath,
     sha256string,
-    delay,
     logInfo,
     groupBy,
 } from "../../core/src/util"
@@ -36,6 +35,7 @@ import { CORE_VERSION } from "../../core/src/version"
 import { Fragment, GenerationResult } from "../../core/src/generation"
 import { parametersToVars } from "../../core/src/parameters"
 import { randomHex } from "../../core/src/crypto"
+import { delay } from "es-toolkit"
 
 export const FRAGMENTS_CHANGE = "fragmentsChange"
 export const AI_REQUEST_CHANGE = "aiRequestChange"


### PR DESCRIPTION
This pull request includes refactoring of imports and updating of changelog formatting across project files.

<!-- genaiscript begin pr-describe --><hr/>

- The `delay` function has been shifted from core utility (`../../core/src/util`) to a different library called `es-toolkit` in three files namely `run.ts`, `test.ts`, and `state.ts.` This seems to be a part of some refactoring effort. 💼 
- In the markdown file `system.mdx`, the format for change log entries has been updated. The change log code block now uses six backticks for demarcation instead of four. This seems to be a minor formatting adjustment for better markdown styling.📘
- Also, in `util.ts`, certain utility functions like `delay`, `randomRange`, and `last` have been removed, indicating a probable optimization or tidying up of the codebase.🧹

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11112853220)



<!-- genaiscript end pr-describe -->

