### PR TITLE
Home page typo

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -124,7 +124,7 @@ or with a [command line](/genaiscript/getting-started/installation).
 Register JavaScript functions as [LLM tools](/genaiscript/reference/scripts/tools/)
 
 ```js wrap
-defTool("weather", "live weahter",
+defTool("weather", "live weather",
     { city: "Paris" }, // schema
     async ({ city }) => // callback
         { ... "sunny" }


### PR DESCRIPTION
"weahter" -> "weather"