### PR TITLE
Add include options for script configuration

### DIFF
--- a/docs/src/content/docs/reference/configuration-files.mdx
+++ b/docs/src/content/docs/reference/configuration-files.mdx
@@ -26,4 +26,16 @@ The configuration file format is the following:
 
 <Code code={hostConfigurationSource} wrap={true} lang="ts" />
 
+## `envFile` property
+
 The final location of `envFile` will be used to load the secret in the environment variables.
+
+## `include` property
+
+The `include` property allows you to provide glob paths to include more scripts.
+Combined with a global configuration file, this allows to share script for a number of projects.
+
+```yaml title="genaiscript.config.yaml"
+include:
+    - "globalpath/*.genai.mjs"
+```

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -21,7 +21,7 @@ export async function buildProject(options?: {
     if (toolFiles?.length) {
         scriptFiles = toolFiles
     } else {
-        let tps = toolsPath
+        let tps = arrayify(toolsPath)
         if (!tps?.length) {
             tps = [GENAI_ANYJS_GLOB, ...arrayify(runtimeHost.config.include)]
         }

--- a/packages/core/src/hostconfiguration.ts
+++ b/packages/core/src/hostconfiguration.ts
@@ -6,4 +6,9 @@ export interface HostConfiguration {
      * Path to the .env file
      */
     envFile?: string
+
+    /**
+     * List of glob paths to scan for genai scripts
+     */
+    include?: string[]
 }


### PR DESCRIPTION
Introduce the `include` property to allow glob paths for including additional scripts, enhancing project configuration flexibility. Update related functions to support this new feature.