### PR TITLE
towards dedupping entries in prompt tree

### DIFF
--- a/packages/core/src/parsers.test.ts
+++ b/packages/core/src/parsers.test.ts
@@ -102,6 +102,6 @@ describe("parsers", () => {
             { test: "test string", arr: [1, 2, "32"], v: new Uint8Array(123) },
             { length: 20 }
         )
-        assert.strictEqual(result, "35a5db1d84a2da503d69") // Example hash value
+        assert.strictEqual(result, "2c34c8d7df7428c89c64") // Example hash value
     })
 })

--- a/packages/sample/genaisrc/dup.genai.mjs
+++ b/packages/sample/genaisrc/dup.genai.mjs
@@ -1,4 +1,9 @@
+script({
+    tests: {
+        keywords: "SUCCESS",
+    },
+})
 def("FILE", "hello world")
 def("FILE", "hello world")
 
-$`What is file?`
+$`If FILE is defined twice in the prompt, respond with FAIL; otherwise respond SUCCESS`

--- a/packages/sample/genaisrc/dup.genai.mjs
+++ b/packages/sample/genaisrc/dup.genai.mjs
@@ -1,0 +1,4 @@
+def("FILE", "hello world")
+def("FILE", "hello world")
+
+$`What is file?`


### PR DESCRIPTION


<!-- genaiscript begin pr-describe --><hr/>

- 🆕 **Function Addition:** Introduced a new `async function deduplicatePromptNode` in `promptdom.ts`. This function aims to identify and mark duplicate definitions and their content within a `PromptNode`. It logs an error for duplicates and ensures unique entries by using a set to track seen definitions.
  
- ⚙️ **Enhancement in Flow:** Integrated `deduplicatePromptNode` into the `renderPromptNode` process. If duplicates are detected, the system now traces them with a "deduplicate" label, enhancing error tracking and debugging.

- 📄 **Sample File Creation:** Added a new sample script `dup.genai.mjs` under `packages/sample/genaisrc/`. This script includes duplicate definitions demonstrating the duplicate detection feature. This likely serves as a test or example of the deduplication functionality.

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/11736878453)



<!-- genaiscript end pr-describe -->

