### PR TITLE
🔄 Update model to "small" in all script definitions 💻

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -50,7 +50,13 @@ script({ model: "small" })
 script({ model: "large" })
 ```
 
-The model can also be overriden from the [cli run command](/genaiscript/reference/cli/run#model).
+The model can also be overriden from the [cli run command](/genaiscript/reference/cli/run#model)
+or by adding the `GENAISCRIPT_DEFAULT_MODEL` and `GENAISCRIPT_DEFAULT_SMALL_MODEL` environment variables.
+
+```txt title=".env"
+GENAISCRIPT_DEFAULT_MODEL="azure_serverless:..."
+GENAISCRIPT_DEFAULT_SMALL_MODEL="azure_serverless:..."
+```
 
 ## `.env` file
 

--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -81,8 +81,8 @@ Arguments:
 
 Options:
   --models <models...>                models to test where mode is the key
-                                      value pair list of m (model), t
-                                      (temperature), p (top-p)
+                                      value pair list of m (model), s (small
+                                      model), t (temperature), p (top-p)
   -o, --out <folder>                  output folder
   -rmo, --remove-out                  remove output folder if it exists
   --cli <string>                      override path to the cli

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -185,7 +185,7 @@ export async function cli() {
         )
         .option(
             "--models <models...>",
-            "models to test where mode is the key value pair list of m (model), t (temperature), p (top-p)"
+            "models to test where mode is the key value pair list of m (model), s (small model), t (temperature), p (top-p)"
         )
         .option("-o, --out <folder>", "output folder")
         .option("-rmo, --remove-out", "remove output folder if it exists")

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -51,6 +51,7 @@ function parseModelSpec(m: string): ModelOptions {
     if (Object.keys(values).length > 1)
         return {
             model: values["m"],
+            smallModel: values["s"],
             temperature: normalizeFloat(values["t"]),
             topP: normalizeFloat(values["p"]),
         }

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -47,7 +47,16 @@ import { delay } from "es-toolkit"
  * @returns A ModelOptions object with model, temperature, and topP fields if applicable.
  */
 function parseModelSpec(m: string): ModelOptions {
-    const values = parseKeyValuePairs(m)
+    const values = m
+        .split(/&/g)
+        .map((kv) => kv.split("=", 2))
+        .reduce(
+            (acc, [key, value]) => {
+                acc[key] = decodeURIComponent(value)
+                return acc
+            },
+            {} as Record<string, string>
+        )
     if (Object.keys(values).length > 1)
         return {
             model: values["m"],

--- a/packages/core/src/genaiscript-api-provider.mjs
+++ b/packages/core/src/genaiscript-api-provider.mjs
@@ -22,7 +22,7 @@ class GenAIScriptApiProvider {
     }
 
     async callApi(prompt, context) {
-        const { model, temperature, top_p, cache, version, cli, quiet } =
+        const { model, smallModel, temperature, top_p, cache, version, cli, quiet } =
             this.config
         const { vars, logger } = context
         try {
@@ -51,6 +51,7 @@ class GenAIScriptApiProvider {
             args.push("--json")
             if (quiet) args.push("--quiet")
             if (model) args.push("--model", model)
+            if (smallModel) args.push("--small-model", smallModel)
             if (temperature !== undefined)
                 args.push("--temperature", temperature)
             if (top_p !== undefined) args.push("--top_p", top_p)

--- a/packages/core/src/test.ts
+++ b/packages/core/src/test.ts
@@ -59,17 +59,19 @@ export function generatePromptFooConfiguration(
         prompts: [id],
         // Map model options to providers
         providers: models
-            .map(({ model, temperature, topP }) => ({
+            .map(({ model, smallModel, temperature, topP }) => ({
                 model: model ?? host.defaultModelOptions.model,
+                smallModel: smallModel ?? host.defaultModelOptions.smallModel,
                 temperature: !isNaN(temperature)
                     ? temperature
                     : host.defaultModelOptions.temperature,
                 top_p: topP,
             }))
-            .map(({ model, temperature, top_p }) => ({
+            .map(({ model, smallModel, temperature, top_p }) => ({
                 id: provider,
                 label: [
                     model,
+                    smallModel,
                     `t=${temperature}`,
                     top_p !== undefined ? `p=${top_p}` : undefined,
                 ]
@@ -77,6 +79,7 @@ export function generatePromptFooConfiguration(
                     .join(":"),
                 config: {
                     model,
+                    smallModel,
                     temperature,
                     top_p,
                     cli,

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -131,7 +131,9 @@ interface ModelConnectionOptions {
      * @default gpt-4
      * @example gpt-4
      */
-    smallModel?: OptionsOrString<"openai:gpt-4o-mini" | "openai:gpt-3.5-turbo">
+    smallModel?: OptionsOrString<
+        "openai:gpt-4o-mini" | "openai:gpt-3.5-turbo" | "azure:gpt-4o-mini"
+    >
 }
 
 interface ModelOptions extends ModelConnectionOptions {

--- a/packages/sample/genaisrc/blog-generate-knowledge.genai.js
+++ b/packages/sample/genaisrc/blog-generate-knowledge.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "blog using generated knowledge",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     description:
         "Using Generated Knowledge technique. More at https://learnprompting.org/docs/intermediate/generated_knowledge",
     tests: {

--- a/packages/sample/genaisrc/console-eval.genai.js
+++ b/packages/sample/genaisrc/console-eval.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {},
 })
 

--- a/packages/sample/genaisrc/csv.genai.mjs
+++ b/packages/sample/genaisrc/csv.genai.mjs
@@ -1,7 +1,7 @@
 script({
     files: "src/penguins.csv",
     tests: {},
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
 })
 
 def("DATA", env.files, { sliceSample: 3 })
@@ -18,9 +18,9 @@ const srows = CSV.parse(
     `A|1
     B|2
     C|3`,
-    { delimiter: ",", headers: ["name", "value"] }
+    { delimiter: "|", headers: ["name", "value"] }
 )
-console.log(srows)
+console.log({ srows })
 if (
     JSON.stringify(srows) ===
     JSON.stringify([

--- a/packages/sample/genaisrc/defdata.genai.mjs
+++ b/packages/sample/genaisrc/defdata.genai.mjs
@@ -1,6 +1,6 @@
 script({
     title: "defData demo",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
     },
     system: ["system"]

--- a/packages/sample/genaisrc/defschema.genai.js
+++ b/packages/sample/genaisrc/defschema.genai.js
@@ -1,6 +1,6 @@
 script({
     tests: {},
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: "src/cities.md"
 })
 

--- a/packages/sample/genaisrc/describe-image-run-prompt.genai.js
+++ b/packages/sample/genaisrc/describe-image-run-prompt.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "Describe objects in each image",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     group: "vision",
     maxTokens: 4000,
     system: [],

--- a/packages/sample/genaisrc/diagrams.genai.mts
+++ b/packages/sample/genaisrc/diagrams.genai.mts
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {},
 })
 $`Generate a diagram of a merge.`

--- a/packages/sample/genaisrc/exec.genai.mjs
+++ b/packages/sample/genaisrc/exec.genai.mjs
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
         keywords: ["Python", "3."],
     },

--- a/packages/sample/genaisrc/fetch.genai.js
+++ b/packages/sample/genaisrc/fetch.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
         keywords: "genaiscript",
     },

--- a/packages/sample/genaisrc/fileoutput.genai.mts
+++ b/packages/sample/genaisrc/fileoutput.genai.mts
@@ -1,6 +1,6 @@
 script({
     title: "summarize all files",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: "src/rag/markdown.md",
     tests: [
         {

--- a/packages/sample/genaisrc/flex.genai.mts
+++ b/packages/sample/genaisrc/flex.genai.mts
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: ["src/rag/markdown.md"],
     system: [],
     flexTokens: 20,

--- a/packages/sample/genaisrc/fs.genai.mjs
+++ b/packages/sample/genaisrc/fs.genai.mjs
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tools: ["fs"],
     tests: {},
 })

--- a/packages/sample/genaisrc/fuzz-search.genai.js
+++ b/packages/sample/genaisrc/fuzz-search.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "fuzz search",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {},
 })
 const kw = (env.vars.keyword || "defdata") + ""

--- a/packages/sample/genaisrc/gcc-container.genai.js
+++ b/packages/sample/genaisrc/gcc-container.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
 })
 const container = await host.container({
     image: "gcc",

--- a/packages/sample/genaisrc/git-history.genai.mts
+++ b/packages/sample/genaisrc/git-history.genai.mts
@@ -1,5 +1,5 @@
 script({ 
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     title: "git-history", tests: {} })
 
 const author = env.vars.author as string || "pelikhan"

--- a/packages/sample/genaisrc/github.genai.mts
+++ b/packages/sample/genaisrc/github.genai.mts
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {},
 })
 

--- a/packages/sample/genaisrc/html.genai.mjs
+++ b/packages/sample/genaisrc/html.genai.mjs
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     title: "HTML to Text",
     tests: {},
 })

--- a/packages/sample/genaisrc/import-template.genai.mts
+++ b/packages/sample/genaisrc/import-template.genai.mts
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
         keywords: ["paris", "abracadabra"],
     },

--- a/packages/sample/genaisrc/json_object.genai.mjs
+++ b/packages/sample/genaisrc/json_object.genai.mjs
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     responseType: "json_object",
     responseSchema: {
         type: "object",

--- a/packages/sample/genaisrc/json_object_ex.genai.mjs
+++ b/packages/sample/genaisrc/json_object_ex.genai.mjs
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     responseType: "json_object",
     responseSchema: { characters: [{ name: "neo", age: 30 }] },
     tests: {},

--- a/packages/sample/genaisrc/llm-as-expert.genai.mts
+++ b/packages/sample/genaisrc/llm-as-expert.genai.mts
@@ -45,7 +45,7 @@ defTool(
     },
     async ({ prompt }) => {
         const res = await env.generator.runPrompt(prompt, {
-            model: "openai:gpt-3.5-turbo",
+            model: "small",
             label: "llm-gpt35",
         })
         return res.text

--- a/packages/sample/genaisrc/math-agent-system.genai.js
+++ b/packages/sample/genaisrc/math-agent-system.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "math-agent-system",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     description: "A port of https://ts.llamaindex.ai/examples/agent",
     system: ["system.math"],
     parameters: {

--- a/packages/sample/genaisrc/mjs.genai.mjs
+++ b/packages/sample/genaisrc/mjs.genai.mjs
@@ -1,6 +1,6 @@
 script({
     title: "top-level-mjs",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: ["src/rag/markdown.md"],
     tests: {
         files: ["src/rag/markdown.md"],

--- a/packages/sample/genaisrc/mts.genai.mts
+++ b/packages/sample/genaisrc/mts.genai.mts
@@ -1,6 +1,6 @@
 script({
     title: "top-level-ts",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: ["src/rag/markdown.md"],
     tests: {
         files: ["src/rag/markdown.md"],

--- a/packages/sample/genaisrc/multi-turn.genai.js
+++ b/packages/sample/genaisrc/multi-turn.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     title: "Multi-turn conversation",
     files: ["src/rag/markdown.md"],
     system: ["system", "system.files"],

--- a/packages/sample/genaisrc/nested-args.genai.mts
+++ b/packages/sample/genaisrc/nested-args.genai.mts
@@ -1,6 +1,6 @@
 script({
     title: "summarize with nested arguments",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: ["src/rag/markdown.md", "src/penguins.csv"],
     tests: [
         {

--- a/packages/sample/genaisrc/output.genai.js
+++ b/packages/sample/genaisrc/output.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     title: "custom output",
     files: "src/rag/markdown.md", tests: { files: "src/rag/markdown.md" },
     system: [],

--- a/packages/sample/genaisrc/pdf-to-tweet.genai.js
+++ b/packages/sample/genaisrc/pdf-to-tweet.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     title: "generate a tweet from a pdf file",    
     tests: {
         files: "src/rag/loremipsum.pdf",

--- a/packages/sample/genaisrc/rag.genai.js
+++ b/packages/sample/genaisrc/rag.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "rag",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: "src/rag/*",
     tests: {
         files: "src/rag/*",

--- a/packages/sample/genaisrc/responseschema.genai.js
+++ b/packages/sample/genaisrc/responseschema.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
     },
     responseSchema: {

--- a/packages/sample/genaisrc/run-prompt-summarize.genai.js
+++ b/packages/sample/genaisrc/run-prompt-summarize.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "run prompt summarize",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: [
         {
             files: ["src/rag/markdown.md"],

--- a/packages/sample/genaisrc/script-files.genai.js
+++ b/packages/sample/genaisrc/script-files.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: "src/rag/*.md",
     tests: {},
 })

--- a/packages/sample/genaisrc/style/runprompt.genai.js
+++ b/packages/sample/genaisrc/style/runprompt.genai.js
@@ -15,7 +15,7 @@ const resPoem = await runPrompt(
         _.$`write haiku poem`
     },
     {
-        model: "openai:gpt-3.5-turbo",
+        model: "small",
         label: "generate poem",
         system: ["system"],
     }
@@ -27,7 +27,7 @@ const resJSON = await runPrompt(
         _.$`generate 3 random numbers between 1 and 10 and respond in JSON`
     },
     {
-        model: "openai:gpt-3.5-turbo",
+        model: "small",
         label: "generate json",
         responseType: "json_object",
     }

--- a/packages/sample/genaisrc/summarize-files-function.genai.js
+++ b/packages/sample/genaisrc/summarize-files-function.genai.js
@@ -1,7 +1,7 @@
 script({
     title: "summarize-files-function",
     tools: ["fs"],
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
         files: ["src/rag/*"],
         keywords: ["markdown", "lorem", "word"],

--- a/packages/sample/genaisrc/summarize-import.genai.mjs
+++ b/packages/sample/genaisrc/summarize-import.genai.mjs
@@ -1,6 +1,6 @@
 script({
     title: "summarize all files using import",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
         files: ["src/rag/markdown.md"],
         keywords: "markdown",

--- a/packages/sample/genaisrc/summarize-link.genai.js
+++ b/packages/sample/genaisrc/summarize-link.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "summarize links",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     description: "Given a URL, summarize the contents of the page",
     group: "hello world",
     system: ["system", "system.files"],

--- a/packages/sample/genaisrc/summarize-max-tokens.genai.js
+++ b/packages/sample/genaisrc/summarize-max-tokens.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "summarize with max tokens",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: ["src/rag/*"],
     tests: {
         files: ["src/rag/*"],

--- a/packages/sample/genaisrc/summarize-nested.genai.js
+++ b/packages/sample/genaisrc/summarize-nested.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "summarize nested",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: ["src/rag/*"],
     tests: {
         files: ["src/rag/*"],

--- a/packages/sample/genaisrc/summarize-pdf.genai.js
+++ b/packages/sample/genaisrc/summarize-pdf.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "summarize pdf",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
         files: "src/rag/loremipsum.pdf",
         keywords: ["lorem", "ipsum"],

--- a/packages/sample/genaisrc/summarize.genai.js
+++ b/packages/sample/genaisrc/summarize.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "summarize all files",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: "src/rag/markdown.md",
     tests: [
         {

--- a/packages/sample/genaisrc/summary-of-summary-gpt35.genai.js
+++ b/packages/sample/genaisrc/summary-of-summary-gpt35.genai.js
@@ -1,6 +1,6 @@
 script({
     title: "summary of summary - gp35",
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     files: ["src/rag/*"],
     tests: {
         files: ["src/rag/*"],

--- a/packages/sample/genaisrc/summary-of-summary-phi3.genai.js
+++ b/packages/sample/genaisrc/summary-of-summary-phi3.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     title: "summary of summary - phi3",
     files: ["src/rag/*.md"],
     tests: {

--- a/packages/sample/genaisrc/templating.genai.mts
+++ b/packages/sample/genaisrc/templating.genai.mts
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
         keywords: ["paris", "monday"],
         asserts: [

--- a/packages/sample/genaisrc/todo.genai.js
+++ b/packages/sample/genaisrc/todo.genai.js
@@ -4,7 +4,7 @@ script({
     group: "samples",
     system: ["system", "system.files"],
     temperature: 0,
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     tests: {
         files: "src/fib.ts",
         asserts: [{

--- a/packages/sample/genaisrc/tool-prompt.genai.js
+++ b/packages/sample/genaisrc/tool-prompt.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     parameters: {
         topic: {
             type: "string",

--- a/packages/sample/genaisrc/weather.genai.js
+++ b/packages/sample/genaisrc/weather.genai.js
@@ -1,5 +1,5 @@
 script({
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
     title: "Weather as function",
     description:
         "Query the weather for each city using a dummy weather function",

--- a/packages/sample/genaisrc/workspace.genai.mjs
+++ b/packages/sample/genaisrc/workspace.genai.mjs
@@ -1,4 +1,4 @@
-script({ model: "openai:gpt-3.5-turbo", tests: {} })
+script({ model: "small", tests: {} })
 const json = await workspace.readJSON("src/sample.json")
 if (json.foo !== "bar") throw new Error("Invalid JSON")
 const xml = await workspace.readXML("src/sample.xml")

--- a/packages/sample/genaisrc/writefile.genai.js
+++ b/packages/sample/genaisrc/writefile.genai.js
@@ -1,6 +1,6 @@
 script({
     tests: {},
-    model: "openai:gpt-3.5-turbo",
+    model: "small",
 })
 const fn = `temp/${Math.random() + ""}.txt`
 const content = JSON.stringify({ val: Math.random() + "" })


### PR DESCRIPTION


<!-- genaiscript begin pr-describe --><hr/>

- The `--models` option for the CLI commands has been updated to include `s (small model)` along with `m (model)`, `t (temperature)`, and `p (top-p)`.
- An attribute for `smallModel` has been added to the function `parseModelSpec(m: string)`.
- Support for "azure:gpt-4o-mini" has been added to the `smallModel` interface in `ModelConnectionOptions`.
- Multiple instances where the model "openai:gpt-3.5-turbo" was previously used have now been replaced with "small" in various JavaScript and TypeScript files, indicating a switch to a smaller model.
- Minor changes in the delimiter in `srows` constant and minor change in console log messages.
- A number of test files in `/packages/sample/genaisrc/` have had their models changed from "openai:gpt-3.5-turbo" to "small".

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11376074310)



<!-- genaiscript end pr-describe -->

