### PR TITLE
send llm output through output trace

### DIFF
--- a/packages/cli/src/info.ts
+++ b/packages/cli/src/info.ts
@@ -5,17 +5,11 @@
  */
 
 import { resolveLanguageModelConfigurations } from "../../core/src/config"
-import { parseTokenFromEnv } from "../../core/src/connection"
-import { MODEL_PROVIDERS } from "../../core/src/constants"
-import { errorMessage } from "../../core/src/error"
 import { host, runtimeHost } from "../../core/src/host"
-import { resolveLanguageModel } from "../../core/src/lm"
 import {
     ModelConnectionInfo,
     resolveModelConnectionInfo,
 } from "../../core/src/models"
-import { LanguageModelConfiguration } from "../../core/src/server/messages"
-import { deleteEmptyValues } from "../../core/src/util"
 import { CORE_VERSION } from "../../core/src/version"
 import { YAMLStringify } from "../../core/src/yaml"
 import { buildProject } from "./build"

--- a/packages/cli/src/scripts.ts
+++ b/packages/cli/src/scripts.ts
@@ -8,7 +8,7 @@ import {
     fixPromptDefinitions,
     createScript as coreCreateScript,
 } from "../../core/src/scripts"
-import { deleteEmptyValues, logInfo, logVerbose } from "../../core/src/util"
+import { logInfo, logVerbose } from "../../core/src/util"
 import { runtimeHost } from "../../core/src/host"
 import { RUNTIME_ERROR_CODE } from "../../core/src/constants"
 import {
@@ -17,6 +17,7 @@ import {
     ScriptFilterOptions,
 } from "../../core/src/ast"
 import { YAMLStringify } from "../../core/src/yaml"
+import { deleteEmptyValues } from "../../core/src/clone"
 
 /**
  * Lists all the scripts in the project.

--- a/packages/core/src/clone.ts
+++ b/packages/core/src/clone.ts
@@ -1,0 +1,20 @@
+export function deleteEmptyValues<T extends Record<string, any>>(o: T): T {
+    if (typeof o === "object")
+        for (const k in o) {
+            const v = o[k]
+            if (
+                v === undefined ||
+                v === null ||
+                v === "" ||
+                (Array.isArray(v) && !v.length)
+            )
+                delete o[k]
+        }
+    return o
+}
+
+export function cleanedClone(o: any) {
+    const c = structuredClone(o)
+    deleteEmptyValues(c)
+    return c
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -14,7 +14,7 @@ import {
 } from "./server/messages"
 import { parseTokenFromEnv } from "./connection"
 import { resolveLanguageModel } from "./lm"
-import { deleteEmptyValues } from "./util"
+import { deleteEmptyValues } from "./clone"
 import { errorMessage } from "./error"
 
 export async function resolveGlobalConfiguration(

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,7 +2,6 @@ import CONFIGURATION_DATA from "./llms.json"
 export const CHANGE = "change"
 export const TRACE_CHUNK = "traceChunk"
 export const TRACE_DETAILS = "traceDetails"
-export const CHAT_PROGRESS = "chatProgress"
 export const RECONNECT = "reconnect"
 export const OPEN = "open"
 export const MAX_TOOL_CALLS = 10000

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,6 +2,7 @@ import CONFIGURATION_DATA from "./llms.json"
 export const CHANGE = "change"
 export const TRACE_CHUNK = "traceChunk"
 export const TRACE_DETAILS = "traceDetails"
+export const CHAT_PROGRESS = "chatProgress"
 export const RECONNECT = "reconnect"
 export const OPEN = "open"
 export const MAX_TOOL_CALLS = 10000

--- a/packages/core/src/llms.ts
+++ b/packages/core/src/llms.ts
@@ -2,7 +2,7 @@ import { Model } from "@anthropic-ai/sdk/resources/index.mjs"
 import { LARGE_MODEL_ID, SMALL_MODEL_ID, VISION_MODEL_ID } from "./constants"
 import { ModelConfiguration, ModelConfigurations } from "./host"
 import LLMS from "./llms.json"
-import { deleteEmptyValues } from "./util"
+import { deleteEmptyValues } from "./clone"
 
 export function defaultModelConfigurations(): ModelConfigurations {
     const aliases = [

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -122,7 +122,8 @@ export async function runTemplate(
     assert(options !== undefined)
     assert(options.trace !== undefined)
     assert(options.outputTrace !== undefined)
-    const { label, cliInfo, trace, outputTrace, cancellationToken, model } = options
+    const { label, cliInfo, trace, outputTrace, cancellationToken, model } =
+        options
     const version = CORE_VERSION
     assert(model !== undefined)
 
@@ -135,7 +136,7 @@ export async function runTemplate(
         }
 
         // Resolve expansion variables for the template
-        const vars = await resolveExpansionVars(
+        const env = await resolveExpansionVars(
             prj,
             trace,
             template,
@@ -163,7 +164,8 @@ export async function runTemplate(
             logprobs,
             topLogprobs,
             disposables,
-        } = await expandTemplate(prj, template, options, vars)
+        } = await expandTemplate(prj, template, options, env)
+        const { output, generator, secrets, ...restEnv } = env
 
         // Handle failed expansion scenario
         if (status !== "success" || !messages.length) {
@@ -172,7 +174,7 @@ export async function runTemplate(
                 status: status as GenerationStatus,
                 statusText,
                 messages,
-                vars,
+                env: restEnv,
                 label,
                 version,
                 text: outputTrace.content,
@@ -211,7 +213,7 @@ export async function runTemplate(
                 status: "error",
                 statusText: "",
                 messages,
-                vars,
+                env: restEnv,
                 label,
                 version,
                 text: outputTrace.content,
@@ -321,7 +323,7 @@ export async function runTemplate(
             finishReason,
             error,
             messages,
-            vars,
+            env: restEnv,
             edits,
             annotations,
             changelogs,

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -30,14 +30,7 @@ import { GenerationOptions } from "./generation"
 import { promptParametersSchemaToJSONSchema } from "./parameters"
 import { consoleLogFormat, stdout } from "./logging"
 import { isGlobMatch } from "./glob"
-import {
-    arrayify,
-    assert,
-    deleteEmptyValues,
-    logError,
-    logVerbose,
-    logWarn,
-} from "./util"
+import { arrayify, assert, logError, logVerbose, logWarn } from "./util"
 import { renderShellOutput } from "./chatrender"
 import { jinjaRender } from "./jinja"
 import { mustacheRender } from "./mustache"
@@ -88,6 +81,7 @@ import { videoExtractAudio } from "./ffmpeg"
 import { BufferToBlob } from "./bufferlike"
 import { host } from "./host"
 import { srtVttRender } from "./transcription"
+import { deleteEmptyValues } from "./clone"
 
 export function createChatTurnGenerationContext(
     options: GenerationOptions,

--- a/packages/core/src/server/messages.ts
+++ b/packages/core/src/server/messages.ts
@@ -182,7 +182,7 @@ export interface GenerationResult extends GenerationOutput {
     /**
      * The environment variables passed to the prompt
      */
-    vars: Partial<ExpansionVariables>
+    env: Partial<ExpansionVariables>
 
     /**
      * Expanded prompt text composed of multiple messages

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -90,7 +90,6 @@ export class MarkdownTrace extends EventTarget implements OutputTrace {
 
         if (!inner) {
             this._content.push(value)
-            this._content.push(value)
             this._tree = undefined
             this.dispatchChange()
         }

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -1,6 +1,5 @@
 import {
     CHANGE,
-    CHAT_PROGRESS,
     EMOJI_FAIL,
     EMOJI_SUCCESS,
     EMOJI_UNDEFINED,

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -63,21 +63,6 @@ export function deleteUndefinedValues<T extends Record<string, any>>(o: T): T {
     return o
 }
 
-export function deleteEmptyValues<T extends Record<string, any>>(o: T): T {
-    if (typeof o === "object")
-        for (const k in o) {
-            const v = o[k]
-            if (
-                v === undefined ||
-                v === null ||
-                v === "" ||
-                (Array.isArray(v) && !v.length)
-            )
-                delete o[k]
-        }
-    return o
-}
-
 export function collapseEmptyLines(text: string) {
     return text?.replace(/(\r?\n){2,}/g, "\n\n")
 }

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -78,7 +78,7 @@ export interface AIRequest {
 
 export function snapshotAIRequest(r: AIRequest): AIRequestSnapshot {
     const { response, error, creationTime, trace } = r
-    const { vars, ...responseWithoutVars } = response || {}
+    const { env, ...responseWithoutVars } = response || {}
     const snapshot = structuredClone({
         creationTime,
         cacheTime: new Date().toISOString(),

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -55,10 +55,10 @@ import { toBase64 } from "../../core/src/base64"
 import { underscore } from "inflection"
 import { lookupMime } from "../../core/src/mime"
 import dedent from "dedent"
-import { convertAnnotationsToMarkdown } from "../../core/src/annotations"
 import "remark-github-blockquote-alert/alert.css"
 import { markdownDiff } from "../../core/src/mddiff"
 import { VscodeMultiSelect as VscodeMultiSelectElement } from "@vscode-elements/elements"
+import { cleanedClone } from "../../core/src/clone"
 
 const urlParams = new URLSearchParams(window.location.hash)
 const apiKey = urlParams.get("api-key")
@@ -145,7 +145,7 @@ class RunClient extends EventTarget {
                     break
                 }
                 case "script.end": {
-                    this.result = data.result
+                    this.result = cleanedClone(data.result)
                     this.dispatchEvent(
                         new CustomEvent(RunClient.RESULT_EVENT, {
                             detail: data,
@@ -1059,7 +1059,11 @@ function ScriptSelect() {
             </VscodeSingleSelect>
             {script && (
                 <VscodeFormHelper>
-                    {toStringList(script.title, script.description, script.filename)}
+                    {toStringList(
+                        script.title,
+                        script.description,
+                        script.filename
+                    )}
                 </VscodeFormHelper>
             )}
         </VscodeFormGroup>


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

### Pull Request Description

- 🔄 **Refactored variable naming**: Replaced `vars` with `env` across multiple files for better clarity and consistency in handling environment variables.
- 🧩 **Enhanced trace handling**: Introduced `chatProgress` method in `MarkdownTrace` for improved progress reporting and event dispatching.
- 📜 **Streamlined event cloning**: Added a `clone` method to `TraceChunkEvent` for safer event propagation.
- 🎨 **Improved token streaming**: Refactored token streaming logic to handle console color wrapping and quiet mode more efficiently.
- 🛠 **Code cleanup**: Removed redundant commented-out code and reorganized token color initialization for better readability.

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->



<!-- genaiscript begin pr-describe --><hr/>

```markdown
- **Refactored Trace Event Handling**
  - Introduced `ChatCompletionsProgressReport` for progress updates.
  - Updated `TraceChunkEvent` to include optional `progress` data.
  
- **Enhanced MarkdownTrace Functionality**
  - Added `chatProgress` method to handle chat completion progress.
  - Modified `startTraceDetails` to avoid duplicate event propagation.

- **Improved Event Duplication Logic**
  - Implemented `clone` method in `TraceChunkEvent` to facilitate event duplication without losing progress data.
``````markdown
- **Refactored Trace Event Handling**
  - Introduced `ChatCompletionsProgressReport` for progress updates.
  - Updated `TraceChunkEvent` to include optional `progress` data.
  
- **Enhanced MarkdownTrace Functionality**
  - Added `chatProgress` method to handle chat completion progress.
  - Modified `startTraceDetails` to avoid duplicate event propagation.

- **Improved Event Duplication Logic**
  - Implemented `clone` method in `TraceChunkEvent` to facilitate event duplication without losing progress data.
```

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/12753848369) may be incorrect



<!-- genaiscript end pr-describe -->

