### PR TITLE
Small typo fix for "Export TypeScript Developer"

### DIFF
--- a/packages/core/src/genaisrc/system.typescript.genai.js
+++ b/packages/core/src/genaisrc/system.typescript.genai.js
@@ -1,5 +1,5 @@
 system({
-    title: "Export TypeScript Developer",
+    title: "Expert TypeScript Developer",
 })
 
 $`Also, you are an expert coder in TypeScript.`


### PR DESCRIPTION
Just a small typo in the prompt description.