### PR TITLE
file cache

### DIFF
--- a/docs/public/schemas/config.json
+++ b/docs/public/schemas/config.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GenAIScript Configuration",
+    "type": "object",
+    "description": "Schema for GenAIScript configuration file",
+    "properties": {
+        "envFile": {
+            "type": "string"
+        },
+        "include": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "modelAliases": {
+            "type": "object",
+            "additionalProperties": true
+        }
+    }
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -16,6 +16,7 @@ import { parseTokenFromEnv } from "./connection"
 import { resolveLanguageModel } from "./lm"
 import { deleteEmptyValues } from "./cleaners"
 import { errorMessage } from "./error"
+import schema from "../../../docs/public/schemas/config.json"
 
 export async function resolveGlobalConfiguration(
     dotEnvPath?: string
@@ -40,24 +41,10 @@ export async function resolveGlobalConfiguration(
                     throw new Error(
                         `Configuration error: failed to parse ${filename}`
                     )
-                const validation = validateJSONWithSchema(parsed, {
-                    type: "object",
-                    properties: {
-                        envFile: {
-                            type: "string",
-                        },
-                        include: {
-                            type: "array",
-                            items: {
-                                type: "string",
-                            },
-                        },
-                        modelAliases: {
-                            type: "object",
-                            additionalProperties: true,
-                        },
-                    },
-                })
+                const validation = validateJSONWithSchema(
+                    parsed,
+                    schema as JSONSchema
+                )
                 if (validation.schemaError)
                     throw new Error(
                         `Configuration error: ` + validation.schemaError

--- a/packages/core/src/filecache.ts
+++ b/packages/core/src/filecache.ts
@@ -1,0 +1,23 @@
+import { fileTypeFromBuffer } from "file-type"
+import { resolveBufferLike } from "./bufferlike"
+import { hash } from "./crypto"
+import { TraceOptions } from "./trace"
+import { join } from "node:path"
+import { stat, writeFile } from "fs/promises"
+
+export async function fileWriteCached(
+    bufferLike: BufferLike,
+    dir: string,
+    options?: TraceOptions
+): Promise<string> {
+    const bytes = await resolveBufferLike(bufferLike, options)
+    const { ext } = (await fileTypeFromBuffer(bytes)) || { ext: ".bin" }
+    const filename = await hash(bytes, { length: 64 })
+    const fn = join(dir, filename + "." + ext)
+    try {
+        await stat(fn)
+        return fn
+    } catch {}
+    await writeFile(fn, bytes)
+    return fn
+}

--- a/packages/core/src/filecache.ts
+++ b/packages/core/src/filecache.ts
@@ -2,8 +2,9 @@ import { fileTypeFromBuffer } from "file-type"
 import { resolveBufferLike } from "./bufferlike"
 import { hash } from "./crypto"
 import { TraceOptions } from "./trace"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { stat, writeFile } from "fs/promises"
+import { ensureDir } from "fs-extra"
 
 export async function fileWriteCached(
     bufferLike: BufferLike,
@@ -11,13 +12,14 @@ export async function fileWriteCached(
     options?: TraceOptions
 ): Promise<string> {
     const bytes = await resolveBufferLike(bufferLike, options)
-    const { ext } = (await fileTypeFromBuffer(bytes)) || { ext: ".bin" }
+    const { ext } = (await fileTypeFromBuffer(bytes)) || { ext: "bin" }
     const filename = await hash(bytes, { length: 64 })
     const fn = join(dir, filename + "." + ext)
     try {
         await stat(fn)
         return fn
     } catch {}
+    await ensureDir(dirname(fn))
     await writeFile(fn, bytes)
     return fn
 }

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -9,9 +9,10 @@ import { readText, writeText } from "./fs"
 import { host } from "./host"
 import { INITryParse } from "./ini"
 import { JSON5TryParse } from "./json5"
-import { arrayify, logVerbose } from "./util"
+import { arrayify, dotGenaiscriptPath, logVerbose } from "./util"
 import { XMLTryParse } from "./xml"
 import { YAMLTryParse } from "./yaml"
+import { fileWriteCached } from "./filecache"
 
 export function createFileSystem(): Omit<WorkspaceFileSystem, "grep"> {
     const fs = {
@@ -110,6 +111,11 @@ export function createFileSystem(): Omit<WorkspaceFileSystem, "grep"> {
         cache: async (name: string) => {
             if (!name) throw new NotSupportedError("missing cache name")
             const res = JSONLineCache.byName<any, any>(name)
+            return res
+        },
+        writeCached: async (bufferOrFile) => {
+            const dir = dotGenaiscriptPath("cache", "files")
+            const res = await fileWriteCached(bufferOrFile, dir)
             return res
         },
         stat: async (filename: string) => {

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -14,7 +14,10 @@ import { XMLTryParse } from "./xml"
 import { YAMLTryParse } from "./yaml"
 import { fileWriteCached } from "./filecache"
 
-export function createFileSystem(): Omit<WorkspaceFileSystem, "grep"> {
+export function createFileSystem(): Omit<
+    WorkspaceFileSystem,
+    "grep" | "writeCached"
+> {
     const fs = {
         findFiles: async (glob: string, options: FindFilesOptions) => {
             const { readText, ignore } = options || {}
@@ -113,11 +116,6 @@ export function createFileSystem(): Omit<WorkspaceFileSystem, "grep"> {
             const res = JSONLineCache.byName<any, any>(name)
             return res
         },
-        writeCached: async (bufferOrFile) => {
-            const dir = dotGenaiscriptPath("cache", "files")
-            const res = await fileWriteCached(bufferOrFile, dir)
-            return res
-        },
         stat: async (filename: string) => {
             try {
                 const res = await stat(filename)
@@ -129,7 +127,7 @@ export function createFileSystem(): Omit<WorkspaceFileSystem, "grep"> {
                 return undefined
             }
         },
-    } satisfies Omit<WorkspaceFileSystem, "grep">
+    } satisfies Omit<WorkspaceFileSystem, "grep" | "writeCached">
     ;(fs as any).readFile = readText
     return Object.freeze(fs)
 }

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -127,7 +127,7 @@ export interface Host {
 
 export interface RuntimeHost extends Host {
     project: Project
-    workspace: Omit<WorkspaceFileSystem, "grep">
+    workspace: Omit<WorkspaceFileSystem, "grep" | "writeCached">
     azureToken: AzureTokenResolver
     modelAliases: Readonly<ModelConfigurations>
     clientLanguageModel?: LanguageModel

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -29,6 +29,7 @@ import { resolveModelConnectionInfo } from "./models"
 import { DOCS_WEB_SEARCH_URL } from "./constants"
 import { fetch, fetchText } from "./fetch"
 import { fileWriteCached } from "./filecache"
+import { join } from "node:path"
 
 /**
  * Creates a prompt context for the given project, variables, trace, options, and model.
@@ -69,7 +70,9 @@ export async function createPromptContext(
         writeCached: async (f, options) => {
             const { scope } = options || {}
             const dir =
-                scope === "run" ? runDir : dotGenaiscriptPath("cache", "files")
+                scope === "run"
+                    ? join(runDir, "files")
+                    : dotGenaiscriptPath("cache", "files")
             return await fileWriteCached(f, dir)
         },
         cache: (n) => runtimeHost.workspace.cache(n),

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -63,6 +63,7 @@ export async function createPromptContext(
         readINI: (f, o) => runtimeHost.workspace.readINI(f, o),
         readData: (f, o) => runtimeHost.workspace.readData(f, o),
         writeText: (f, c) => runtimeHost.workspace.writeText(f, c),
+        writeCached: (f) => runtimeHost.workspace.writeCached(f),
         cache: (n) => runtimeHost.workspace.cache(n),
         findFiles: async (pattern, options) => {
             // Log and find files matching the given pattern

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -15,7 +15,7 @@ import { YAMLStringify } from "./yaml"
 import { errorMessage, serializeError } from "./error"
 import prettyBytes from "pretty-bytes"
 import { host } from "./host"
-import { dotGenaiscriptPath, ellipse, toStringList } from "./util"
+import { ellipse, toStringList } from "./util"
 import { estimateTokens } from "./tokens"
 import { renderWithPrecision } from "./precision"
 import { fenceMD } from "./mkmd"
@@ -43,7 +43,7 @@ export class TraceChunkEvent extends Event {
 }
 
 export class MarkdownTrace extends EventTarget implements OutputTrace {
-    filesDir: string = dotGenaiscriptPath("cache", "files")
+    filesDir: string
     readonly _errors: { message: string; error: SerializedError }[] = []
     private detailsDepth = 0
     private _content: (string | MarkdownTrace)[] = []

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -15,7 +15,7 @@ import { YAMLStringify } from "./yaml"
 import { errorMessage, serializeError } from "./error"
 import prettyBytes from "pretty-bytes"
 import { host } from "./host"
-import { ellipse, toStringList } from "./util"
+import { dotGenaiscriptPath, ellipse, toStringList } from "./util"
 import { estimateTokens } from "./tokens"
 import { renderWithPrecision } from "./precision"
 import { fenceMD } from "./mkmd"
@@ -26,6 +26,7 @@ import { dedent } from "./indent"
 import { CSVStringify, CSVToMarkdown } from "./csv"
 import { INIStringify } from "./ini"
 import { ChatCompletionsProgressReport } from "./chattypes"
+import { fileWriteCached } from "./filecache"
 
 export class TraceChunkEvent extends Event {
     constructor(
@@ -42,6 +43,7 @@ export class TraceChunkEvent extends Event {
 }
 
 export class MarkdownTrace extends EventTarget implements OutputTrace {
+    filesDir: string = dotGenaiscriptPath("cache", "files")
     readonly _errors: { message: string; error: SerializedError }[] = []
     private detailsDepth = 0
     private _content: (string | MarkdownTrace)[] = []
@@ -289,11 +291,14 @@ ${this.toResultIcon(success, "")}${title}
     }
 
     async image(url: string, caption: string) {
-        if (/^https?:\/\//.test(url) || url.length < TRACE_MAX_IMAGE_SIZE)
+        if (/^https?:\/\//.test(url))
             return this.appendContent(
                 `\n\n![${caption || "image"}](${url})\n\n`
             )
-        else return this.appendContent(`\n\n${caption} (too large...)\n\n`)
+        else {
+            const fn = await fileWriteCached(url, this.filesDir)
+            return this.appendContent(`\n\n![${caption || "image"}](${fn})\n\n`)
+        }
     }
 
     private toResultIcon(value: boolean, missing: string) {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -984,6 +984,12 @@ interface WorkspaceFileSystem {
     writeText(path: string, content: string): Promise<void>
 
     /**
+     * Caches a buffer to file and returns the unique file name
+     * @param bytes
+     */
+    writeCached(bytes: BufferLike): Promise<string>
+
+    /**
      * Opens a file-backed key-value cache for the given cache name.
      * The cache is persisted across runs of the script. Entries are dropped when the cache grows too large.
      * @param cacheName

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -987,7 +987,10 @@ interface WorkspaceFileSystem {
      * Caches a buffer to file and returns the unique file name
      * @param bytes
      */
-    writeCached(bytes: BufferLike): Promise<string>
+    writeCached(
+        bytes: BufferLike,
+        options?: { scope?: "workspace" | "run" }
+    ): Promise<string>
 
     /**
      * Opens a file-backed key-value cache for the given cache name.

--- a/packages/sample/genaisrc/video.genai.mjs
+++ b/packages/sample/genaisrc/video.genai.mjs
@@ -16,6 +16,13 @@ const audio = await ffmpeg.extractAudio("src/audio/helloworld.mp4", {
     outputOptions: "-b:a 16k",
 })
 console.log({ audio })
+const cached = await workspace.writeCached("src/audio/helloworld.mp4", {
+    scope: "run",
+})
+const cached2 = await workspace.writeCached("src/audio/helloworld.mp4", {
+    scope: "run",
+})
+console.log({ cached, cached2 })
 
 const custom = await ffmpeg.run(
     "src/audio/helloworld.mp4",


### PR DESCRIPTION
API to cache large immutable files locally to avoid exploding the size of repots, moving large files around in memory.

<!-- genaiscript begin pr-describe --><hr/>

- 🔄 **Refactored `writeCached` Method**: Added a new method `writeCached` to the `WorkspaceFileSystem` interface, allowing for caching of buffers to file.
  
- 🔧 **Improved Error Handling for Images**: Updated error handling for image processing in `MarkdownTrace`. Now caches images larger than predefined size instead of uploading them directly.

- 🔄 **Renamed and Optimized Imports**: Consolidated import statements and renamed some imports to improve code organization and readability.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/12953115809) may be incorrect



<!-- genaiscript end pr-describe -->

