### PR TITLE
Use random port for server connection

### DIFF
--- a/packages/vscode/src/connectioninfotree.ts
+++ b/packages/vscode/src/connectioninfotree.ts
@@ -30,11 +30,11 @@ class ConnectionInfoTreeDataProvider
         element: ConnectionInfoTreeData
     ): Promise<vscode.TreeItem> {
         const item = new vscode.TreeItem(element.provider)
-        const res =
-            await this.state.host.server.client.getLanguageModelConfiguration(
-                element.provider + ":*",
-                { token: false }
-            )
+        const client = await this.state.host.server.client()
+        const res = await client.getLanguageModelConfiguration(
+            element.provider + ":*",
+            { token: false }
+        )
         if (res) {
             item.description = res.base || "?"
             item.tooltip = YAMLStringify(res)

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -61,7 +61,8 @@ export async function activate(context: ExtensionContext) {
             }
         }),
         registerCommand("genaiscript.info.env", async () => {
-            state.host.server.client.infoEnv()
+            const client = await state.host.server.client()
+            await client.infoEnv()
         }),
         registerCommand(
             "genaiscript.openIssueReporter",

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -279,7 +279,8 @@ export class ExtensionState extends EventTarget {
         }
 
         // todo: send js source
-        const { runId, request } = await this.host.server.client.startScript(
+        const client = await this.host.server.client()
+        const { runId, request } = await client.startScript(
             template.id,
             files,
             {
@@ -344,7 +345,8 @@ export class ExtensionState extends EventTarget {
             a.computing = false
             if (a.controller && !a.controller?.signal?.aborted)
                 a.controller.abort?.("user cancelled")
-            this.host.server.client.cancel()
+            const client = await this.host.server.client({ doNotStart: true })
+            client?.cancel()
             this.dispatchChange()
             await delay(100)
         }
@@ -390,7 +392,8 @@ export class ExtensionState extends EventTarget {
                 await saveAllTextDocuments()
                 performance.mark(`project-start`)
                 performance.mark(`scan-tools`)
-                const newProject = await this.host.server.client.listScripts()
+                const client = await this.host.server.client()
+                const newProject = await client.listScripts()
                 await this.setProject(newProject)
                 this.setDiagnostics()
                 logMeasure(`project`, `project-start`, `project-end`)

--- a/packages/vscode/src/testcontroller.ts
+++ b/packages/vscode/src/testcontroller.ts
@@ -51,8 +51,7 @@ export async function activateTestController(state: ExtensionState) {
         if (!state.project) await state.parseWorkspace()
         if (token?.isCancellationRequested) return
         const scripts =
-            state.project.scripts.filter((t) => arrayify(t.tests)?.length) ||
-            []
+            state.project.scripts.filter((t) => arrayify(t.tests)?.length) || []
         // refresh existing
         for (const script of scripts) {
             getOrCreateFile(script)
@@ -96,7 +95,8 @@ export async function activateTestController(state: ExtensionState) {
             }
 
             const serverUrl = await startTestViewer()
-            await state.host.server.client.init()
+            const client = await state.host.server.client()
+            await client.init()
             try {
                 for (const { script, test } of scripts) {
                     // check for cancellation
@@ -105,7 +105,7 @@ export async function activateTestController(state: ExtensionState) {
                         return
                     }
                     run.started(test)
-                    const res = await state.host.server.client.runTest(script)
+                    const res = await client.runTest(script)
                     for (const r of res.value || []) {
                         run.appendOutput(
                             `${r.ok ? EMOJI_SUCCESS : EMOJI_FAIL} ${r.script} ${errorMessage(r.error) || ""} ${serverUrl}/eval?evalId=${encodeURIComponent(r.value?.evalId)}`,

--- a/packages/vscode/src/vshost.ts
+++ b/packages/vscode/src/vshost.ts
@@ -186,10 +186,8 @@ export class VSCodeHost extends EventTarget implements Host {
         modelId: string,
         options?: { token?: boolean } & AbortSignalOptions & TraceOptions
     ): Promise<LanguageModelConfiguration> {
-        const tok = await this.server.client.getLanguageModelConfiguration(
-            modelId,
-            options
-        )
+        const client = await this.server.client()
+        const tok = await client.getLanguageModelConfiguration(modelId, options)
         return tok
     }
 
@@ -200,12 +198,8 @@ export class VSCodeHost extends EventTarget implements Host {
         args: string[],
         options: ShellOptions
     ): Promise<ShellOutput> {
-        const res = await this.server.client.exec(
-            containerId,
-            command,
-            args,
-            options
-        )
+        const client = await this.server.client()
+        const res = await client.exec(containerId, command, args, options)
         return res.value
     }
 }


### PR DESCRIPTION
Implement functionality to use a random open port for server connections, enhancing flexibility and avoiding port conflicts. Update client initialization to accommodate this change.