### PR TITLE
Add RangeOptions interface for line range specification

### DIFF
--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -810,6 +810,17 @@ interface ContextExpansionOptions {
     ephemeral?: boolean
 }
 
+interface RangeOptions {
+    /**
+     * The inclusive start of the line range, with a 1-based index
+     */
+    lineStart?: number
+    /**
+     * The inclusive end of the line range, with a 1-based index
+     */
+    lineEnd?: number
+}
+
 interface DefOptions extends FenceOptions, ContextExpansionOptions, DataFilter {
     /**
      * Filename filter based on file suffix. Case insensitive.


### PR DESCRIPTION
This PR introduces a new `RangeOptions` interface that allows for the specification of a line range using inclusive start and end indices. This enhancement provides more flexibility in handling line-based operations within the code.