### PR TITLE
refactor: ♻️ refine JSON schema typing and processing

### DIFF
--- a/packages/core/src/prompty.ts
+++ b/packages/core/src/prompty.ts
@@ -75,13 +75,16 @@ function promptyFrontmatterToMeta(frontmatter: PromptyFrontmatter): PromptArgs {
         configuration,
         parameters: modelParameters,
     } = model ?? {}
-    const parameters: Record<string, JSONSchemaType> = inputs ? Object.entries(
-        inputs
-    ).reduce<Record<string, JSONSchemaType>>((acc, [k, v]) => {
-        if (v.type === "list") acc[k] = { type: "array" }
-        else acc[k] = v
-        return acc
-    }, {}) : undefined
+    const parameters: Record<string, JSONSchemaSimpleType> = inputs
+        ? Object.entries(inputs).reduce<Record<string, JSONSchemaSimpleType>>(
+              (acc, [k, v]) => {
+                  if (v.type === "list") acc[k] = { type: "array" }
+                  else acc[k] = v
+                  return acc
+              },
+              {}
+          )
+        : undefined
     if (parameters && sample && typeof sample === "object")
         for (const p in sample) {
             const s = sample[p]

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -52,6 +52,7 @@ describe("schema", () => {
                 "    population: number,\n" +
                 "    // The URL of the city's Wikipedia page.\n" +
                 "    url: string,\n" +
+                "    extra?: string | number,\n" +
                 "  }>"
         )
     }),

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -25,6 +25,16 @@ describe("schema", () => {
                         type: "string",
                         description: "The URL of the city's Wikipedia page.",
                     },
+                    extra: {
+                        anyOf: [
+                            {
+                                type: "string",
+                            },
+                            {
+                                type: "number",
+                            }
+                        ]
+                    }
                 },
                 required: ["name", "population", "url"],
             },

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -93,7 +93,7 @@ export function JSONSchemaStringifyToTypeScript(
             return n.anyOf
                 .map((x) => {
                     const v = stringifyNode(x)
-                    return v ? `(${v})` : undefined
+                    return /\s/.test(v) ? `(${v})` : v
                 })
                 .filter((x) => x)
                 .join(" | ")

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1010,24 +1010,34 @@ type JSONSchemaTypeName =
     | "array"
     | "null"
 
-type JSONSchemaType =
+type JSONSchemaSimpleType =
     | JSONSchemaString
     | JSONSchemaNumber
     | JSONSchemaBoolean
     | JSONSchemaObject
     | JSONSchemaArray
-    | null
 
-interface JSONSchemaString {
+type JSONSchemaType = JSONSchemaSimpleType | JSONSchemaAnyOf | null
+
+interface JSONSchemaAnyOf {
+    anyOf: JSONSchemaType[]
+}
+
+interface JSONSchemaDescripted {
+    /**
+     * A clear description of the property.
+     */
+    description?: string
+}
+
+interface JSONSchemaString extends JSONSchemaDescripted {
     type: "string"
     enum?: string[]
-    description?: string
     default?: string
 }
 
-interface JSONSchemaNumber {
+interface JSONSchemaNumber extends JSONSchemaDescripted {
     type: "number" | "integer"
-    description?: string
     default?: number
     minimum?: number
     exclusiveMinimum?: number
@@ -1035,16 +1045,14 @@ interface JSONSchemaNumber {
     exclusiveMaximum?: number
 }
 
-interface JSONSchemaBoolean {
+interface JSONSchemaBoolean extends JSONSchemaDescripted {
     type: "boolean"
-    description?: string
     default?: boolean
 }
 
-interface JSONSchemaObject {
+interface JSONSchemaObject extends JSONSchemaDescripted {
     $schema?: string
     type: "object"
-    description?: string
     properties?: {
         [key: string]: JSONSchemaType
     }
@@ -1054,10 +1062,9 @@ interface JSONSchemaObject {
     default?: object
 }
 
-interface JSONSchemaArray {
+interface JSONSchemaArray extends JSONSchemaDescripted {
     $schema?: string
     type: "array"
-    description?: string
     items?: JSONSchemaType
 
     default?: any[]


### PR DESCRIPTION
Fix for https://github.com/microsoft/genaiscript/issues/913

<!-- genaiscript begin pr-describe --><hr/>

- 🔄 `JSONSchemaType` now includes `null`
- 👼 Introducing a new interface `JSONSchemaDescripted` for common properties like `description`
- 🦄 New interface `JSONSchemaAnyOf` allows complex schemas to be defined using the `anyOf` keyword, enabling more flexibility in what types can be accepted
- 💡 Enhanced `JSONSchemaString`, `JSONSchemaNumber`, `JSONSchemaBoolean`, and `JSONSchemaObject` by extending them from `JSONSchemaDescripted`, which now includes a common `description` property with an optional type

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/12187798891)



<!-- genaiscript end pr-describe -->

