### PR TITLE
fix: "convinient" → "convenient" in two README files

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,12 +1,12 @@
 # GenAIScript
 
-Scripting environment with convinient tooling for file ingestion, prompt development and structured data extraction.
+Scripting environment with convenient tooling for file ingestion, prompt development and structured data extraction.
 
 ```js
 // define the context
 def("FILE", env.files, { endsWith: ".pdf" })
 // define the data
-const schema = defSchema("DATA", 
+const schema = defSchema("DATA",
   { type: "array", items: { type: "string" } })
 // define the task
 $`Analyze FILE and

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,4 +1,4 @@
-Scripting environment with convinient tooling for file ingestion, prompt development and structured data extraction.
+Scripting environment with convenient tooling for file ingestion, prompt development and structured data extraction.
 
 [![A screenshot of a code editor with multiple tabs open, showing TypeScript code for a "Code Optimizer" script. The editor displays a script with a class named "Greeter" and a description of optimizing code performance. The right pane previews the script's output and optimization suggestions. The left sidebar contains file navigation and icons for various functions.](https://microsoft.github.io/genaiscript/images/visual-studio-code.png)](https://microsoft.github.io/genaiscript/images/visual-studio-code.png)
 


### PR DESCRIPTION
## Summary

This pull request fixes a typo in the `README.md` _(packages/vscode/README.md)_ file.

<img width="539" alt="Screenshot 2024-10-30 at 8 18 47 PM" src="https://github.com/user-attachments/assets/4085be77-79af-4373-a150-1bc90aaefaf8">


## Changes

- Corrected the spelling of "convenient" in the `README.md` file.

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [ ] I have signed the CLA (if required).
- [x] My changes are in a separate branch from `main`.
- [x] I have provided a clear description of the changes.