### PR TITLE
Add Meta-Llama-3-405B-Instruct model and update usage stats

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -351,6 +351,7 @@ The rest of the steps are the same: Find the deployment name and use it in your 
 
 </Steps>
 
+
 ## GitHub Copilot Chat Models <a id="github-copilot" href=""></a>
 
 If you have access to **GitHub Copilot Chat in Visual Studio Code**,

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -351,6 +351,54 @@ The rest of the steps are the same: Find the deployment name and use it in your 
 
 </Steps>
 
+## Azure AI Serverless APIs <a id="azureai" href=""></a>
+
+Certain models in the model catalog can be deployed as [a serverless API](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-serverless-availability) with pay-as-you-go billing.
+This kind of deployment provides a way to consume models
+as an API without hosting them on your subscription,
+while keeping the enterprise security and compliance that organizations need.
+This deployment option doesn't require quota from your subscription.
+
+<Steps>
+
+<ol>
+
+<li>
+
+Open https://ai.azure.com/ and open the **Deployments** page.
+
+</li>
+
+<li>
+
+Deploy a **base model** from the catalog.
+You can use the `Deployment Options` -> `Serverless API` option to deploy a model as a serverless API.
+
+</li>
+
+<li>
+
+Configure the **Endpoint Target URL** as the `OPENAI_API_BASE` variable and the
+`OPENAI_API_TYPE=azure` in the `.env` file.
+
+```txt title=".env"
+OPENAI_API_BASE=https://...azurewebsites.net
+OPENAI_API_TYPE=azure
+```
+
+</li>
+
+<li>
+
+Use the "large" model in your script.
+
+</li>
+
+</ol>
+
+</Steps>
+
+Note: better support will come in future versions.
 
 ## GitHub Copilot Chat Models <a id="github-copilot" href=""></a>
 

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -505,7 +505,7 @@ async function processChatMessage(
         cancellationToken,
     } = options
 
-    stats.addUsage(req, resp.usage)
+    stats.addUsage(req, resp)
 
     if (resp.text)
         messages.push({

--- a/packages/core/src/pricing.json
+++ b/packages/core/src/pricing.json
@@ -166,5 +166,13 @@
     "azure:gpt-4-32k": {
         "price_per_million_input_tokens": 60,
         "price_per_million_output_tokens": 120
+    },
+    "openai:Meta-Llama-3-405B-Instruct": {
+        "price_per_million_input_tokens": 5.33,
+        "price_per_million_output_tokens": 16
+    },
+    "azure:Meta-Llama-3-405B-Instruct": {
+        "price_per_million_input_tokens": 5.33,
+        "price_per_million_output_tokens": 16
     }
 }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -120,6 +120,7 @@ interface ModelConnectionOptions {
         | "openai:gpt-3.5-turbo"
         | "azure:gpt-4o"
         | "azure:gpt-4o-mini"
+        | "azure:llama3-1-405"
         | "ollama:phi3"
         | "ollama:llama3"
         | "ollama:mixtral"


### PR DESCRIPTION
This pull request introduces the Meta-Llama-3-405B-Instruct model, updating the pricing structure for both OpenAI and Azure. Additionally, it modifies the `addUsage` method to accept a `ChatCompletionResponse` instead of a `ChatCompletionUsage`, allowing for more accurate tracking of usage statistics. The `GenerationStats` class has been enhanced to include model information in usage calculations, ensuring that costs are accurately estimated based on the specific model used. Overall, these changes improve the functionality and tracking of chat model usage.