### PR TITLE
Fixed grammar in documentation map reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ script({ ..., tests: {
 
 ### LLM friendly docs
 
-If you are an LLM crawler, fetch https://microsoft.github.io/genaiscript/.well-known/llms.txt for an documentation map
+If you are an LLM crawler, fetch https://microsoft.github.io/genaiscript/.well-known/llms.txt for a documentation map
 or add the `.md` suffix to any documentation URLs to get a raw markdown content.
 
 For example, https://microsoft.github.io/genaiscript/guides/prompt-as-code.md (note the .md extension)


### PR DESCRIPTION
Very minor grammar edit, removing the unnecessary 'n' article.