### PR TITLE
Refactor Prompt Node Options Structure

### DIFF
--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -1087,20 +1087,17 @@ export function tracePromptResult(
 export function appendUserMessage(
     messages: ChatCompletionMessageParam[],
     content: string,
-    options?: { ephemeral?: boolean }
+    options?: ContextExpansionOptions
 ) {
     if (!content) return
-    const { ephemeral } = options || {}
+    const { cacheControl } = options || {}
     let last = messages.at(-1) as ChatCompletionUserMessageParam
-    if (
-        last?.role !== "user" ||
-        !!ephemeral !== (last?.cacheControl === "ephemeral")
-    ) {
+    if (last?.role !== "user" || options?.cacheControl !== last?.cacheControl) {
         last = {
             role: "user",
             content: "",
         } satisfies ChatCompletionUserMessageParam
-        if (ephemeral) last.cacheControl = "ephemeral"
+        if (cacheControl) last.cacheControl = cacheControl
         messages.push(last)
     }
     if (last.content) {
@@ -1112,20 +1109,20 @@ export function appendUserMessage(
 export function appendAssistantMessage(
     messages: ChatCompletionMessageParam[],
     content: string,
-    options?: { ephemeral?: boolean }
+    options?: ContextExpansionOptions
 ) {
     if (!content) return
-    const { ephemeral } = options || {}
+    const { cacheControl } = options || {}
     let last = messages.at(-1) as ChatCompletionAssistantMessageParam
     if (
         last?.role !== "assistant" ||
-        !!ephemeral !== (last?.cacheControl === "ephemeral")
+        options?.cacheControl !== last?.cacheControl
     ) {
         last = {
             role: "assistant",
             content: "",
         } satisfies ChatCompletionAssistantMessageParam
-        if (ephemeral) last.cacheControl = "ephemeral"
+        if (cacheControl) last.cacheControl = cacheControl
         messages.push(last)
     }
     if (last.content) {
@@ -1137,21 +1134,21 @@ export function appendAssistantMessage(
 export function appendSystemMessage(
     messages: ChatCompletionMessageParam[],
     content: string,
-    options?: { ephemeral?: boolean }
+    options?: ContextExpansionOptions
 ) {
     if (!content) return
-    const { ephemeral } = options || {}
+    const { cacheControl } = options || {}
 
     let last = messages[0] as ChatCompletionSystemMessageParam
     if (
         last?.role !== "system" ||
-        !!ephemeral !== (last?.cacheControl === "ephemeral")
+        options?.cacheControl !== last?.cacheControl
     ) {
         last = {
             role: "system",
             content: "",
         } as ChatCompletionSystemMessageParam
-        if (ephemeral) last.cacheControl = "ephemeral"
+        if (cacheControl) last.cacheControl = cacheControl
         messages.unshift(last)
     }
     if (last.content) {

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -333,7 +333,7 @@ function renderDefNode(def: PromptDefNode): string {
 async function renderDefDataNode(n: PromptDefDataNode): Promise<string> {
     const { name, headers, priority, cacheControl, query } = n
     let data = n.resolved
-    let format = n?.format
+    let format = n.format
     if (
         !format &&
         Array.isArray(data) &&

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -173,7 +173,7 @@ export function createChatTurnGenerationContext(
                     return res
                 },
                 cacheControl: (cc) => {
-                    current.ephemeral = cc === "ephemeral"
+                    current.cacheControl = cc
                     return res
                 },
             } satisfies PromptTemplateString)

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -952,11 +952,6 @@ interface ContextExpansionOptions {
     flex?: number
 
     /**
-     * @deprecated use cacheControl instead
-     */
-    ephemeral?: boolean
-
-    /**
      * Caching policy for this text. `ephemeral` means the prefix can be cached for a short amount of time.
      */
     cacheControl?: PromptCacheControlType

--- a/packages/sample/genaisrc/ephemeral.genai.mjs
+++ b/packages/sample/genaisrc/ephemeral.genai.mjs
@@ -1,6 +1,7 @@
 script({
     title: "summarize all files with caching",
     files: "src/rag/markdown.md",
+    model: "small",
     tests: [
         {
             files: "src/rag/markdown.md",


### PR DESCRIPTION
The refactor moves options into explicit properties for `PromptDefNode` and `PromptDefDataNode`, enhancing clarity and structure in the codebase. Additionally, it updates related functions to accommodate this change.

<!-- genaiscript begin pr-describe --><hr/>

* Renamed script to `ephemeral.genai.mjs` from `summarize-cached.genai.mjs`. 🔄
* Added new option `model: "small"` to the script. This could affect how the model processes the data it receives. 👨‍💻🔍

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/12482847618) may be incorrect



<!-- genaiscript end pr-describe -->

