### PR TITLE
Add GitHub helper to create issue comments

### DIFF
--- a/docs/src/content/docs/reference/scripts/github.md
+++ b/docs/src/content/docs/reference/scripts/github.md
@@ -48,6 +48,13 @@ const issueComments = await github.listIssueComments(issues[0].number)
 console.log(issueComments)
 ```
 
+You can also create issue comments:
+
+```js
+// Use issue number!
+await github.createIssueComment(issues[0].number, "Hello, world!")
+```
+
 ### Pull Requests
 
 Query pull requests and pull request review comments using `listPullRequests` and `listPullRequestReviewComments`.

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -584,6 +584,25 @@ export class GitHubClient implements GitHub {
         return data
     }
 
+    async createIssueComment(
+        issue_number: number | string,
+        body: string
+    ): Promise<GitHubComment> {
+        if (typeof issue_number === "string")
+            issue_number = parseInt(issue_number)
+        const { client, owner, repo } = await this.api()
+        if (isNaN(issue_number)) issue_number = (await this._connection).issue
+        if (isNaN(issue_number)) return undefined
+        const { data } = await client.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number,
+            body,
+        })
+        return data
+    }
+
+
     async listPullRequests(
         options?: {
             state?: "open" | "closed" | "all"

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -457,10 +457,9 @@ export class GitHubClient implements GitHub {
         this._info = info
     }
 
-    private connection(): Promise<Omit<GithubConnectionInfo, "issue">> {
-        if (!this._connection) {
+    private connection(): Promise<GithubConnectionInfo> {
+        if (!this._connection)
             this._connection = githubParseEnv(process.env, this._info)
-        }
         return this._connection
     }
 
@@ -536,6 +535,7 @@ export class GitHubClient implements GitHub {
             owner,
             ref,
             refName,
+            issue,
         } = await this.connection()
         return Object.freeze({
             baseUrl,
@@ -544,6 +544,7 @@ export class GitHubClient implements GitHub {
             auth,
             ref,
             refName,
+            issueNumber: issue
         })
     }
 
@@ -601,7 +602,6 @@ export class GitHubClient implements GitHub {
         })
         return data
     }
-
 
     async listPullRequests(
         options?: {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1753,6 +1753,7 @@ interface GitHubOptions {
     auth?: string
     ref?: string
     refName?: string
+    issueNumber?: number
 }
 
 type GitHubWorkflowRunStatus =

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1941,9 +1941,19 @@ interface GitHub {
 
     /**
      * Gets the details of a GitHub issue
-     * @param number issue number (not the issue id!). If missing, reads value from GITHUB_ISSUE environment variable.
+     * @param issueNumber issue number (not the issue id!). If undefined, reads value from GITHUB_ISSUE environment variable.
      */
-    getIssue(number?: number | string): Promise<GitHubIssue>
+    getIssue(issueNumber?: number | string): Promise<GitHubIssue>
+
+    /**
+     * Create a GitHub issue comment
+     * @param issueNumber issue number (not the issue id!). If undefined, reads value from GITHUB_ISSUE environment variable.
+     * @param body the body of the comment as Github Flavored markdown
+     */
+    createIssueComment(
+        issueNumber: number | string,
+        body: string
+    ): Promise<GitHubComment>
 
     /**
      * Lists comments for a given issue

--- a/packages/sample/genaisrc/github.genai.mts
+++ b/packages/sample/genaisrc/github.genai.mts
@@ -3,6 +3,9 @@ script({
     tests: {},
 })
 
+const info = await github.info()
+console.log(info)
+
 const ts = github.client("microsoft", "typescript")
 const tsissues = await ts.listIssues({ count: 5 })
 console.log({ typescriptIssues: tsissues.map((i) => i.title) })
@@ -62,3 +65,6 @@ console.log(
 
 const branches = await github.listBranches()
 console.log(branches)
+
+if (info.issueNumber)
+    await github.createIssueComment(info.issueNumber, "Hello from GenAIClient")


### PR DESCRIPTION
Introduce a method to create comments on GitHub issues, enhancing interaction with issues through the API. Update the interface to include this new functionality.

<!-- genaiscript begin pr-describe --><hr/>

-The `GitHubClient` class now includes a new method for creating issue comments. This method accepts an issue number and a comment body, returning the created comment as a `GitHubComment`. #Enhancement

-The types for GitHub-related methods have been updated to more accurately reflect parameter names (e.g., "issueNumber" instead of just "number"). #CodeCleanliness

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/12167450813)



<!-- genaiscript end pr-describe -->

