### PR TITLE
add image tiling

### DIFF
--- a/packages/core/src/image.ts
+++ b/packages/core/src/image.ts
@@ -114,7 +114,7 @@ async function encode(
 ) {
     // Determine the output MIME type, defaulting to image/jpeg
     const { detail } = options
-    const outputMime = img.mime || ("image/png" as any)
+    const outputMime = img.mime || ("image/jpeg" as any)
     const buf = await img.getBuffer(outputMime)
     const b64 = buf.toString("base64")
     const imageDataUri = `data:${outputMime};base64,${b64}`
@@ -152,8 +152,8 @@ export async function imageTileEncodeForLLM(
 
     const imgw = imgs.reduce((acc, img) => Math.max(acc, img.width), 0)
     const imgh = imgs.reduce((acc, img) => Math.max(acc, img.height), 0)
-    const nrows = Math.ceil(Math.sqrt(imgs.length))
-    const ncols = Math.ceil(imgs.length / nrows)
+    const ncols = Math.ceil(Math.sqrt(imgs.length))
+    const nrows = Math.ceil(imgs.length / ncols)
     const width = ncols * imgw
     const height = nrows * imgh
 
@@ -161,11 +161,12 @@ export async function imageTileEncodeForLLM(
     const canvas = new Jimp({ width, height })
 
     for (let i = 0; i < imgs.length; i++) {
-        const ri = Math.floor(i / ncols)
-        const ci = i % ncols
-
-        canvas.blit({ bitmap: imgs[i].bitmap, x: ci * imgw, y: ri * imgh })
+        const ci = Math.floor(i / nrows)
+        const ri = i % nrows
+        const x = ci * imgw
+        const y = ri * imgh
+        canvas.composite(imgs[i], x, y)
     }
 
-    return encode(canvas, options)
+    return encode(canvas, { ...options, detail: undefined })
 }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1314,6 +1314,10 @@ interface DefImagesOptions {
      * Selects the a random sample of N items in the collection.
      */
     sliceSample?: number
+    /**
+     * Renders all images in a single tiled image
+     */
+    tiled?: boolean
 }
 
 type JSONSchemaTypeName =

--- a/packages/sample/genaisrc/defimagestiled.genai.mjs
+++ b/packages/sample/genaisrc/defimagestiled.genai.mjs
@@ -1,0 +1,6 @@
+script({
+    files: ["src/robots.jpg", "src/vision/*.jpg"],
+})
+
+defImages(env.files, { tiled: true, detail: "low", autoCrop: true })
+$`describe the images in the tiled image`


### PR DESCRIPTION


<!-- genaiscript begin pr-describe --><hr/>

- **Refactoring:** Extracted image preparation logic into `prepare` function to clean up `imageEncodeForLLM`.
- **Unified Encoding:** Created a general `encode` function that handles the core encoding logic, reducing redundancy.
- **New Functionality:** Added a new function `tileImageEncodeForLLM` to encode multiple images into a single image tile.
- **Documentation Update:** Updated the docstring for `imageEncodeForLLM` and added new documentation for the new function.
- **Performance Optimizations:** Improved performance by using asynchronous operations and Jimp library for image manipulation.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/13043911674) may be incorrect



<!-- genaiscript end pr-describe -->

