### PR TITLE
Add prediction feature for model outputs

### DIFF
--- a/docs/src/content/docs/reference/scripts/context.md
+++ b/docs/src/content/docs/reference/scripts/context.md
@@ -209,7 +209,7 @@ def("FILE", env.files, { detectPromptInjection: true })
 
 ### Predicted output
 
-Some models, like OpenAI gpt-4o and gpt-4o-mini, support specifying a [predicted output](https://platform.openai.com/docs/guides/predicted-outputs). This helps reduce latency for model responses where much of the response is known ahead of time.
+Some models, like OpenAI gpt-4o and gpt-4o-mini, support specifying a [predicted output](https://platform.openai.com/docs/guides/predicted-outputs) (with some [limitations](https://platform.openai.com/docs/guides/predicted-outputs#limitations)). This helps reduce latency for model responses where much of the response is known ahead of time.
 This can be helpful when asking the LLM to edit specific files.
 
 Set the `prediction: true` flag to enable it on a `def` call. Note that only a single file can be predicted.
@@ -217,6 +217,12 @@ Set the `prediction: true` flag to enable it on a `def` call. Note that only a s
 ```js
 def("FILE", env.files[0], { prediction: true })
 ```
+
+:::note
+
+This feature disables line number insertion.
+
+:::
 
 ## Data definition (`defData`)
 

--- a/docs/src/content/docs/reference/scripts/context.md
+++ b/docs/src/content/docs/reference/scripts/context.md
@@ -207,6 +207,17 @@ You can schedule a check for prompt injection/jai break with your configured [co
 def("FILE", env.files, { detectPromptInjection: true })
 ```
 
+### Predicted output
+
+Some models, like OpenAI gpt-4o and gpt-4o-mini, support specifying a [predicted output](https://platform.openai.com/docs/guides/predicted-outputs). This helps reduce latency for model responses where much of the response is known ahead of time.
+This can be helpful when asking the LLM to edit specific files.
+
+Set the `prediction: true` flag to enable it on a `def` call. Note that only a single file can be predicted.
+
+```js
+def("FILE", env.files[0], { prediction: true })
+```
+
 ## Data definition (`defData`)
 
 The `defData` function offers additional formatting options for converting a data object into a textual representation. It supports rendering objects as YAML, JSON, or CSV (formatted as a Markdown table).

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -1,6 +1,6 @@
 // cspell: disable
 import { MarkdownTrace } from "./trace"
-import { PromptImage, renderPromptNode } from "./promptdom"
+import { PromptImage, PromptPrediction, renderPromptNode } from "./promptdom"
 import { LanguageModelConfiguration, host } from "./host"
 import { GenerationOptions } from "./generation"
 import {
@@ -801,6 +801,7 @@ export async function executeChatSession(
     fileOutputs: FileOutput[],
     outputProcessors: PromptOutputProcessorHandler[],
     fileMerges: FileMergeHandler[],
+    prediction: PromptPrediction,
     completer: ChatCompletionHandler,
     chatParticipants: ChatParticipant[],
     genOptions: GenerationOptions
@@ -878,6 +879,10 @@ export async function executeChatSession(
                         top_logprobs,
                         messages,
                         tools: fallbackTools ? undefined : tools,
+                        // https://platform.openai.com/docs/guides/predicted-outputs
+                        prediction: prediction?.content
+                            ? prediction
+                            : undefined,
                         response_format:
                             responseType === "json_object"
                                 ? { type: responseType }

--- a/packages/core/src/expander.ts
+++ b/packages/core/src/expander.ts
@@ -8,7 +8,12 @@ import {
     MODEL_PROVIDER_AICI,
     PROMPTY_REGEX,
 } from "./constants"
-import { finalizeMessages, PromptImage, renderPromptNode } from "./promptdom"
+import {
+    finalizeMessages,
+    PromptImage,
+    PromptPrediction,
+    renderPromptNode,
+} from "./promptdom"
 import { createPromptContext } from "./promptcontext"
 import { evalPrompt } from "./evalprompt"
 import { renderAICI } from "./aici"
@@ -48,6 +53,7 @@ export async function callExpander(
     let outputProcessors: PromptOutputProcessorHandler[] = []
     let chatParticipants: ChatParticipant[] = []
     let fileOutputs: FileOutput[] = []
+    let prediction: PromptPrediction
     let aici: AICIRequest
 
     const logCb = (msg: any) => {
@@ -79,6 +85,7 @@ export async function callExpander(
                 outputProcessors: ops,
                 chatParticipants: cps,
                 fileOutputs: fos,
+                prediction: pred,
             } = await renderPromptNode(model, node, {
                 flexTokens: options.flexTokens,
                 trace,
@@ -91,6 +98,7 @@ export async function callExpander(
             outputProcessors = ops
             chatParticipants = cps
             fileOutputs = fos
+            prediction = pred
             if (errors?.length) {
                 for (const error of errors) trace.error(``, error)
                 status = "error"
@@ -127,6 +135,7 @@ export async function callExpander(
         outputProcessors,
         chatParticipants,
         fileOutputs,
+        prediction,
         aici,
     })
 }
@@ -232,7 +241,8 @@ export async function expandTemplate(
     const outputProcessors = prompt.outputProcessors.slice(0)
     const chatParticipants = prompt.chatParticipants.slice(0)
     const fileOutputs = prompt.fileOutputs.slice(0)
-
+    const prediction = prompt.prediction
+    
     if (prompt.logs?.length) trace.details("📝 console.log", prompt.logs)
     if (prompt.aici) trace.fence(prompt.aici, "yaml")
     trace.endDetails()
@@ -380,6 +390,7 @@ ${schemaTs}
         responseType,
         responseSchema,
         fileMerges,
+        prediction,
         outputProcessors,
         chatParticipants,
         fileOutputs,

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -240,7 +240,7 @@ export function createDefDiff(
 // Function to render a definition node to a string.
 function renderDefNode(def: PromptDefNode): string {
     const { name, resolved: file } = def
-    const { language, lineNumbers, schema } = def || {}
+    const { language, lineNumbers, schema, prediction } = def || {}
 
     file.content = extractRange(file.content, def)
 
@@ -250,7 +250,8 @@ function renderDefNode(def: PromptDefNode): string {
             : PROMPT_FENCE
     const norm = (s: string, lang: string) => {
         s = (s || "").replace(/\n*$/, "")
-        if (s && lineNumbers) s = addLineNumbers(s, { language: lang })
+        if (s && lineNumbers && !prediction)
+            s = addLineNumbers(s, { language: lang })
         if (s) s += "\n"
         return s
     }

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -138,6 +138,7 @@ export async function runTemplate(
             outputProcessors,
             chatParticipants,
             fileOutputs,
+            prediction,
             status,
             statusText,
             temperature,
@@ -221,6 +222,7 @@ export async function runTemplate(
             fileOutputs,
             outputProcessors,
             fileMerges,
+            prediction,
             completer,
             chatParticipants,
             genOptions

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -20,6 +20,7 @@ import {
     createSystemNode,
     finalizeMessages,
     PromptImage,
+    PromptPrediction,
 } from "./promptdom"
 import { MarkdownTrace } from "./trace"
 import { GenerationOptions } from "./generation"
@@ -626,6 +627,7 @@ export function createChatGenerationContext(
             const fileMerges: FileMergeHandler[] = []
             const outputProcessors: PromptOutputProcessorHandler[] = []
             const fileOutputs: FileOutput[] = []
+            let prediction: PromptPrediction
 
             // expand template
             const { provider } = parseModelIdentifier(genOptions.model)
@@ -644,6 +646,7 @@ export function createChatGenerationContext(
                     outputProcessors: ops,
                     fileOutputs: fos,
                     images: imgs,
+                    prediction: pred,
                 } = await renderPromptNode(genOptions.model, node, {
                     flexTokens: genOptions.flexTokens,
                     trace: runTrace,
@@ -657,6 +660,7 @@ export function createChatGenerationContext(
                 outputProcessors.push(...ops)
                 fileOutputs.push(...fos)
                 images.push(...imgs)
+                prediction = pred
 
                 if (errors?.length) {
                     logError(errors.map((err) => errorMessage(err)).join("\n"))
@@ -773,6 +777,7 @@ export function createChatGenerationContext(
                     fileOutputs,
                     outputProcessors,
                     fileMerges,
+                    prediction,
                     completer,
                     chatParticipants,
                     genOptions

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -930,6 +930,12 @@ interface DefOptions
      * By default, throws an error if the value in def is empty.
      */
     ignoreEmpty?: boolean
+
+    /**
+     * The content of the def is a predicted output.
+     * @see https://platform.openai.com/docs/guides/predicted-outputs
+     */
+    prediction?: boolean
 }
 
 /**

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -933,7 +933,7 @@ interface DefOptions
 
     /**
      * The content of the def is a predicted output.
-     * @see https://platform.openai.com/docs/guides/predicted-outputs
+     * This setting disables line numbers.
      */
     prediction?: boolean
 }

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -129,6 +129,8 @@ export class GenerationStats {
             completion_tokens_details: {
                 audio_tokens: 0,
                 reasoning_tokens: 0,
+                accepted_prediction_tokens: 0,
+                rejected_prediction_tokens: 0,
             },
             prompt_tokens_details: {
                 audio_tokens: 0,
@@ -169,6 +171,12 @@ export class GenerationStats {
             res.completion_tokens += childUsage.completion_tokens
             res.prompt_tokens += childUsage.prompt_tokens
             res.total_tokens += childUsage.total_tokens
+            res.completion_tokens_details.accepted_prediction_tokens +=
+                childUsage.completion_tokens_details
+                    .accepted_prediction_tokens ?? 0
+            res.completion_tokens_details.rejected_prediction_tokens +=
+                childUsage.completion_tokens_details
+                    .rejected_prediction_tokens ?? 0
             res.completion_tokens_details.audio_tokens +=
                 childUsage.completion_tokens_details.audio_tokens
             res.completion_tokens_details.reasoning_tokens +=
@@ -232,7 +240,16 @@ export class GenerationStats {
                 "reasoning tokens",
                 this.usage.completion_tokens_details.reasoning_tokens
             )
-
+        if (this.usage.completion_tokens_details?.accepted_prediction_tokens)
+            trace.itemValue(
+                "accepted prediction tokens",
+                this.usage.completion_tokens_details.accepted_prediction_tokens
+            )
+        if (this.usage.completion_tokens_details?.rejected_prediction_tokens)
+            trace.itemValue(
+                "rejected prediction tokens",
+                this.usage.completion_tokens_details.rejected_prediction_tokens
+            )
         if (this.chatTurns.length > 1) {
             trace.startDetails("chat turns")
             try {

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -336,6 +336,10 @@ export class GenerationStats {
             usage.prompt_tokens_details?.audio_tokens ?? 0
         this.usage.completion_tokens_details.reasoning_tokens +=
             usage.prompt_tokens_details?.cached_tokens ?? 0
+        this.usage.completion_tokens_details.accepted_prediction_tokens +=
+            usage.completion_tokens_details?.accepted_prediction_tokens ?? 0
+        this.usage.completion_tokens_details.rejected_prediction_tokens +=
+            usage.completion_tokens_details?.rejected_prediction_tokens ?? 0
 
         const { provider } = parseModelIdentifier(this.model)
         const chatTurn = {

--- a/packages/sample/genaisrc/prediction.genai.mjs
+++ b/packages/sample/genaisrc/prediction.genai.mjs
@@ -1,4 +1,5 @@
 script({
+    model: "openai:gpt-4o",
     files: "src/greeter.ts",
     tests: {
         files: "src/greeter.ts",
@@ -7,4 +8,4 @@ script({
 
 def("FILE", env.files[0], { prediction: true })
 
-$`Add comments to every line of code. Respond only with code.`
+$`Update FILE with a top level file comment that summarize the content.`

--- a/packages/sample/genaisrc/prediction.genai.mjs
+++ b/packages/sample/genaisrc/prediction.genai.mjs
@@ -1,0 +1,10 @@
+script({
+    files: "src/greeter.ts",
+    tests: {
+        files: "src/greeter.ts",
+    },
+})
+
+def("FILE", env.files[0], { prediction: true })
+
+$`Add comments to every line of code. Respond only with code.`


### PR DESCRIPTION
Introduce a prediction flag to enable anticipated outputs for specific model calls, enhancing response efficiency when the output is largely known in advance. This feature supports improved interaction with models like OpenAI's gpt-4o.