### PR TITLE
Refactor paginatorToArray to use AsyncIterable instead of AsyncIterableIterator

### DIFF
--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -412,7 +412,7 @@ export async function githubCreatePullRequestReviews(
 }
 
 async function paginatorToArray<T, R>(
-    iterator: AsyncIterableIterator<T>,
+    iterator: AsyncIterable<T>,
     count: number,
     iteratorItem: (item: T) => R[],
     elementFilter?: (item: R) => boolean


### PR DESCRIPTION
This pull request refactors the `paginatorToArray` function to use `AsyncIterable` instead of `AsyncIterableIterator`. The change simplifies the code and improves readability.