### PR TITLE
Prompt reorg for caching + usage collection

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/docs/src/content/docs/reference/scripts/context.md
+++ b/docs/src/content/docs/reference/scripts/context.md
@@ -106,7 +106,7 @@ def("DIFF", gitdiff, { language: "diff" })
 ### Referencing
 
 The `def` function returns a variable name that can be used in the prompt.
-The name might be formatted diferently to accommodate the model's preference.
+The name might be formatted differently to accommodate the model's preference.
 
 ```js "const f = "
 const f = def("FILE", file)
@@ -180,6 +180,15 @@ def("FILE", env.files, { sliceTail: 100 })
 
 ```js "sliceSample: 100"
 def("FILE", env.files, { sliceSample: 100 })
+```
+
+### Prompt Caching
+
+You can specify `ephemeral: true` to turn on some prompt caching optimization. In paricular, a `def` with `ephemeral` will be rendered at the back of the prompt
+to persist the [cache prefix](https://openai.com/index/api-prompt-caching/).
+
+```js
+def("FILE", env.files, { ephemeral: true })
 ```
 
 ## Data definition (`defData`)

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -530,7 +530,7 @@ export async function runScript(
     for (const [key, value] of Object.entries(usages)) {
         if (value.total_tokens > 0)
             logVerbose(
-                `  ${key}: ${value.total_tokens} (${value.prompt_tokens} => ${value.completion_tokens})`
+                `tokens:  ${key}, ${value.total_tokens} (${value.prompt_tokens} => ${value.completion_tokens})`
             )
     }
     if (outTraceFilename) logVerbose(`  trace: ${outTraceFilename}`)

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -527,7 +527,7 @@ export async function runScript(
         return fail("error annotations found", ANNOTATION_ERROR_CODE)
 
     logVerbose("genaiscript: done")
-    for (const [key, value] of Object.entries(result.usages)) {
+    for (const [key, value] of Object.entries(usages)) {
         if (value.total_tokens > 0)
             logVerbose(
                 `  ${key}: ${value.total_tokens} (${value.prompt_tokens} => ${value.completion_tokens})`

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -517,7 +517,7 @@ async function processChatMessage(
         if (needsNewTurn) return undefined
     }
 
-    return structurifyChatSession(messages, schemas, genVars, options, {
+    return structurifyChatSession(messages, schemas, genVars, options, usages, {
         resp,
     })
 }
@@ -556,9 +556,9 @@ function accumulateChatUsage(
             prompt_tokens: 0,
             total_tokens: 0,
         })
-    u.completion_tokens += u.completion_tokens
-    u.prompt_tokens += u.prompt_tokens
-    u.total_tokens += u.total_tokens
+    u.completion_tokens += usage.completion_tokens ?? 0
+    u.prompt_tokens += usage.prompt_tokens ?? 0
+    u.total_tokens += usage.total_tokens ?? 0
 }
 
 export async function executeChatSession(

--- a/packages/core/src/chattypes.ts
+++ b/packages/core/src/chattypes.ts
@@ -18,6 +18,15 @@ export interface AICIRequest {
 }
 
 // Aliases for OpenAI chat completion types
+export type ChatCompletionUsage = Omit<
+    OpenAI.Completions.CompletionUsage,
+    "completion_tokens_details"
+>
+
+/**
+ * Per model storage of chat completion usages.
+ */
+export type ChatCompletionUsages = Record<string, ChatCompletionUsage>
 
 // Text content part of a chat completion
 export type ChatCompletionContentPartText =
@@ -99,6 +108,7 @@ export interface ChatCompletionResponse {
     toolCalls?: ChatCompletionToolCall[] // List of tool calls made during the response
     finishReason?: // Reason why the chat completion finished
     "stop" | "length" | "tool_calls" | "content_filter" | "cancel" | "fail"
+    usage?: ChatCompletionUsage // Usage information for the completion
 }
 
 // Alias for OpenAI's API error type

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -105,4 +105,5 @@ export interface GenerationOptions
     }
     vars?: PromptParameters // Variables for prompt customization
     stats: GenerationStats // Statistics of the generation
+    usages: ChatCompletionUsages
 }

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -1,7 +1,11 @@
 // Import necessary modules and interfaces
 import { CancellationToken } from "./cancellation"
 import { LanguageModel } from "./chat"
-import { ChatCompletionMessageParam, ChatCompletionsOptions } from "./chattypes"
+import {
+    ChatCompletionMessageParam,
+    ChatCompletionsOptions,
+    ChatCompletionUsages,
+} from "./chattypes"
 import { MarkdownTrace } from "./trace"
 
 // Represents a code fragment with associated files
@@ -55,6 +59,11 @@ export interface GenerationResult extends GenerationOutput {
      * Completion status from the language model
      */
     finishReason?: string
+
+    /**
+     * Token usage statistics if reported by LLM
+     */
+    usages?: ChatCompletionUsages
 
     /**
      * Optional label for the run

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -43,7 +43,6 @@ export async function createPromptContext(
     options: GenerationOptions,
     model: string
 ) {
-    const { infoCb } = options || {}
     const { generator, ...varsNoGenerator } = vars
     // Clone variables to prevent modification of the original object
     const env = { generator, ...structuredClone(varsNoGenerator) }

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -234,7 +234,7 @@ export async function createPromptContext(
     })
 
     // Freeze project options to prevent modification
-    const projectOptions = Object.freeze({ prj, vars, env })
+    const projectOptions = Object.freeze({ prj, env })
     const ctx: PromptContext & RunPromptContextNode = {
         ...createChatGenerationContext(options, trace, projectOptions),
         script: () => {},

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -518,13 +518,16 @@ export interface PromptNodeRender {
  */
 async function layoutPromptNode(mode: string, root: PromptNode) {
     let changed = false
+    const variables: PromptNode["type"][] = ["def", "image"]
+
     await visitNode(root, {
         node: (n) => {
             // sort children
             const before = n.children?.map((c) => c.preview)?.join("\n")
             n.children?.sort(
                 (a, b) =>
-                    (a.type === "def" ? 1 : -1) - (b.type === "def" ? 1 : -1)
+                    (variables.includes(a.type) ? 1 : -1) -
+                    (variables.includes(b.type) ? 1 : -1)
             )
             const after = n.children?.map((c) => c.preview)?.join("\n")
             changed = changed || before !== after

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -52,6 +52,10 @@ export interface PromptNode extends ContextExpansionOptions {
     children?: PromptNode[] // Child nodes for hierarchical structure
     error?: unknown // Error information if present
     tokens?: number // Token count for the node
+    /**
+     * This text is likely to change within 5 to 10 minutes.
+     */
+    ephemeral?: boolean
 
     /**
      * Rendered markdown preview of the node
@@ -518,16 +522,12 @@ export interface PromptNodeRender {
  */
 async function layoutPromptNode(mode: string, root: PromptNode) {
     let changed = false
-    const variables: PromptNode["type"][] = ["def", "image"]
-
     await visitNode(root, {
         node: (n) => {
             // sort children
             const before = n.children?.map((c) => c.preview)?.join("\n")
             n.children?.sort(
-                (a, b) =>
-                    (variables.includes(a.type) ? 1 : -1) -
-                    (variables.includes(b.type) ? 1 : -1)
+                (a, b) => (a.ephemeral ? 1 : -1) - (b.ephemeral ? 1 : -1)
             )
             const after = n.children?.map((c) => c.preview)?.join("\n")
             changed = changed || before !== after

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -236,7 +236,6 @@ export async function runTemplate(
             connection.configuration,
             cancellationToken,
             messages,
-            vars,
             functions,
             schemas,
             completer,
@@ -252,6 +251,7 @@ export async function runTemplate(
             genVars = {},
             error,
             finishReason,
+            usages,
         } = output
         let { text, annotations } = output
 
@@ -458,6 +458,7 @@ export async function runTemplate(
             genVars,
             schemas,
             json,
+            usages,
         }
 
         // If there's an error, provide status text

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -227,12 +227,11 @@ export function createChatGenerationContext(
     trace: MarkdownTrace,
     projectOptions: {
         prj: Project
-        vars: ExpansionVariables
         env: ExpansionVariables
     }
 ): RunPromptContextNode {
     const { cancellationToken, infoCb } = options || {}
-    const { prj, vars, env } = projectOptions
+    const { prj, env } = projectOptions
     const turnCtx = createChatTurnGenerationContext(options, trace)
     const node = turnCtx.node
 
@@ -535,7 +534,6 @@ export function createChatGenerationContext(
                     connection.configuration,
                     cancellationToken,
                     messages,
-                    vars,
                     tools,
                     schemas,
                     completer,

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -35,6 +35,7 @@ import { checkCancelled } from "./cancellation"
 import {
     ChatCompletionMessageParam,
     ChatCompletionSystemMessageParam,
+    ChatCompletionUsages,
 } from "./chattypes"
 import { parseModelIdentifier, resolveModelConnectionInfo } from "./models"
 import {
@@ -230,7 +231,7 @@ export function createChatGenerationContext(
         env: ExpansionVariables
     }
 ): RunPromptContextNode {
-    const { cancellationToken, infoCb } = options || {}
+    const { cancellationToken, infoCb, usages } = options || {}
     const { prj, env } = projectOptions
     const turnCtx = createChatTurnGenerationContext(options, trace)
     const node = turnCtx.node

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -741,6 +741,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -881,6 +881,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -803,6 +803,10 @@ interface ContextExpansionOptions {
      * It defaults to 1 on all elements.
      */
     flex?: number
+    /**
+     * This text is likely to change and will probably break the prefix cache.
+     */
+    ephemeral?: boolean
 }
 
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -943,6 +943,7 @@ interface RunPromptResult {
         | "content_filter"
         | "cancel"
         | "fail"
+    usages?: ChatCompletionUsages
 }
 
 /**


### PR DESCRIPTION
This pull request optimizes chat caching by moving definitions to the back of the prompt structure. The `layoutPromptNode` function is introduced to sort the children of a prompt node, ensuring that definitions are placed after other types of nodes. This change improves the efficiency of chat caching with OpenAI.

<!-- genaiscript begin pr-describe --><hr/>

- 🧩 A new function `layoutPromptNode` has been added which aims to optimize chat caching with OpenAI by reordering nodes inside the prompt. It places the "def" type nodes towards the end. This function is triggered before the node tracing functionality. 
  - The function works by sorting child nodes based on their type. Nodes with type "def" are pushed towards the end. 
  - It maps the preview field of children nodes before and after the sorting operation. Any changes detected in the preview result in the function returning true.
  - The returned value indicates whether there was a change in the order of the nodes.
- 🔄 The order in which nodes are processed during a prompt rendering operation has been updated. After resolving a prompt node, the new `layoutPromptNode` function is called. If it identifies a change in the order of the nodes, the trace of the prompt node is called again with the label "layout".  
- 🔃 The prompt rendering operation is further adjusted to accommodate this new structural change. 
  
All these modifications will help to better leverage OpenAI's chat caching functionality, thus potentially improving performance.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11131316389)



<!-- genaiscript end pr-describe -->

