### PR TITLE
fix script create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test.sh
 esbuild.*.json
 esbuild.*.html
 dev/
+foobar*.genai.mjs

--- a/packages/cli/src/nodehost.ts
+++ b/packages/cli/src/nodehost.ts
@@ -289,7 +289,7 @@ export class NodeHost implements RuntimeHost {
         if (wksrx.test(name))
             name = join(this.projectFolder(), name.replace(wksrx, ""))
         // check if file exists
-        if (!(await exists(name))) return new Uint8Array()
+        if (!(await exists(name))) return undefined
         // read file
         const res = await readFile(name)
         return res ? new Uint8Array(res) : new Uint8Array()

--- a/packages/cli/src/scripts.ts
+++ b/packages/cli/src/scripts.ts
@@ -37,7 +37,7 @@ export async function listScripts() {
  */
 export async function createScript(name: string) {
     const t = coreCreateScript(name) // Call core function to create a script
-    const pr = await copyPrompt(t, { fork: false, name }) // Copy prompt definitions
+    const pr = await copyPrompt(t, { fork: true, name }) // Copy prompt definitions
     console.log(`created script at ${pr}`) // Notify the location of the created script
     await compileScript([]) // Compile all scripts immediately after creation
 }

--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -22,8 +22,7 @@ export async function writeText(fn: string, content: string) {
 
 export async function fileExists(fn: string) {
     try {
-        await host.readFile(fn)
-        return true
+        return await host.readFile(fn) !== undefined
     } catch {
         return false
     }

--- a/packages/core/src/xlsx.ts
+++ b/packages/core/src/xlsx.ts
@@ -42,6 +42,7 @@ export async function XLSXTryParse(
     options?: ParseXLSXOptions
 ): Promise<WorkbookSheet[]> {
     try {
+        if (!data) return []
         // Attempt to parse the XLSX data
         return await XLSXParse(data, options)
     } catch (e) {

--- a/packages/core/src/zip.ts
+++ b/packages/core/src/zip.ts
@@ -9,6 +9,7 @@ export async function unzip(
     options?: ParseZipOptions
 ): Promise<WorkspaceFile[]> {
     const { glob } = options || {}
+    if (!data) return []
     const res = unzipSync(data, {
         filter: (file: { name: string; originalSize: number }) => {
             if (glob) return isGlobMatch(file.name, glob)

--- a/packages/sample/src/cli.test.ts
+++ b/packages/sample/src/cli.test.ts
@@ -35,12 +35,20 @@ describe("run", async () => {
 describe("scripts", async () => {
     const cmd = "scripts"
     await test("list", async () => {
-        const res = await $`node ${cli} ${cmd}`
+        const res = await $`node ${cli} ${cmd} list`
         assert(
             res.stdout.includes(
                 "system.files, File generation, system, builtin, system"
             )
         )
+    })
+    await test("create foobar", async () => {
+        const res = await $`node ${cli} ${cmd} create foobar`
+        assert(res.stdout.includes("foobar"))
+    })
+    await test("create foobar", async () => {
+        const res = await $`node ${cli} ${cmd} create foobar`
+        assert(res.stdout.includes("foobar"))
     })
 })
 describe("cli", async () => {


### PR DESCRIPTION
Fix cli command 

```
scripts create foobar
```

<!-- genaiscript begin prd --><hr/>

### Pull Request Description

- 🛠️ **NodeHost File Handling:** Modified the `NodeHost` class to return `undefined` instead of an empty `Uint8Array` when a file does not exist, improving the clarity of return values.

- 🔄 **Script Creation Update:** Changed the `createScript` function to enable forking by default when copying prompt definitions, potentially enhancing script versioning and collaboration.

- 📂 **File Existence Check:** Simplified the `fileExists` function logic by directly checking if the file read result is `undefined`, which streamlines error handling.

- 📊 **XLSX Parsing Enhancement:** Added a safeguard in `XLSXTryParse` to return an empty array if no data is provided, preventing unnecessary parsing attempts.

- 📦 **ZIP Data Validation:** Implemented a check in the `unzip` function to return an empty array when no data is available, ensuring robustness against invalid input.

> generated by prd



<!-- genaiscript end prd -->

