### PR TITLE
feat: ✨ add support for <think> tags conversion to markdown

### DIFF
--- a/packages/core/src/think.test.ts
+++ b/packages/core/src/think.test.ts
@@ -5,21 +5,21 @@ import { convertThinkToMarkdown } from "./think"
 describe("convertThinkToMarkdown", () => {
     test("should convert <think> tags to <details> tags", () => {
         const input = "<think>This is \na test</think>"
-        const expected = "<details><summary>Thinking...</summary>This is \na test</details>"
+        const expected = "<details><summary>🤔 think</summary>This is \na test</details>"
         const result = convertThinkToMarkdown(input)
         assert.equal(result, expected)
     })
 
     test("should handle multiple <think> tags", () => {
         const input = "<think>First</think> and <think>Second</think>"
-        const expected = "<details><summary>Thinking...</summary>First</details> and <details><summary>Thinking...</summary>Second</details>"
+        const expected = "<details><summary>🤔 think</summary>First</details> and <details><summary>🤔 think</summary>Second</details>"
         const result = convertThinkToMarkdown(input)
         assert.equal(result, expected)
     })
 
     test("should handle <think> tags without closing tags", () => {
         const input = "<think>This is a test"
-        const expected = "<details><summary>Thinking...</summary>This is a test</details>"
+        const expected = "<details><summary>🤔 thinking...</summary>This is a test</details>"
         const result = convertThinkToMarkdown(input)
         assert.equal(result, expected)
     })

--- a/packages/core/src/think.ts
+++ b/packages/core/src/think.ts
@@ -1,8 +1,8 @@
 export function convertThinkToMarkdown(md: string) {
     if (!md) return md
 
-    md = md.replace(/<think>(.*?)($|<\/think>)/gis, (_, text) => {
-        return `<details><summary>🤔 think</summary>${text}</details>`
+    md = md.replace(/<think>(.*?)($|<\/think>)/gis, (_, text, end) => {
+        return `<details><summary>🤔 think${end === "</think>" ? "" : "ing..."}</summary>${text}</details>`
     })
     return md
 }

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -266,6 +266,7 @@ export class ExtensionState extends EventTarget {
         }
         const partialCb = (progress: ChatCompletionsProgressReport) => {
             r.progress = progress
+            if (!r.response) r.response = { text: "" }
             if (r.response) {
                 r.response.text = progress.responseSoFar
                 r.response.logprobs = progress.responseTokens

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -60,10 +60,8 @@ import { markdownDiff } from "../../core/src/mddiff"
 import { VscodeMultiSelect as VscodeMultiSelectElement } from "@vscode-elements/elements"
 import { cleanedClone } from "../../core/src/clone"
 import { WebSocketClient } from "../../core/src/server/wsclient"
-import {
-    convertAnnotationsToMarkdown,
-    convertAnnotationToItem,
-} from "../../core/src/annotations"
+import { convertAnnotationToItem } from "../../core/src/annotations"
+import MarkdownWithPreview from "./MarkdownWithPreview"
 
 interface GenAIScriptViewOptions {
     apiKey?: string
@@ -723,10 +721,9 @@ function TraceTabPanel(props: { selected?: boolean }) {
 
 function OutputMarkdown() {
     const output = useOutput()
-    const md = convertAnnotationsToMarkdown(output)
     return (
         <VscodeScrollable>
-            <Markdown>{md}</Markdown>
+            <MarkdownWithPreview>{output}</MarkdownWithPreview>
         </VscodeScrollable>
     )
 }

--- a/packages/web/src/MarkdownWithPreview.tsx
+++ b/packages/web/src/MarkdownWithPreview.tsx
@@ -1,0 +1,37 @@
+import {
+    VscodeTabHeader,
+    VscodeTabPanel,
+    VscodeTabs,
+} from "@vscode-elements/react-elements"
+import React from "react"
+import { fenceMD } from "../../core/src/mkmd"
+import Markdown from "./Markdown"
+import { convertThinkToMarkdown } from "../../core/src/think"
+import { convertAnnotationsToMarkdown } from "../../core/src/annotations"
+
+export default function MarkdownWithPreview(props: {
+    className?: string
+    children: any
+}) {
+    const { className, children } = props
+    const childrenAsString = typeof children === "string" ? children : ""
+    if (!childrenAsString)
+        return <Markdown className={className}>{children}</Markdown>
+
+    const md = convertThinkToMarkdown(
+        convertAnnotationsToMarkdown(childrenAsString)
+    )
+
+    return (
+        <VscodeTabs>
+            <VscodeTabHeader slot="header">Preview</VscodeTabHeader>
+            <VscodeTabPanel>
+                <Markdown className={className}>{md}</Markdown>
+            </VscodeTabPanel>
+            <VscodeTabHeader slot="header">Source</VscodeTabHeader>
+            <VscodeTabPanel>
+                <Markdown>{fenceMD(children, "markdown")}</Markdown>
+            </VscodeTabPanel>
+        </VscodeTabs>
+    )
+}


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

### Pull Request Description

- 🛠️ **Enhanced `<details><summary>🤔 thinking...</summary>` tag conversion logic:**
  - Updated `<details><summary>🤔 thinking...</summary>` tag handling to differentiate between open and closed tags, appending "ing..." for unclosed tags.
  - Replaced "Thinking..." with "🤔 think" in test cases for consistency and clarity.

- 💡 **Introduced `MarkdownWithPreview` component:**
  - Combines markdown rendering with a preview/source tab interface for better user experience.
  - Integrates `convertThinkToMarkdown` and `convertAnnotationsToMarkdown` for processing markdown content.

- 🔧 **Refactored `OutputMarkdown` rendering:**
  - Replaced direct markdown rendering with the new `MarkdownWithPreview` component for enhanced functionality.

- 🐛 **Fixed potential issue in `ExtensionState`:**
  - Ensured `response` object is initialized before updating its properties during progress updates.

- 🔥 **Removed unused import:**
  - Eliminated `convertAnnotationsToMarkdown` import from `App.tsx` to clean up the code.</details></details>

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->



<!-- genaiscript begin pr-describe --><hr/>

Here's a summary of the changes in the codebase:

- **Refactored `convertThinkToMarkdown` function**:
  - Added a parameter to distinguish between complete and incomplete tags for more accurate display.
  - Updated the regex in the replace function to handle both cases.

- **Added `MarkdownWithPreview` component**:
  - This component allows switching between preview and source views of Markdown content.
  - It uses existing functions (`convertAnnotationsToMarkdown`, `convertThinkToMarkdown`) to process the text before rendering it in a tabbed interface.

- **Removed unused imports**:
  - Removed unnecessary import statements from files where they were no longer needed after refactoring or simplification.

These changes improve code readability and usability, providing developers with a more intuitive way of viewing Markdown content with side-by-side previews.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/12913871109) may be incorrect



<!-- genaiscript end pr-describe -->

