### PR TITLE
tool metadata parsing

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/docs/src/content/docs/reference/scripts/system.mdx
+++ b/docs/src/content/docs/reference/scripts/system.mdx
@@ -107,12 +107,6 @@ Agent that can find, search or read files to accomplish tasks
 `````js wrap title="system.agent_fs"
 system({
     title: "Agent that can find, search or read files to accomplish tasks",
-    parameters: {
-        agentFsModel: {
-            type: "string",
-            description: "Model to use for the agent",
-        },
-    },
 })
 
 const model = env.vars.agentFsModel
@@ -172,12 +166,6 @@ Agent that can query Git to accomplish tasks.
 `````js wrap title="system.agent_git"
 system({
     title: "Agent that can query Git to accomplish tasks.",
-    parameters: {
-        agentGitModel: {
-            type: "string",
-            description: "Model to use for the agent",
-        },
-    },
 })
 
 const model = env.vars.agentGitModel
@@ -234,12 +222,6 @@ Agent that can query GitHub to accomplish tasks.
 `````js wrap title="system.agent_github"
 system({
     title: "Agent that can query GitHub to accomplish tasks.",
-    parameters: {
-        agentGithubModel: {
-            type: "string",
-            description: "Model to use for the agent",
-        },
-    },
 })
 
 const model = env.vars.agentGithubModel

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/core/src/genaisrc/system.agent_fs.genai.mjs
+++ b/packages/core/src/genaisrc/system.agent_fs.genai.mjs
@@ -1,11 +1,5 @@
 system({
     title: "Agent that can find, search or read files to accomplish tasks",
-    parameters: {
-        agentFsModel: {
-            type: "string",
-            description: "Model to use for the agent",
-        },
-    },
 })
 
 const model = env.vars.agentFsModel

--- a/packages/core/src/genaisrc/system.agent_git.genai.mjs
+++ b/packages/core/src/genaisrc/system.agent_git.genai.mjs
@@ -1,11 +1,5 @@
 system({
     title: "Agent that can query Git to accomplish tasks.",
-    parameters: {
-        agentGitModel: {
-            type: "string",
-            description: "Model to use for the agent",
-        },
-    },
 })
 
 const model = env.vars.agentGitModel

--- a/packages/core/src/genaisrc/system.agent_github.genai.mjs
+++ b/packages/core/src/genaisrc/system.agent_github.genai.mjs
@@ -1,11 +1,5 @@
 system({
     title: "Agent that can query GitHub to accomplish tasks.",
-    parameters: {
-        agentGithubModel: {
-            type: "string",
-            description: "Model to use for the agent",
-        },
-    },
 })
 
 const model = env.vars.agentGithubModel

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -386,6 +386,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -678,7 +683,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -699,6 +699,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -448,6 +448,11 @@ interface PromptScript
      * Set if this is a system prompt.
      */
     isSystem?: boolean
+
+    /**
+     * List of tools defined in the script
+     */
+    defTools?: { id: string, description: string }[]
 }
 
 /**
@@ -740,7 +745,7 @@ interface ExpansionVariables {
 
 type MakeOptional<T, P extends keyof T> = Partial<Pick<T, P>> & Omit<T, P>
 
-type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation">
+type PromptArgs = Omit<PromptScript, "text" | "id" | "jsSource" | "activation" | "defTools">
 
 type PromptSystemArgs = Omit<
     PromptArgs,

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -761,6 +761,7 @@ type PromptSystemArgs = Omit<
     | "responseSchema"
     | "files"
     | "modelConcurrency"
+    | "parameters"
 >
 
 type StringLike = string | WorkspaceFile | WorkspaceFile[]


### PR DESCRIPTION


<!-- genaiscript begin pr-describe --><hr/>

- The parameters of agent tasks have been removed from the system scripts including `system.agent_fs`, `system.agent_git` and `system.agent_github`. This implies that agent tasks may now consume parameters differently.
- A new function `parsePromptScriptTools` has been introduced to capture the tools from javascript source files. These tools have been removed from the `scanTools` function and incorporated within `fixPromptDefinitions`.
- The `fixPromptDefinitions` function now uses `defTools` instead of scanning tools with `scanTools` function.
- The definition of the tools, `defTools`, has been added to the `PromptScript` interface.
- Changes have been made to the `git-release-notes` script, there is now the usage of the `git.lastTag()` and `git.log()` methods instead of manual execution of Git commands. The enhanced methods are likely more error-proof and easier to maintain.
- In the `git-release-notes`, the definition of `COMMITS` has been updated to join the commit messages into a string before passing to the `def` function.
- Explicit instructions have been added not to wrap text in markdown sections for the `git-release-notes` script. 

These changes appear to improve the maintainability of the system scripts and enhance the organization of tools' description. Improvements to the `git-release-notes` script make it likely more reliable and easier to use. 👍

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11134555628)



<!-- genaiscript end pr-describe -->

