### PR TITLE
add pattern support in json string

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -126,6 +126,11 @@ export function JSONSchemaStringifyToTypeScript(
                 if (n.exclusiveMaximum !== undefined)
                     doc.push(`exclusiveMaximum : ${n.exclusiveMaximum}`)
                 if (n.maximum !== undefined) doc.push(`maximum: ${n.maximum}`)
+                break
+            }
+            case "string": {
+                if (n.pattern) doc.push(`pattern: ${n.pattern}`)
+                break
             }
         }
         return doc.filter((d) => d).join("\n")

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1034,6 +1034,7 @@ interface JSONSchemaString extends JSONSchemaDescripted {
     type: "string"
     enum?: string[]
     default?: string
+    pattern?: string
 }
 
 interface JSONSchemaNumber extends JSONSchemaDescripted {


### PR DESCRIPTION


<!-- genaiscript begin pr-describe --><hr/>

```
* Added pattern property to JSONSchemaString type in "types/prompt_template.d.ts"
* Refactored JSONSchemaStringifyToTypeScript function logic to handle string type schema correctly, introducing a `break` statement after handling non-string types
```

> generated by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/12193529390)



<!-- genaiscript end pr-describe -->

