### PR TITLE
proxy support for fetch methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
         "npm-check-updates": "^17.1.11",
         "prettier": "^3.3.3",
         "zx": "^8.2.2"
+    },
+    "dependencies": {
+        "https-proxy-agent": "^7.0.5"
     }
 }


### PR DESCRIPTION
When `HTTP_PROXY` or `HTTPS_PROXY` env variables are present, the `fetch` method is enriched with a proxy from `https-proxy-agent`.


Tested locally using `tinyproxy` and the following script `test.genai.mjs`
```
script({
    title: "Test for proxy",
    description: "Simple script to test fetch with proxy",
    model: "github:o1-mini",
    temperature: 0,
})


const url = "http://neverssl.com";    // HTTTP
const urls = "https://raw.githubusercontent.com/sahuguet/genaiscript/refs/heads/main/.gitignore"; // HTTPS
const { text, file } = await fetchText(url)

console.log(text);
```

using `HTTP_PROXY=http://127.0.0.1:3128 node packages/cli/built/genaiscript.cjs run test.genai.mjs`


Note: when I created the commit, some changes were added, not sure why.
```
-    const cmd = `curl "${url}" \\
---no-buffer \\
+    const cmd = `curl ${url} \\
 ${Object.entries(headers)
     .map(([k, v]) => `-H "${k}: ${v}"`)
-    .join(" \\\n")} \\
+    .join("\\\n")} \\
```