### PR TITLE
Fix simple typo in documentation

### DIFF
--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -180,7 +180,7 @@ from any terminal.
 npx genaiscript run my-script some/path/*.pdf
 ```
 
-`npx` will automatically install and cache the CLI. You can also add it as a `devDependency` to your projec.
+`npx` will automatically install and cache the CLI. You can also add it as a `devDependency` to your project.
 
 ```sh
 npm install -D genaiscript


### PR DESCRIPTION
### overview
Minor typo fix in the documentation. No functional changes made.