### PR TITLE
small model configuration and "small" alias

### DIFF
--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/docs/genaisrc/genaiscript.d.ts
+++ b/docs/genaisrc/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/docs/src/content/docs/blog/gentle-introduction-to-genaiscript.md
+++ b/docs/src/content/docs/blog/gentle-introduction-to-genaiscript.md
@@ -95,7 +95,7 @@ GitHub Models, Ollama and more.
 script({
     title: "Technical proofreading",
     description: "Reviews the text as a tech writer.",
-    model: "openai:gpt-3.5-turbo",
+    model: "openai:gpt-4o",
     temperature: 0.1,
 })
 def("FILES", env.files)

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -146,10 +146,11 @@ script({
 
 :::tip[Default Model Configuration]
 
-Use `GENAISCRIPT_DEFAULT_MODEL` in your `.env` file to set the default model.
+Use `GENAISCRIPT_DEFAULT_MODEL` and `GENAISCRIPT_DEFAULT_SMALL_MODEL` in your `.env` file to set the default model and small model.
 
 ```txt
 GENAISCRIPT_DEFAULT_MODEL=openai:gpt-4o
+GENAISCRIPT_DEFAULT_SMALL_MODEL=openai:gpt-4o-mini
 ```
 
 :::

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -28,16 +28,26 @@ If you do not have access to an LLM, you can try [GitHub Models](#github), [GitH
 
 :::
 
-## model selection
+## Model selection
 
 The model used by the script is configured throught the `model` field in the `script` function.
 The model name is formatted as `provider:model-name`, where `provider` is the LLM provider
 and the `model-name` is provider specific.
 
-```js 'model: "openai:gpt-4"'
+```js 'model: "openai:gpt-4o"'
 script({
-    model: "openai:gpt-4",
+    model: "openai:gpt-4o",
 })
+```
+
+You can also use the `small` and `large` aliases to use the default configured small and large models.
+
+```js 'model: "small"'
+script({ model: "small" })
+```
+
+```js 'model: "large"'
+script({ model: "large" })
 ```
 
 The model can also be overriden from the [cli run command](/genaiscript/reference/cli/run#model).

--- a/docs/src/content/docs/getting-started/tutorial.md
+++ b/docs/src/content/docs/getting-started/tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorial Notebook
 sidebar:
-  order: 100
+    order: 100
 description: Learn how to use GenAIScript with this interactive tutorial notebook featuring executable JavaScript code blocks.
 keywords: tutorial, GenAIScript notebook, interactive learning, JavaScript, markdown
 ---
@@ -9,7 +9,6 @@ keywords: tutorial, GenAIScript notebook, interactive learning, JavaScript, mark
 This Notebook is a GenAISCript tutorial. It is a Markdown document where each JavaScript code section is a runnable GenAIScript. You can execute each code block individually and see the results in the output section below the code block. To open this notebook in Visual Studio Code, press **F1** and run **GenAIScript: Create GenAIScript Markdown Notebook**.
 
 Follow the steps in [configuration](https://microsoft.github.io/genaiscript/getting-started/configuration) to set up your environment and LLM access.
-
 
 ## Prompt as code
 
@@ -45,10 +44,9 @@ Say "hello!" in emojis
 
 <!-- genaiscript output end -->
 
-
 The `$` function formats the strings and write them to the user message. This user message is added to the chat messages and sent to the LLM API. Under the snippet, you can review both the **user** message (that our program generated) and the **assistant** (LLM) response.
 
-You can run the code block by clicking the **Execute Cell** button on the top left corner of the code block. It will be default try to use the `openai:gpt-3.5-turbo` LLM. If you need to use a different model, update the `model` field in the front matter at the start of the document. There are many options documented in [configuration](https://microsoft.github.io/genaiscript/getting-started/configuration).
+You can run the code block by clicking the **Execute Cell** button on the top left corner of the code block. It will be default try to use the LLMs from various providers. If you need to use a different model, update the `model` field in the front matter at the start of the document. There are many options documented in [configuration](https://microsoft.github.io/genaiscript/getting-started/configuration).
 
 Once the execution is done, you will also an additional **trace** entry that allows you to dive in the internal details of the GenAIScript execution. This is very helpful to diagnose issues with your prompts. The trace can be quite large so it is not serialized in the markdown file.
 
@@ -88,7 +86,6 @@ $`Respond with a markdown list`
 
 <!-- genaiscript output end -->
 
-
 To recap, the GenAIScript runs and generates a user messages; that gets sent to the LLM. You can review the user message (and others) in the trace.
 
 ## `def` and `env.files`
@@ -105,7 +102,7 @@ $`Summarize FILE in one short sentence. Respond as plain text.`
 <details>
 <summary>👤 user</summary>
 
-``````markdown wrap
+````markdown wrap
 FILE:
 
 ```md file="src/samples/markdown.md"
@@ -125,7 +122,7 @@ For example, to denote a heading, you add a number sign before it (e.g., # Headi
 ```
 
 Summarize FILE in one short sentence. Respond as plain text.
-``````
+````
 
 </details>
 
@@ -139,7 +136,6 @@ Markdown is a lightweight markup language for formatting plain text, using synta
 </details>
 
 <!-- genaiscript output end -->
-
 
 In GenAIScript, the [`env.files`](https://microsoft.github.io/genaiscript/reference/scripts/context/#environment-env) variable contains the [list of files in context](https://microsoft.github.io/genaiscript/reference/script/files), which can be determined by a user selection in the UI, CLI arguments, or pre-configured like in this script. You can change the files in `env.files` by editing the `files` field in the front matter at the start of the document.
 
@@ -160,7 +156,7 @@ $`Summarize FILE in one short sentence. Respond as plain text.`
 <details>
 <summary>👤 user</summary>
 
-``````markdown wrap
+````markdown wrap
 FILE:
 
 ```md file="src/samples/markdown.md"
@@ -180,7 +176,7 @@ For example, to denote a heading, you add a number sign before it (e.g., # Headi
 ```
 
 Summarize FILE in one short sentence. Respond as plain text.
-``````
+````
 
 </details>
 
@@ -195,14 +191,18 @@ Markdown is a lightweight markup language for formatting plaintext documents, di
 
 <!-- genaiscript output end -->
 
-
 ## Tools
 
 You can register JavaScript functions as tools that the LLM will call as needed.
 
 ```js
 // requires openai, azure openai or github models
-defTool("fetch", "Download text from a URL", { url: "https://...", }, ({ url }) => fetchText(url))
+defTool(
+    "fetch",
+    "Download text from a URL",
+    { url: "https://..." },
+    ({ url }) => fetchText(url)
+)
 
 $`Summarize https://raw.githubusercontent.com/microsoft/genaiscript/main/README.md in 1 sentence.`
 ```
@@ -214,12 +214,10 @@ You can run nested LLMs to execute tasks on other, smaller models.
 ```js
 // summarize each files individually
 for (const file of env.files) {
-    const { text } = await runPrompt(
-        (_) => {
-            _.def("FILE", file)
-            _.$`Summarize the FILE.`
-        },
-    )
+    const { text } = await runPrompt((_) => {
+        _.def("FILE", file)
+        _.$`Summarize the FILE.`
+    })
     def("FILE", { ...file, content: text })
 }
 // summarize all summaries

--- a/docs/src/content/docs/getting-started/your-first-genai-script.mdx
+++ b/docs/src/content/docs/getting-started/your-first-genai-script.mdx
@@ -97,7 +97,7 @@ def("FILES", env.files)
 <details open>
 <summary>👤 user</summary>
 
-``````markdown wrap
+````markdown wrap
 FILES:
 
 ```md file="src/samples/markdown.md"
@@ -115,7 +115,7 @@ Using Markdown is different than using a WYSIWYG editor. In an application like 
 
 For example, to denote a heading, you add a number sign before it (e.g., # Heading One). Or to make a phrase bold, you add two asterisks before and after it (e.g., **this text is bold**). It may take a while to get used to seeing Markdown syntax in your text, especially if you’re accustomed to WYSIWYG applications. The screenshot below shows a Markdown file displayed in the Visual Studio Code text editor....
 ```
-``````
+````
 
 </details>
 
@@ -137,7 +137,7 @@ Review the documents in FILE and report the 2 most important issues.`
 <details>
 <summary>👤 user</summary>
 
-``````markdown wrap
+````markdown wrap
 FILES:
 
 ```md file="src/samples/markdown.md"
@@ -158,7 +158,7 @@ For example, to denote a heading, you add a number sign before it (e.g., # Headi
 
 You are an expert technical writer and proofreader.
 Review the documents in FILE and report the 2 most important issues.
-``````
+````
 
 </details>
 
@@ -192,7 +192,7 @@ script({
     description: "Reviews the text as a tech writer.",
     group: "documentation",
     // model configuration
-    model: "openai:gpt-3.5-turbo",
+    model: "large",
     temperature: 0,
 })
 def("FILES", env.files)
@@ -205,7 +205,7 @@ Review the documents in FILE and report the 2 most important issues.`
 <details>
 <summary>👤 user</summary>
 
-``````markdown wrap
+````markdown wrap
 FILES:
 
 ```md file="src/samples/markdown.md"
@@ -226,7 +226,7 @@ For example, to denote a heading, you add a number sign before it (e.g., # Headi
 
 You are an expert technical writer and proofreader.
 Review the documents in FILE and report the 2 most important issues.
-``````
+````
 
 </details>
 

--- a/docs/src/content/docs/guides/containerized-tools.md
+++ b/docs/src/content/docs/guides/containerized-tools.md
@@ -38,7 +38,7 @@ The LLM engine will invoke the tool to validate the syntax of the generated code
 
 ```js
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "large",
 })
 let container = undefined
 let sourceIndex = 0

--- a/docs/src/content/docs/guides/llm-as-tool.mdx
+++ b/docs/src/content/docs/guides/llm-as-tool.mdx
@@ -1,10 +1,9 @@
 ---
 title: LLM as a tool
 sidebar:
-  order: 60
+    order: 60
 description: Create tools and inline prompts using LLM models for executing various tasks
 keywords: LLM, inline prompts, tools, gpt-3.5-turbo, task automation
-
 ---
 
 It is possible [tools](/genaiscript/reference/scripts/tools)
@@ -13,8 +12,8 @@ to create a tool that uses an LLM model to execute a prompt.
 
 ```js "defTool" "runPrompt"
 defTool(
-    "llm-gpt35",
-    "Invokes gpt-3.5-turbo to execute a LLM request",
+    "llm-small",
+    "Invokes smaller LLM",
     {
         prompt: {
             type: "string",
@@ -23,10 +22,18 @@ defTool(
     },
     async ({ prompt }) =>
         await runPrompt(prompt, {
-            model: "openai:gpt-3.5-turbo",
-            label: "llm-gpt35",
+            model: "small",
+            label: "llm-small",
         })
 )
+```
+
+The `"small"` model is an alias that can be configured in the `script` metadata, cli arguments or environment variables.
+
+```js "small"
+script({
+    smallModel: "openai:gpt-4o-mini",
+})
 ```
 
 The inlined prompts can declare their own tools or use system prompts declaring them.

--- a/docs/src/content/docs/guides/search-and-fetch.mdx
+++ b/docs/src/content/docs/guides/search-and-fetch.mdx
@@ -24,7 +24,7 @@ You will need a [Bing Web Search API key](/genaiscript/reference/scripts/web-sea
     script({
         title: "plan-weekend",
         description: "Given details about my goals, help plan my weekend",
-        model: "openai:gpt-4",
+        model: "openai:gpt-4o",
     })
     ```
 3. Use the [`webSearch`](/genaiscript/reference/scripts/web-search/) function to 
@@ -85,7 +85,7 @@ Here's the complete GenAIScript:
 script({
     title: "plan-weekend",
     description: "Given details about my goals, help plan my weekend",
-    model: "openai:gpt-4",
+    model: "openai:gpt-4o",
 })
 
 const parkinfo = await retrieval.webSearch("mt rainier things to do")

--- a/docs/src/content/docs/guides/tool-agent.mdx
+++ b/docs/src/content/docs/guides/tool-agent.mdx
@@ -1,14 +1,13 @@
 ---
 title: Tool Agent
 sidebar:
-  order: 7
+    order: 7
 description: Learn how to define a built-in agent using functions for
-  decision-making and reasoning in arithmetic operations.
+    decision-making and reasoning in arithmetic operations.
 keywords: tool agent, arithmetic agent, function declaration, script parameters,
-  system.math
+    system.math
 genaiscript:
-  model: openai:gpt-3.5-turbo
-
+    model: openai:gpt-3.5-turbo
 ---
 
 import { Code } from "@astrojs/starlight/components"
@@ -51,15 +50,10 @@ defTool(
 )
 ```
 
-You can also simplify the parameter definition by provider an example object and the schema will be inferred._createMdxContent
+You can also simplify the parameter definition by provider an example object and the schema will be inferred.\_createMdxContent
 
 ```js "{ a: 1, b: 2 }"
-defTool(
-    "sum",
-    "Sum two numbers",
-    { a: 1, b: 2 },
-    ({ a, b }) => `${a + b}`
-)
+defTool("sum", "Sum two numbers", { a: 1, b: 2 }, ({ a, b }) => `${a + b}`)
 ```
 
 ## Parameters
@@ -94,49 +88,59 @@ and inline an arithmetic question.
 ```js wrap
 script({
     title: "math-agent",
-    model: "openai:gpt-35-turbo",
+    model: "small",
     description: "A port of https://ts.llamaindex.ai/examples/agent",
     parameters: {
-        "question": {
+        question: {
             type: "string",
-            default: "How much is 11 + 4? then divide by 3?"
+            default: "How much is 11 + 4? then divide by 3?",
         },
     },
     tests: {
         description: "Testing the default prompt",
-        keywords: "5"
-    }
+        keywords: "5",
+    },
 })
 
-defTool("sum", "Use this function to sum two numbers", {
-    type: "object",
-    properties: {
-        a: {
-            type: "number",
-            description: "The first number",
+defTool(
+    "sum",
+    "Use this function to sum two numbers",
+    {
+        type: "object",
+        properties: {
+            a: {
+                type: "number",
+                description: "The first number",
+            },
+            b: {
+                type: "number",
+                description: "The second number",
+            },
         },
-        b: {
-            type: "number",
-            description: "The second number",
-        },
+        required: ["a", "b"],
     },
-    required: ["a", "b"],
-}, ({ a, b }) => `${a + b}`)
+    ({ a, b }) => `${a + b}`
+)
 
-defTool("divide", "Use this function to divide two numbers", {
-    type: "object",
-    properties: {
-        a: {
-            type: "number",
-            description: "The first number",
+defTool(
+    "divide",
+    "Use this function to divide two numbers",
+    {
+        type: "object",
+        properties: {
+            a: {
+                type: "number",
+                description: "The first number",
+            },
+            b: {
+                type: "number",
+                description: "The second number",
+            },
         },
-        b: {
-            type: "number",
-            description: "The second number",
-        },
+        required: ["a", "b"],
     },
-    required: ["a", "b"],
-}, ({ a, b }) => `${a / b}`)
+    ({ a, b }) => `${a / b}`
+)
 
 $`Answer the following arithmetic question: 
 
@@ -149,51 +153,40 @@ $`Answer the following arithmetic question:
 <details>
 <summary>👤 user</summary>
 
-
 ```markdown wrap
-Answer the following arithmetic question: 
+Answer the following arithmetic question:
 
 How much is 11 + 4? then divide by 3?
 ```
 
-
 </details>
-
 
 <details open>
 <summary>🤖 assistant </summary>
 
--  📠 tool call `divide({"a":15,"b":3})` (`call_9p0oWdWpT6vGyxzwq2vJXHrq`)
+-   📠 tool call `divide({"a":15,"b":3})` (`call_9p0oWdWpT6vGyxzwq2vJXHrq`)
 
 </details>
 
-
 <details>
 <summary>🛠️ tool <code>call_9p0oWdWpT6vGyxzwq2vJXHrq</code></summary>
-
 
 ```json wrap
 5
 ```
 
-
 </details>
-
 
 <details open>
 <summary>🤖 assistant </summary>
-
 
 ```markdown wrap
 The result of (11 + 4) divided by 3 is 5.
 ```
 
-
 </details>
 
 {/* genaiscript output end */}
-
-
 
 ## Using `system.math`
 

--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -39,6 +39,7 @@ Options:
   -t, --temperature <number>                 temperature for the run
   -tp, --top-p <number>                      top-p for the run
   -m, --model <string>                       model for the run
+  -sm, --small-model <string>                small model for the run
   -mt, --max-tokens <number>                 maximum tokens for the run
   -mdr, --max-data-repairs <number>          maximum data repairs
   -mtc, --max-tool-calls <number>            maximum tool calls for the run

--- a/docs/src/content/docs/reference/scripts/system.mdx
+++ b/docs/src/content/docs/reference/scripts/system.mdx
@@ -335,7 +335,7 @@ defAgent(
         )
     },
     {
-        model: "openai:gpt-4o",
+        model: "large",
         flexTokens: 30000,
         system: ["system"],
         disableMemory: true,

--- a/eval/extrism/genaisrc/genaiscript.d.ts
+++ b/eval/extrism/genaisrc/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/eval/extrism/genaisrc/genaiscript.d.ts
+++ b/eval/extrism/genaisrc/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/genaisrc/genaiscript.d.ts
+++ b/genaisrc/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/auto/genaiscript.d.ts
+++ b/packages/auto/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -152,6 +152,7 @@ export async function cli() {
         .option("-t, --temperature <number>", "temperature for the run")
         .option("-tp, --top-p <number>", "top-p for the run")
         .option("-m, --model <string>", "model for the run")
+        .option("-sm, --small-model <string>", "small model for the run")
         .option("-mt, --max-tokens <number>", "maximum tokens for the run")
         .option("-mdr, --max-data-repairs <number>", "maximum data repairs")
         .option(

--- a/packages/cli/src/nodehost.ts
+++ b/packages/cli/src/nodehost.ts
@@ -25,6 +25,7 @@ import {
     MODEL_PROVIDER_OLLAMA,
     TOOL_ID,
     DEFAULT_EMBEDDINGS_MODEL,
+    DEFAULT_SMALL_MODEL,
 } from "../../core/src/constants"
 import { tryReadText } from "../../core/src/fs"
 import {
@@ -114,6 +115,7 @@ export class NodeHost implements RuntimeHost {
     readonly browsers = new BrowserManager()
     readonly defaultModelOptions = {
         model: DEFAULT_MODEL,
+        smallModel: DEFAULT_SMALL_MODEL,
         temperature: DEFAULT_TEMPERATURE,
     }
     readonly defaultEmbeddingsModelOptions = {

--- a/packages/cli/src/parse.ts
+++ b/packages/cli/src/parse.ts
@@ -17,7 +17,6 @@ import { resolveTokenEncoder } from "../../core/src/encoders"
 import { DEFAULT_MODEL } from "../../core/src/constants"
 import { promptyParse, promptyToGenAIScript } from "../../core/src/prompty"
 import { basename, join } from "node:path"
-import { JSONLLMTryParse } from "../../core/src/json5"
 
 /**
  * This module provides various parsing utilities for different file types such

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -191,6 +191,10 @@ export async function runScript(
     const cancellationToken = options.cancellationToken
     const jsSource = options.jsSource
 
+    if (options.model) host.defaultModelOptions.model = options.model
+    if (options.smallModel)
+        host.defaultModelOptions.smallModel = options.smallModel
+
     const fail = (msg: string, exitCode: number, url?: string) => {
         logError(url ? `${msg} (see ${url})` : msg)
         return { exitCode, result }

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -26,7 +26,7 @@ import { errorMessage, isCancelError, serializeError } from "./error"
 import { estimateChatTokens } from "./chatencoder"
 import { createChatTurnGenerationContext } from "./runpromptcontext"
 import { dedent } from "./indent"
-import { traceLanguageModelConnection } from "./models"
+import { resolveModelAlias, traceLanguageModelConnection } from "./models"
 import {
     ChatCompletionContentPartImage,
     ChatCompletionMessageParam,
@@ -587,13 +587,17 @@ export function mergeGenerationOptions(
     options: GenerationOptions,
     runOptions: ModelOptions & EmbeddingsModelOptions
 ): GenerationOptions {
-    return {
+    const res =  {
         ...options,
         ...(runOptions || {}),
         model:
             runOptions?.model ??
             options?.model ??
             host.defaultModelOptions.model,
+        smallModel:
+            runOptions?.smallModel ??
+            options?.smallModel ??
+            host.defaultModelOptions.smallModel,
         temperature:
             runOptions?.temperature ?? host.defaultModelOptions.temperature,
         embeddingsModel:
@@ -601,6 +605,8 @@ export function mergeGenerationOptions(
             options?.embeddingsModel ??
             host.defaultEmbeddingsModelOptions.embeddingsModel,
     }
+    res.model = resolveModelAlias(res.model, res)
+    return res
 }
 
 export async function executeChatSession(

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -29,7 +29,6 @@ import {
 } from "./constants"
 import { fileExists, readText, tryReadText, writeText } from "./fs"
 import { APIType, host, LanguageModelConfiguration } from "./host"
-import { dedent } from "./indent"
 import { parseModelIdentifier } from "./models"
 import { normalizeFloat, trimTrailingSlash } from "./util"
 
@@ -37,7 +36,8 @@ export async function parseDefaultsFromEnv(env: Record<string, string>) {
     if (env.GENAISCRIPT_DEFAULT_MODEL)
         host.defaultModelOptions.model = env.GENAISCRIPT_DEFAULT_MODEL
     if (env.GENAISCRIPT_DEFAULT_SMALL_MODEL)
-        host.defaultModelOptions.smallModel = env.GENAISCRIPT_DEFAULT_SMALL_MODEL
+        host.defaultModelOptions.smallModel =
+            env.GENAISCRIPT_DEFAULT_SMALL_MODEL
     const t = normalizeFloat(env.GENAISCRIPT_DEFAULT_TEMPERATURE)
     if (!isNaN(t)) host.defaultModelOptions.temperature = t
     if (env.GENAISCRIPT_DEFAULT_EMBEDDINGS_MODEL)
@@ -259,95 +259,6 @@ export async function parseTokenFromEnv(
             trimTrailingSlash(b.replace(/\/openai\/deployments.*$/, "")) +
             `/openai/deployments`
         return b
-    }
-}
-
-function dotEnvTemplate(
-    provider: string,
-    apiType: APIType
-): { config: string; model: string } {
-    if (provider === MODEL_PROVIDER_OLLAMA)
-        return {
-            config: `
-## Ollama ${DOCS_CONFIGURATION_OLLAMA_URL}
-# use "${MODEL_PROVIDER_OLLAMA}:<model>" or "${MODEL_PROVIDER_OLLAMA}:<model>:<tag>" in script({ model: ... })
-# OLLAMA_API_BASE="${PLACEHOLDER_API_BASE}" # uses ${OLLAMA_API_BASE} by default
-`,
-            model: `${MODEL_PROVIDER_OLLAMA}:phi3`,
-        }
-
-    if (provider === MODEL_PROVIDER_LLAMAFILE)
-        return {
-            config: `
-## llamafile ${DOCS_CONFIGURATION_LLAMAFILE_URL}
-# use "${MODEL_PROVIDER_LLAMAFILE}" in script({ model: ... })
-# There is no configuration for llamafile
-`,
-            model: MODEL_PROVIDER_LLAMAFILE,
-        }
-
-    if (provider === MODEL_PROVIDER_LITELLM)
-        return {
-            config: `
-## LiteLLM ${DOCS_CONFIGURATION_LITELLM_URL}
-# use "${MODEL_PROVIDER_LITELLM}" in script({ model: ... })
-# LITELLM_API_BASE="${PLACEHOLDER_API_BASE}" # uses ${LITELLM_API_BASE} by default
-`,
-            model: MODEL_PROVIDER_LITELLM,
-        }
-
-    if (provider === MODEL_PROVIDER_AICI)
-        return {
-            config: `
-## AICI ${DOCS_CONFIGURATION_AICI_URL}
-# use "${MODEL_PROVIDER_AICI}:<model>" in script({ model: ... })
-AICI_API_BASE="${PLACEHOLDER_API_BASE}"
-`,
-            model: `${MODEL_PROVIDER_AICI}:mixtral`,
-        }
-
-    if (apiType === "azure" || provider === MODEL_PROVIDER_AZURE)
-        return {
-            config: `
-## Azure OpenAI ${DOCS_CONFIGURATION_AZURE_OPENAI_URL}
-# use "${MODEL_PROVIDER_AZURE}:<deployment>" in script({ model: ... })
-AZURE_OPENAI_ENDPOINT="${PLACEHOLDER_API_BASE}"
-# Uses managed identity by default, or set:
-# AZURE_OPENAI_API_KEY="${PLACEHOLDER_API_KEY}"
-`,
-            model: `${MODEL_PROVIDER_AZURE}:deployment`,
-        }
-
-    if (apiType === "localai")
-        return {
-            config: `
-## LocalAI ${DOCS_CONFIGURATION_LOCALAI_URL}
-# use "${MODEL_PROVIDER_OPENAI}:<model>" in script({ model: ... })
-OPENAI_API_TYPE="localai"
-# OPENAI_API_KEY="${PLACEHOLDER_API_KEY}" # use if you have an access token in the localai web ui
-# OPENAI_API_BASE="${PLACEHOLDER_API_BASE}" # uses ${LOCALAI_API_BASE} by default
-`,
-            model: `${MODEL_PROVIDER_OPENAI}:gpt-3.5-turbo`,
-        }
-
-    if (provider === MODEL_PROVIDER_GITHUB)
-        return {
-            config: `
-## GitHub Models ${DOCS_CONFIGURATION_GITHUB_URL}
-# use "${MODEL_PROVIDER_GITHUB}:<model>" in script({ model: ... })
-# GITHUB_MODELS_TOKEN="${PLACEHOLDER_API_KEY}" # use a personal access token if not available
-    `,
-            model: `${MODEL_PROVIDER_GITHUB}:gpt-4o`,
-        }
-
-    return {
-        config: `
-## OpenAI ${DOCS_CONFIGURATION_OPENAI_URL}
-# use "${MODEL_PROVIDER_OPENAI}:<model>" in script({ model: ... })
-OPENAI_API_KEY="${PLACEHOLDER_API_KEY}"
-# OPENAI_API_BASE="${PLACEHOLDER_API_BASE}" # uses ${OPENAI_API_BASE} by default
-`,
-        model: `${MODEL_PROVIDER_OPENAI}:gpt-4o`,
     }
 }
 

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -36,6 +36,8 @@ import { normalizeFloat, trimTrailingSlash } from "./util"
 export async function parseDefaultsFromEnv(env: Record<string, string>) {
     if (env.GENAISCRIPT_DEFAULT_MODEL)
         host.defaultModelOptions.model = env.GENAISCRIPT_DEFAULT_MODEL
+    if (env.GENAISCRIPT_DEFAULT_SMALL_MODEL)
+        host.defaultModelOptions.smallModel = env.GENAISCRIPT_DEFAULT_SMALL_MODEL
     const t = normalizeFloat(env.GENAISCRIPT_DEFAULT_TEMPERATURE)
     if (!isNaN(t)) host.defaultModelOptions.temperature = t
     if (env.GENAISCRIPT_DEFAULT_EMBEDDINGS_MODEL)

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -54,7 +54,7 @@ export const DEFAULT_MODEL_CANDIDATES = [
 export const DEFAULT_SMALL_MODEL = "openai:gpt-4o-mini"
 export const DEFAULT_SMALL_MODEL_CANDIDATES = [
     "azure:gpt-4o-mini",
-    DEFAULT_MODEL,
+    DEFAULT_SMALL_MODEL,
     "github:gpt-4o-mini",
     "client:gpt-4-mini",
 ]

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -49,6 +49,14 @@ export const DEFAULT_MODEL_CANDIDATES = [
     "github:gpt-4o",
     "client:gpt-4",
 ]
+export const SMALL_MODEL_ID = "small"
+export const DEFAULT_SMALL_MODEL = "openai:gpt-4o-mini"
+export const DEFAULT_SMALL_MODEL_CANDIDATES = [
+    "azure:gpt-4o-mini",
+    DEFAULT_MODEL,
+    "github:gpt-4o-mini",
+    "client:gpt-4-mini",
+]
 export const DEFAULT_EMBEDDINGS_MODEL_CANDIDATES = [
     "azure:text-embedding-3-small",
     "openai:text-embedding-3-small",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -41,6 +41,8 @@ export const CLIENT_RECONNECT_DELAY = 3000
 export const CLIENT_RECONNECT_MAX_ATTEMPTS = 20
 export const RETRIEVAL_PERSIST_DIR = "retrieval"
 export const HIGHLIGHT_LENGTH = 4000
+export const SMALL_MODEL_ID = "small"
+export const LARGE_MODEL_ID = "large"
 export const DEFAULT_MODEL = "openai:gpt-4o"
 export const DEFAULT_MODEL_CANDIDATES = [
     "azure:gpt-4o",
@@ -49,7 +51,6 @@ export const DEFAULT_MODEL_CANDIDATES = [
     "github:gpt-4o",
     "client:gpt-4",
 ]
-export const SMALL_MODEL_ID = "small"
 export const DEFAULT_SMALL_MODEL = "openai:gpt-4o-mini"
 export const DEFAULT_SMALL_MODEL_CANDIDATES = [
     "azure:gpt-4o-mini",
@@ -59,6 +60,7 @@ export const DEFAULT_SMALL_MODEL_CANDIDATES = [
 ]
 export const DEFAULT_EMBEDDINGS_MODEL_CANDIDATES = [
     "azure:text-embedding-3-small",
+    "azure:text-embedding-2-small",
     "openai:text-embedding-3-small",
     "github:text-embedding-3-small",
     "client:text-embedding-3-small",

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -52,8 +52,8 @@ export class RequestError extends Error {
         readonly retryAfter?: number
     ) {
         super(
-            `LLM error: ${
-                body?.message ? body?.message : `${statusText} (${status})`
+            `LLM error (${status}): ${
+                body?.message ? body?.message : statusText
             }`
         )
         this.name = "RequestError"

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/core/src/genaisrc/genaiscript.d.ts
+++ b/packages/core/src/genaisrc/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/core/src/genaisrc/system.agent_memory.genai.mjs
+++ b/packages/core/src/genaisrc/system.agent_memory.genai.mjs
@@ -30,7 +30,7 @@ defAgent(
         )
     },
     {
-        model: "openai:gpt-4o",
+        model: "large",
         flexTokens: 30000,
         system: ["system"],
         disableMemory: true,

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -275,7 +275,9 @@ export class GitClient implements Git {
         }
         if (!nameOnly && llmify) {
             res = llmifyDiff(res)
-            const encoder = await resolveTokenEncoder(DEFAULT_MODEL)
+            const encoder = await resolveTokenEncoder(
+                runtimeHost.defaultModelOptions.model || DEFAULT_MODEL
+            )
             const tokens = estimateTokens(res, encoder)
             if (tokens > maxTokensFullDiff)
                 res = `## Diff

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -97,7 +97,9 @@ export interface Host {
     resolvePath(...segments: string[]): string
 
     // read a secret from the environment or a .env file
-    defaultModelOptions: Required<Pick<ModelOptions, "model" | "temperature">>
+    defaultModelOptions: Required<
+        Pick<ModelOptions, "model" | "smallModel" | "temperature">
+    >
     defaultEmbeddingsModelOptions: Required<
         Pick<EmbeddingsModelOptions, "embeddingsModel">
     >

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -1,3 +1,4 @@
+import { uniq } from "es-toolkit"
 import {
     DEFAULT_EMBEDDINGS_MODEL_CANDIDATES,
     DEFAULT_MODEL_CANDIDATES,
@@ -97,24 +98,22 @@ export async function resolveModelConnectionInfo(
     configuration?: LanguageModelConfiguration
 }> {
     const { trace, token: askToken, signal } = options || {}
-    let candidates = [
-        host.defaultModelOptions.model,
-        ...DEFAULT_MODEL_CANDIDATES,
-    ]
+    let candidates = options?.candidates
     let m = options?.model ?? conn.model
     if (m === SMALL_MODEL_ID) {
-        m = host.defaultModelOptions.smallModel
+        m = undefined
         candidates ??= [
             host.defaultModelOptions.smallModel,
             ...DEFAULT_SMALL_MODEL_CANDIDATES,
         ]
     } else if (m === LARGE_MODEL_ID) {
-        m = host.defaultModelOptions.model
+        m = undefined
         candidates ??= [
             host.defaultModelOptions.model,
             ...DEFAULT_MODEL_CANDIDATES,
         ]
     }
+    candidates ??= [host.defaultModelOptions.model, ...DEFAULT_MODEL_CANDIDATES]
 
     const resolveModel = async (
         model: string,
@@ -165,7 +164,7 @@ export async function resolveModelConnectionInfo(
     if (m) {
         return await resolveModel(m, { withToken: askToken, reportError: true })
     } else {
-        for (const candidate of new Set(candidates || [])) {
+        for (const candidate of uniq(candidates).filter((c) => !!c)) {
             const res = await resolveModel(candidate, {
                 withToken: askToken,
                 reportError: false,

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -1,7 +1,11 @@
 import {
+    DEFAULT_EMBEDDINGS_MODEL_CANDIDATES,
     DEFAULT_MODEL_CANDIDATES,
+    DEFAULT_SMALL_MODEL_CANDIDATES,
+    LARGE_MODEL_ID,
     MODEL_PROVIDER_LLAMAFILE,
     MODEL_PROVIDER_OPENAI,
+    SMALL_MODEL_ID,
 } from "./constants"
 import { errorMessage } from "./error"
 import { LanguageModelConfiguration, host } from "./host"
@@ -92,16 +96,25 @@ export async function resolveModelConnectionInfo(
     info: ModelConnectionInfo
     configuration?: LanguageModelConfiguration
 }> {
-    const {
-        trace,
-        token: askToken,
-        signal,
-        candidates = [
+    const { trace, token: askToken, signal } = options || {}
+    let candidates = [
+        host.defaultModelOptions.model,
+        ...DEFAULT_MODEL_CANDIDATES,
+    ]
+    let m = options?.model ?? conn.model
+    if (m === SMALL_MODEL_ID) {
+        m = undefined
+        candidates ??= [
+            host.defaultModelOptions.smallModel,
+            ...DEFAULT_SMALL_MODEL_CANDIDATES,
+        ]
+    } else if (m === LARGE_MODEL_ID) {
+        m = undefined // Large model is the default
+        candidates ??= [
             host.defaultModelOptions.model,
             ...DEFAULT_MODEL_CANDIDATES,
-        ],
-    } = options || {}
-    const m = options?.model ?? conn.model
+        ]
+    }
 
     const resolveModel = async (
         model: string,

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -103,13 +103,13 @@ export async function resolveModelConnectionInfo(
     ]
     let m = options?.model ?? conn.model
     if (m === SMALL_MODEL_ID) {
-        m = undefined
+        m = host.defaultModelOptions.smallModel
         candidates ??= [
             host.defaultModelOptions.smallModel,
             ...DEFAULT_SMALL_MODEL_CANDIDATES,
         ]
     } else if (m === LARGE_MODEL_ID) {
-        m = undefined // Large model is the default
+        m = host.defaultModelOptions.model
         candidates ??= [
             host.defaultModelOptions.model,
             ...DEFAULT_MODEL_CANDIDATES,

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -179,3 +179,14 @@ export async function resolveModelConnectionInfo(
         }
     }
 }
+
+export function resolveModelAlias(
+    modelId: string,
+    options?: ModelConnectionOptions
+) {
+    if (modelId === SMALL_MODEL_ID)
+        return options?.smallModel || host.defaultModelOptions.smallModel
+    if (modelId === LARGE_MODEL_ID)
+        return options?.model || host.defaultModelOptions.model
+    return modelId
+}

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -101,6 +101,7 @@ export async function resolveModelConnectionInfo(
             ...DEFAULT_MODEL_CANDIDATES,
         ],
     } = options || {}
+    const m = options?.model ?? conn.model
 
     const resolveModel = async (
         model: string,
@@ -148,7 +149,6 @@ export async function resolveModelConnectionInfo(
         }
     }
 
-    const m = options?.model ?? conn.model
     if (m) {
         return await resolveModel(m, { withToken: askToken, reportError: true })
     } else {

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -356,7 +356,7 @@ export function createChatGenerationContext(
                 context.log(`${agentLabel}: ${query}`)
 
                 let memoryAnswer: string
-                if (memory && !disableMemoryQuery) {
+                if (memory && query && !disableMemoryQuery) {
                     // always pre-query memory with cheap model
                     const res = await runPrompt(
                         async (_) => {
@@ -376,7 +376,11 @@ export function createChatGenerationContext(
                             label: "agent memory query",
                         }
                     )
-                    memoryAnswer = res.text
+                    if (!res.error) memoryAnswer = res.text
+                    else
+                        logVerbose(
+                            `memory query error: ${errorMessage(res.error)}`
+                        )
                 }
 
                 const res = await runPrompt(
@@ -664,7 +668,8 @@ export function createChatGenerationContext(
             checkCancelled(cancellationToken)
             if (!connection.configuration)
                 throw new Error(
-                    "model connection error " + connection.info?.model
+                    "missing model connection information for " +
+                        connection.info?.model
                 )
             const { completer } = await resolveLanguageModel(
                 connection.configuration.provider

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -384,14 +384,13 @@ export function createChatGenerationContext(
                         if (typeof fn === "string") _.writeText(dedent(fn))
                         else await fn(_, args)
                         _.$`- Assume that your answer will be analyzed by an LLM, not a human.
-                ${memory ? `- If you are missing information, try querying the memory using 'agent_memory'.` : ""}                        
                 - If you are missing information, reply "MISSING_INFO: <what is missing>".
                 - If you cannot answer the query, return "NO_ANSWER: <reason>".
                 - Be concise. Minimize output to the most relevant information to save context tokens.`
                         if (memoryAnswer)
-                            _.$`- The query applied to the agent memory is in MEMORY_ANSWER.`
+                            _.$`- The query applied to the agent memory is in MEMORY.`
                         _.def("QUERY", query)
-                        if (memoryAnswer) _.def("MEMORY_QUERY", memoryAnswer)
+                        if (memoryAnswer) _.def("MEMORY", memoryAnswer)
                         if (memory)
                             _.defOutputProcessor(async ({ text }) => {
                                 if (

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -305,6 +305,7 @@ export function createChatGenerationContext(
                 )
         }
     }
+
     const defAgent = (
         name: string,
         description: string,
@@ -369,10 +370,10 @@ export function createChatGenerationContext(
                             await defMemory(_)
                         },
                         {
-                            model: "openai:gpt-4o-mini",
+                            model: "small",
                             system: ["system"],
                             flexTokens: 20000,
-                            label: "memory query",
+                            label: "agent memory query",
                         }
                     )
                     memoryAnswer = res.text

--- a/packages/core/src/scripts.ts
+++ b/packages/core/src/scripts.ts
@@ -25,16 +25,14 @@ export function createScript(
 
 export async function fixPromptDefinitions(project: Project) {
     const folders = project.folders()
+    const systems = project.templates.filter((t) => t.isSystem)
+    const tools = systems.map(({ defTools }) => defTools || []).flat()
+
     for (const folder of folders) {
         const { dirname, ts, js } = folder
         for (let [defName, defContent] of Object.entries(promptDefinitions)) {
             // patch genaiscript
             if (defName === "genaiscript.d.ts") {
-                const systems = project.templates.filter((t) => t.isSystem)
-                const tools = systems
-                    .map(({ defTools }) => defTools || [])
-                    .flat()
-
                 // update the system prompt identifiers
                 defContent = defContent
                     .replace(

--- a/packages/core/src/server/messages.ts
+++ b/packages/core/src/server/messages.ts
@@ -70,6 +70,7 @@ export interface PromptScriptRunOptions {
     maxToolCalls: string
     maxDataRepairs: string
     model: string
+    smallModel: string
     embeddingsModel: string
     csvSeparator: string
     cache: boolean | string

--- a/packages/core/src/testhost.ts
+++ b/packages/core/src/testhost.ts
@@ -19,6 +19,7 @@ import { TraceOptions } from "./trace"
 import {
     DEFAULT_EMBEDDINGS_MODEL,
     DEFAULT_MODEL,
+    DEFAULT_SMALL_MODEL,
     DEFAULT_TEMPERATURE,
 } from "./constants"
 import {
@@ -68,6 +69,7 @@ export class TestHost implements RuntimeHost {
     // Default options for language models
     readonly defaultModelOptions = {
         model: DEFAULT_MODEL,
+        smallModel: DEFAULT_SMALL_MODEL,
         temperature: DEFAULT_TEMPERATURE,
     }
     // Default options for embeddings models

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -125,6 +125,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -110,24 +110,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/genaisrc/analyze-data.genai.mjs
+++ b/packages/sample/genaisrc/analyze-data.genai.mjs
@@ -1,6 +1,6 @@
 script({
     title: "analyze-data",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: "src/penguins.csv",
     tests: [
         {

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/genaisrc/blog/genaiscript.d.ts
+++ b/packages/sample/genaisrc/blog/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/genaisrc/console-module.genai.mjs
+++ b/packages/sample/genaisrc/console-module.genai.mjs
@@ -1,5 +1,4 @@
 script({
-    model: "openai:gpt-3.5-turbo",
     tests: {},
 })
 
@@ -14,7 +13,7 @@ await runPrompt(
         _.console.error("prompt.error")
         _.$`write a movie title`
     },
-    { label: "inner prompt" }
+    { label: "inner prompt", model: "small" }
 )
 
 console.log(`after run prompt`)

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/genaisrc/genaiscript.d.ts
+++ b/packages/sample/genaisrc/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/genaisrc/inline-small.genai.mts
+++ b/packages/sample/genaisrc/inline-small.genai.mts
@@ -1,0 +1,8 @@
+script({
+    model: "small",
+    tests: {},
+})
+let res = await prompt`write a poem`.options({ model: "small" })
+if (res.error) throw res.error
+res = await runPrompt((_) => _.$`write a poem`, { model: "small" })
+if (res.error) throw res.error

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/genaisrc/node/genaiscript.d.ts
+++ b/packages/sample/genaisrc/node/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/genaisrc/python/genaiscript.d.ts
+++ b/packages/sample/genaisrc/python/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/genaisrc/style/genaiscript.d.ts
+++ b/packages/sample/genaisrc/style/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/genaisrc/style/runprompt.genai.js
+++ b/packages/sample/genaisrc/style/runprompt.genai.js
@@ -5,7 +5,7 @@ script({
 
 const r = await prompt`write a haiku poem`
 if (r.error) throw r.error
-const r2 = await runPrompt(`write a haiku poem`)
+const r2 = await runPrompt(`write a haiku poem`, { model: "small" })
 if (r2.error) throw r2.error
 const r3 = await runPrompt(() => `write a haiku poem`)
 if (r3.error) throw r3.error

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/src/aici/genaiscript.d.ts
+++ b/packages/sample/src/aici/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/src/errors/genaiscript.d.ts
+++ b/packages/sample/src/errors/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/src/genaiscript.d.ts
+++ b/packages/sample/src/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/src/makecode/genaiscript.d.ts
+++ b/packages/sample/src/makecode/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/src/tla/genaiscript.d.ts
+++ b/packages/sample/src/tla/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/sample/src/vision/genaiscript.d.ts
+++ b/packages/sample/src/vision/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/packages/vscode/genaisrc/genaiscript.d.ts
+++ b/packages/vscode/genaisrc/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/vscode/genaisrc/prd.genai.mts
+++ b/packages/vscode/genaisrc/prd.genai.mts
@@ -3,7 +3,6 @@ script({
     description: "Generate a pull request description from the git diff",
     tools: ["fs"],
     temperature: 0.5,
-    model: "openai:gpt-4o",
 })
 
 const defaultBranch = await git.defaultBranch()

--- a/packages/vscode/src/vshost.ts
+++ b/packages/vscode/src/vshost.ts
@@ -10,6 +10,7 @@ import { parseDefaultsFromEnv } from "../../core/src/connection"
 import {
     DEFAULT_EMBEDDINGS_MODEL,
     DEFAULT_MODEL,
+    DEFAULT_SMALL_MODEL,
     DEFAULT_TEMPERATURE,
     DOT_ENV_FILENAME,
 } from "../../core/src/constants"
@@ -32,6 +33,7 @@ export class VSCodeHost extends EventTarget implements Host {
     readonly server: TerminalServerManager
     readonly defaultModelOptions = {
         model: DEFAULT_MODEL,
+        smallModel: DEFAULT_SMALL_MODEL,
         temperature: DEFAULT_TEMPERATURE,
     }
     readonly defaultEmbeddingsModelOptions = {

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -195,24 +195,23 @@ type PromptTemplateResponseType = "json_object" | "json_schema" | undefined
 
 interface ModelConnectionOptions {
     /**
-     * Which LLM model to use.
-     *
-     * @default gpt-4
-     * @example gpt-4
+     * Which LLM model to use. Use `large` for the default set of model candidates, `small` for the set of small models like gpt-4o-mini.
      */
     model?: OptionsOrString<
+        | "large"
+        | "small"
         | "openai:gpt-4o"
         | "openai:gpt-4o-mini"
-        | "openai:gpt-4"
-        | "openai:gpt-4-turbo"
         | "openai:gpt-3.5-turbo"
+        | "azure:gpt-4o"
+        | "azure:gpt-4o-mini"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"
     >
 
     /**
-     * Which LLM model to use.
+     * Which LLM model to use for the "small" model.
      *
      * @default gpt-4
      * @example gpt-4

--- a/slides/genaisrc/genaiscript.d.ts
+++ b/slides/genaisrc/genaiscript.d.ts
@@ -210,6 +210,14 @@ interface ModelConnectionOptions {
         | "ollama:llama3"
         | "ollama:mixtral"
     >
+
+    /**
+     * Which LLM model to use.
+     *
+     * @default gpt-4
+     * @example gpt-4
+     */
+    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
 }
 
 interface ModelOptions extends ModelConnectionOptions {


### PR DESCRIPTION
This pull request introduces support for a default small model configuration, allowing users to specify both a standard and a small model in their environment settings. The changes include updates to the CLI options, model connection interfaces, and default model options across various components. This enhancement aims to improve flexibility and usability when selecting models for different use cases. Additionally, documentation has been updated to reflect these new options.

<!-- genaiscript begin prd --><hr/>

- 🔧 **Configuration Enhancements:**
  - Added support for specifying a default small model using `GENAISCRIPT_DEFAULT_SMALL_MODEL` in the environment configuration.
  - Updated CLI options to include a `--small-model` flag for specifying a small model.

- 📚 **Documentation Updates:**
  - Updated getting started and CLI command documentation to reflect the new small model configuration option.

- 🛠️ **Core System Modifications:**
  - Introduced `DEFAULT_SMALL_MODEL` and `DEFAULT_SMALL_MODEL_CANDIDATES` constants.
  - Adjusted model handling logic to differentiate between large and small models.
  - Removed redundant dotenv template function to streamline configuration handling.

- 🐛 **Error Handling Improvement:**
  - Refined error messages in `RequestError` to enhance clarity.

- 🧪 **Testing and Host Adjustments:**
  - Updated `NodeHost`, `TestHost`, and `VSCodeHost` to include small model options in default configurations.

- 🗂️ **Code Cleanup:**
  - Removed unused imports and redundant code sections for better maintainability.

> generated by prd



<!-- genaiscript end prd -->

