### PR TITLE
Fixup typo 'weahter' -> 'weather'

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Register JavaScript functions as **tools**.
 
 ```js
 defTool(
-    "weahter",
+    "weather",
     "query a weather web api",
     { location: "string" },
     async (args) =>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -54,7 +54,7 @@ $`Analyze FILE and extract data to JSON.`
 // save results to file
 defFileOutput("*.pdf.txt", "Extracted data", { schema })
 // tools
-defTool("weather", "live weahter", { city: "Paris" }, /* schema */
+defTool("weather", "live weather", { city: "Paris" }, /* schema */
     async ({ city }) => { ... "sunny" }) /* callback */
 // agents!
 defAgent("git", "answer git questions", "You are a git expert.", { tools: ["git"] })


### PR DESCRIPTION
Noticed this typo on the website and found another in the README.md.