### PR TITLE
fix(fs_find_files): use count instead of findFilesCount

### DIFF
--- a/packages/core/src/genaisrc/system.fs_find_files.genai.js
+++ b/packages/core/src/genaisrc/system.fs_find_files.genai.js
@@ -51,8 +51,8 @@ defTool(
         if (!res?.length) return "No files found."
 
         let suffix = ""
-        if (res.length > findFilesCount) {
-            res = res.slice(0, findFilesCount)
+        if (res.length > count) {
+            res = res.slice(0, count)
             suffix =
                 "\n<too many files found. Showing first 100. Use 'count' to specify how many and/or use 'pattern' to do a grep search>"
         }


### PR DESCRIPTION
...to slice the files array.

I noticed this variable from the tool argument is not being used, and the global variable from `env.vars` is being used instead. That's probably not the intention here.