### PR TITLE
Add "echo" model for dry run debugging

### DIFF
--- a/docs/public/schemas/llms.json
+++ b/docs/public/schemas/llms.json
@@ -23,6 +23,10 @@
                         "type": "string",
                         "description": "Description of the LLM provider"
                     },
+                    "hidden": {
+                        "type": "boolean",
+                        "description": "Indicates if the provider is hidden"
+                    },
                     "limitations": {
                         "type": "string",
                         "description": "General note about limitations"

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -1588,6 +1588,17 @@ docker run -d -p 9000:9000 -e ASR_MODEL=base -e ASR_ENGINE=openai_whisper onerah
 
 You can also override the `transcription` model alias to change the default model used by `transcribe`.
 
+## Echo
+
+This is a dry run LLM provider that returns the messages without calling any LLM.
+It is most useful for debugging when you want to see the result LLM request without sending it.
+
+```js 'model: "echo"'
+script({
+    model: "echo",
+})
+```
+
 ## Model specific environment variables
 
 You can provide different environment variables

--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -22,7 +22,7 @@ Options:
                            "anthropic", "anthropic_bedrock", "google",
                            "huggingface", "mistral", "alibaba", "deepseek",
                            "transformers", "lmstudio", "jan", "llamafile",
-                           "litellm", "whisperasr")
+                           "litellm", "whisperasr", "echo")
   -h, --help               display help for command
 ```
 
@@ -34,7 +34,7 @@ Usage: genaiscript run [options] <script> [files...]
 Runs a GenAIScript against files.
 
 Options:
-  -p, --provider <string>                    Preferred LLM provider aliases (choices: "openai", "azure", "azure_serverless", "azure_serverless_models", "github", "ollama", "anthropic", "anthropic_bedrock", "google", "huggingface", "mistral", "alibaba", "deepseek", "transformers", "lmstudio", "jan", "llamafile", "litellm", "whisperasr")
+  -p, --provider <string>                    Preferred LLM provider aliases (choices: "openai", "azure", "azure_serverless", "azure_serverless_models", "github", "ollama", "anthropic", "anthropic_bedrock", "google", "huggingface", "mistral", "alibaba", "deepseek", "transformers", "lmstudio", "jan", "llamafile", "litellm", "whisperasr", "echo")
   -m, --model <string>                       'large' model alias (default)
   -sm, --small-model <string>                'small' alias model
   -vm, --vision-model <string>               'vision' alias model
@@ -118,7 +118,7 @@ Options:
                                       "huggingface", "mistral", "alibaba",
                                       "deepseek", "transformers", "lmstudio",
                                       "jan", "llamafile", "litellm",
-                                      "whisperasr")
+                                      "whisperasr", "echo")
   -m, --model <string>                'large' model alias (default)
   -sm, --small-model <string>         'small' alias model
   -vm, --vision-model <string>        'vision' alias model

--- a/docs/src/content/docs/reference/cli/run.mdx
+++ b/docs/src/content/docs/reference/cli/run.mdx
@@ -54,7 +54,7 @@ npx genaiscript run <script> <files> --exclude-git-ignore
 
 ### --model ...
 
-Configure the default or `large` model alias
+Configure the default or `large` model alias. Use `echo` to do a dry run and return the messages instead of calling a LLM provider.
 
 ## --provider ...
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -111,9 +111,9 @@ export async function cli() {
                 "-p, --provider <string>",
                 "Preferred LLM provider aliases"
             ).choices(
-                MODEL_PROVIDERS.filter(
-                    ({ id }) => id !== MODEL_PROVIDER_GITHUB_COPILOT_CHAT
-                ).map(({ id }) => id)
+                MODEL_PROVIDERS.filter(({ hidden }) => !hidden).map(
+                    ({ id }) => id
+                )
             )
         )
         .action(configure)
@@ -554,9 +554,9 @@ export async function cli() {
                     "-p, --provider <string>",
                     "Preferred LLM provider aliases"
                 ).choices(
-                    MODEL_PROVIDERS.filter(
-                        ({ id }) => id !== MODEL_PROVIDER_GITHUB_COPILOT_CHAT
-                    ).map(({ id }) => id)
+                    MODEL_PROVIDERS.filter(({ hidden }) => !hidden).map(
+                        ({ id }) => id
+                    )
                 )
             )
             .option("-m, --model <string>", "'large' model alias (default)")

--- a/packages/cli/src/configure.ts
+++ b/packages/cli/src/configure.ts
@@ -18,13 +18,13 @@ export async function configure(options: { provider?: string }) {
             ? MODEL_PROVIDERS.find(({ id }) => options.provider === id)
             : await select({
                   message: "Select a LLM provider to configure",
-                  choices: MODEL_PROVIDERS.filter(
-                      (p) => p.id !== MODEL_PROVIDER_GITHUB_COPILOT_CHAT
-                  ).map((provider) => ({
-                      name: provider.detail,
-                      value: provider,
-                      description: `'${provider.id}': https://microsoft.github.io/genaiscript/getting-started/configuration#${provider.id}`,
-                  })),
+                  choices: MODEL_PROVIDERS.filter(({ hidden }) => !hidden).map(
+                      (provider) => ({
+                          name: provider.detail,
+                          value: provider,
+                          description: `'${provider.id}': https://microsoft.github.io/genaiscript/getting-started/configuration#${provider.id}`,
+                      })
+                  ),
               })
         if (!provider) break
 

--- a/packages/core/src/chatrender.ts
+++ b/packages/core/src/chatrender.ts
@@ -6,6 +6,7 @@ import type {
     ChatCompletionToolMessageParam,
     ChatCompletionUserMessageParam,
 } from "./chattypes"
+import { collapseNewlines } from "./cleaners"
 
 // Import utility functions for JSON5 parsing, markdown formatting, and YAML stringification.
 import { JSONLLMTryParse } from "./json5"
@@ -194,7 +195,7 @@ export function renderMessagesToMarkdown(
             }
         })
     // Join the result array into a single markdown string.
-    return res.filter((s) => s !== undefined).join("\n")
+    return collapseNewlines(res.filter((s) => s !== undefined).join("\n"))
 }
 
 /**

--- a/packages/core/src/cleaners.ts
+++ b/packages/core/src/cleaners.ts
@@ -60,3 +60,10 @@ export function unmarkdown(text: string) {
         ?.replace(/\[([^\]]+)\]\([^)]+\)/g, (m, n) => n)
         ?.replace(/<\/?([^>]+)>/g, "")
 }
+
+/**
+ * Collapse 3+ lines to 1
+ */
+export function collapseNewlines(res: string): string {
+    return res?.replace(/(\r?\n){3,}/g, "\n\n")
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,12 +2,7 @@ import { homedir } from "os"
 import { existsSync, readFileSync } from "fs"
 import { YAMLTryParse } from "./yaml"
 import { JSON5TryParse } from "./json5"
-import {
-    DOT_ENV_FILENAME,
-    MODEL_PROVIDER_GITHUB_COPILOT_CHAT,
-    MODEL_PROVIDERS,
-    TOOL_ID,
-} from "./constants"
+import { DOT_ENV_FILENAME, MODEL_PROVIDERS, TOOL_ID } from "./constants"
 import { resolve } from "path"
 import { validateJSONWithSchema } from "./schema"
 import { HostConfiguration } from "./hostconfiguration"
@@ -24,7 +19,6 @@ import { errorMessage } from "./error"
 import schema from "../../../docs/public/schemas/config.json"
 import defaultConfig from "./config.json"
 import { CancellationOptions } from "./cancellation"
-import { runtimeHost } from "./host"
 
 export async function resolveGlobalConfiguration(
     dotEnvPath?: string

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -38,8 +38,9 @@ import {
     MODEL_PROVIDER_ANTHROPIC_BEDROCK,
     MODEL_PROVIDER_DEEPSEEK,
     DEEPSEEK_API_BASE,
-    MODEL_WHISPERASR_PROVIDER,
+    MODEL_PROVIDER_WHISPERASR,
     WHISPERASR_API_BASE,
+    MODEL_PROVIDER_ECHO,
 } from "./constants"
 import { host, runtimeHost } from "./host"
 import { parseModelIdentifier } from "./models"
@@ -431,7 +432,7 @@ export async function parseTokenFromEnv(
         }
     }
 
-    if (provider === MODEL_WHISPERASR_PROVIDER) {
+    if (provider === MODEL_PROVIDER_WHISPERASR) {
         const base =
             findEnvVar(env, "WHISPERASR", BASE_SUFFIX)?.value ||
             WHISPERASR_API_BASE
@@ -551,6 +552,15 @@ export async function parseTokenFromEnv(
             model,
             base: undefined,
             token: MODEL_PROVIDER_GITHUB_COPILOT_CHAT,
+        }
+    }
+
+    if (provider === MODEL_PROVIDER_ECHO) {
+        return {
+            provider,
+            model,
+            base: undefined,
+            token: "echo",
         }
     }
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -175,7 +175,8 @@ export const MODEL_PROVIDER_MISTRAL = "mistral"
 export const MODEL_PROVIDER_LMSTUDIO = "lmstudio"
 export const MODEL_PROVIDER_JAN = "jan"
 export const MODEL_PROVIDER_DEEPSEEK = "deepseek"
-export const MODEL_WHISPERASR_PROVIDER = "whisperasr"
+export const MODEL_PROVIDER_WHISPERASR = "whisperasr"
+export const MODEL_PROVIDER_ECHO = "echo"
 
 export const MODEL_PROVIDER_OPENAI_HOSTS = Object.freeze([
     MODEL_PROVIDER_OPENAI,
@@ -223,6 +224,7 @@ export const MODEL_PROVIDERS = Object.freeze<
         transcribe?: boolean
         speech?: boolean
         tokenless?: boolean
+        hidden?: boolean
         aliases?: Record<string, string>
         env?: Record<
             string,

--- a/packages/core/src/echomodel.ts
+++ b/packages/core/src/echomodel.ts
@@ -1,0 +1,39 @@
+import { LanguageModel } from "./chat"
+import { renderMessagesToMarkdown } from "./chatrender"
+import { deleteEmptyValues } from "./cleaners"
+import { MODEL_PROVIDER_ECHO } from "./constants"
+import { logVerbose } from "./util"
+
+export const EchoModel = Object.freeze<LanguageModel>({
+    id: MODEL_PROVIDER_ECHO,
+    completer: async (req, connection, options) => {
+        const { messages, model, ...rest } = req
+        const { partialCb, inner } = options
+        const text = `## Messages
+        
+${renderMessagesToMarkdown(messages, {
+    textLang: "text",
+    assistant: true,
+    system: true,
+    user: true,
+})}
+
+## Request
+
+\`\`\`json
+${JSON.stringify(deleteEmptyValues({ messages, ...rest }), null, 2)}
+\`\`\`
+`
+        partialCb?.({
+            responseChunk: text,
+            tokensSoFar: 0,
+            responseSoFar: text,
+            inner,
+        })
+
+        return {
+            finishReason: "stop",
+            text,
+        }
+    },
+})

--- a/packages/core/src/encoders.test.ts
+++ b/packages/core/src/encoders.test.ts
@@ -5,27 +5,27 @@ import { dedent } from "./indent"
 
 describe("resolveTokenEncoder", () => {
     test("gpt-3.5-turbo", async () => {
-        const encoder = await resolveTokenEncoder("gpt-3.5-turbo")
+        const encoder = await resolveTokenEncoder("openai:gpt-3.5-turbo")
         const result = encoder.encode("test line")
         assert.deepEqual(result, [1985, 1584])
     })
     test("gpt-4", async () => {
-        const encoder = await resolveTokenEncoder("gpt-4")
+        const encoder = await resolveTokenEncoder("openai:gpt-4")
         const result = encoder.encode("test line")
         assert.deepEqual(result, [1985, 1584])
     })
     test("gpt-4o", async () => {
-        const encoder = await resolveTokenEncoder("gpt-4o")
+        const encoder = await resolveTokenEncoder("openai:gpt-4o")
         const result = encoder.encode("test line")
         assert.deepEqual(result, [3190, 2543])
     })
     test("gpt-4o-mini", async () => {
-        const encoder = await resolveTokenEncoder("gpt-4o-mini")
+        const encoder = await resolveTokenEncoder("openai:gpt-4o-mini")
         const result = encoder.encode("test line")
         assert.deepEqual(result, [3190, 2543])
     })
     test("gpt-4o forbidden", async () => {
-        const encoder = await resolveTokenEncoder("gpt-4o")
+        const encoder = await resolveTokenEncoder("openai:gpt-4o")
         const result = encoder.encode("<|im_end|>")
         assert.deepEqual(result, [27, 91, 321, 13707, 91, 29])
     })
@@ -57,7 +57,7 @@ For example, to denote a heading, you add a number sign before it (e.g., # Headi
             {
                 chunkSize: 128,
                 chunkOverlap: 16,
-                model: "gpt-4o",
+                model: "openai:gpt-4o",
                 lineNumbers: true,
             }
         )

--- a/packages/core/src/llms.json
+++ b/packages/core/src/llms.json
@@ -423,6 +423,7 @@
         {
             "id": "github_copilot_chat",
             "detail": "GitHub Copilot Chat Models",
+            "hidden": true,
             "tools": false,
             "prediction": false,
             "tokenless": true,
@@ -433,6 +434,12 @@
                 "reasoning_small": "o1-mini"
             },
             "env": {}
+        },
+        {
+            "id": "echo",
+            "detail": "A fake LLM provider that responds with the input messages.",
+            "tools": true,
+            "tokenless": true
         }
     ],
     "aliases": {

--- a/packages/core/src/lm.ts
+++ b/packages/core/src/lm.ts
@@ -11,8 +11,9 @@ import {
     MODEL_PROVIDER_OLLAMA,
     MODEL_PROVIDER_TRANSFORMERS,
     MODEL_PROVIDERS,
-    MODEL_WHISPERASR_PROVIDER,
+    MODEL_PROVIDER_WHISPERASR,
     MODEL_PROVIDER_AZURE_OPENAI,
+    MODEL_PROVIDER_ECHO,
 } from "./constants"
 import { runtimeHost } from "./host"
 import { OllamaModel } from "./ollama"
@@ -22,6 +23,7 @@ import { GitHubModel } from "./github"
 import { LMStudioModel } from "./lmstudio"
 import { WhiserAsrModel } from "./whisperasr"
 import { AzureOpenAIModel } from "./azureopenai"
+import { EchoModel } from "./echomodel"
 
 export function resolveLanguageModel(provider: string): LanguageModel {
     if (provider === MODEL_PROVIDER_GITHUB_COPILOT_CHAT) {
@@ -38,7 +40,8 @@ export function resolveLanguageModel(provider: string): LanguageModel {
         return AnthropicBedrockModel
     if (provider === MODEL_PROVIDER_TRANSFORMERS) return TransformersModel
     if (provider === MODEL_PROVIDER_LMSTUDIO) return LMStudioModel
-    if (provider === MODEL_WHISPERASR_PROVIDER) return WhiserAsrModel
+    if (provider === MODEL_PROVIDER_WHISPERASR) return WhiserAsrModel
+    if (provider === MODEL_PROVIDER_ECHO) return EchoModel
 
     const features = MODEL_PROVIDERS.find((p) => p.id === provider)
     return LocalOpenAICompatibleModel(provider, {

--- a/packages/core/src/markdown.ts
+++ b/packages/core/src/markdown.ts
@@ -4,6 +4,7 @@
 // and working with trace trees.
 
 import { convertAnnotationsToMarkdown } from "./annotations"
+import { collapseNewlines } from "./cleaners"
 import { fenceMD } from "./mkmd"
 import { convertThinkToMarkdown } from "./think"
 
@@ -16,17 +17,8 @@ export function prettifyMarkdown(md: string) {
     let res = md
     res = convertAnnotationsToMarkdown(res) // Convert annotations to markdown format
     res = convertThinkToMarkdown(res)
-    res = cleanMarkdown(res) // Clean up excessive newlines
+    res = collapseNewlines(res) // Clean up excessive newlines
     return res
-}
-
-/**
- * Cleans markdown by reducing multiple consecutive newlines to two.
- * @param res - The string to be cleaned.
- * @returns The cleaned string.
- */
-function cleanMarkdown(res: string): string {
-    return res?.replace(/(\r?\n){3,}/g, "\n\n")
 }
 
 /**

--- a/packages/core/src/models.test.ts
+++ b/packages/core/src/models.test.ts
@@ -37,7 +37,7 @@ describe("parseModelIdentifier", () => {
         const { provider, model, family } = parseModelIdentifier("llamafile")
         assert(provider === MODEL_PROVIDER_LLAMAFILE)
         assert(family === "*")
-        assert(model === "llamafile")
+        assert(model === "*")
     })
     test("github:gpt4", () => {
         const { provider, model, family } = parseModelIdentifier("github:gpt4")
@@ -45,8 +45,8 @@ describe("parseModelIdentifier", () => {
         assert(model === "gpt4")
         assert(family === "gpt4")
     })
-    test("gpt4", () => {
-        const { provider, model, family } = parseModelIdentifier("gpt4")
+    test("openai:gpt4", () => {
+        const { provider, model, family } = parseModelIdentifier("openai:gpt4")
         assert(provider === MODEL_PROVIDER_OPENAI)
         assert(model === "gpt4")
         assert(family === "gpt4")

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -1,9 +1,5 @@
 import { uniq } from "es-toolkit"
-import {
-    LARGE_MODEL_ID,
-    MODEL_PROVIDER_LLAMAFILE,
-    MODEL_PROVIDER_OPENAI,
-} from "./constants"
+import { LARGE_MODEL_ID } from "./constants"
 import { errorMessage } from "./error"
 import { host, ModelConfiguration, runtimeHost } from "./host"
 import { MarkdownTrace, TraceOptions } from "./trace"
@@ -24,7 +20,6 @@ export function parseModelIdentifier(id: string): {
     tag?: string
 } {
     assert(!!id)
-    id = id.replace("-35-", "-3.5-")
     const parts = id.split(":")
     if (parts.length >= 3)
         return {
@@ -35,9 +30,7 @@ export function parseModelIdentifier(id: string): {
         }
     else if (parts.length === 2)
         return { provider: parts[0], family: parts[1], model: parts[1] }
-    else if (id === MODEL_PROVIDER_LLAMAFILE)
-        return { provider: MODEL_PROVIDER_LLAMAFILE, family: "*", model: id }
-    else return { provider: MODEL_PROVIDER_OPENAI, family: id, model: id }
+    else return { provider: id, family: "*", model: "*" }
 }
 
 export interface ModelConnectionInfo

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -211,6 +211,7 @@ type ModelType = OptionsOrString<
     | "deepseek:deepseek-chat"
     | "transformers:onnx-community/Qwen2.5-0.5B-Instruct:q4"
     | "transformers:HuggingFaceTB/SmolLM2-1.7B-Instruct:q4f16"
+    | "echo"
 >
 
 type ModelSmallType = OptionsOrString<
@@ -250,6 +251,8 @@ type ModelProviderType = OptionsOrString<
     | "litellm"
     | "github_copilot_chat"
     | "deepseek"
+    | "whisperasr"
+    | "echo"
 >
 
 interface ModelConnectionOptions {

--- a/packages/core/src/whisperasr.ts
+++ b/packages/core/src/whisperasr.ts
@@ -2,7 +2,7 @@ import prettyBytes from "pretty-bytes"
 import { serializeError } from "serialize-error"
 import { CancellationOptions } from "./cancellation"
 import { CreateTranscriptionRequest, LanguageModel } from "./chat"
-import { MODEL_WHISPERASR_PROVIDER } from "./constants"
+import { MODEL_PROVIDER_WHISPERASR } from "./constants"
 import { traceFetchPost } from "./fetch"
 import { getConfigHeaders } from "./openai"
 import { LanguageModelConfiguration } from "./server/messages"
@@ -59,6 +59,6 @@ async function WhisperASRTranscribe(
 }
 
 export const WhiserAsrModel: LanguageModel = Object.freeze({
-    id: MODEL_WHISPERASR_PROVIDER,
+    id: MODEL_PROVIDER_WHISPERASR,
     transcriber: WhisperASRTranscribe,
 } satisfies LanguageModel)

--- a/packages/sample/genaisrc/poem-echo.genai.mjs
+++ b/packages/sample/genaisrc/poem-echo.genai.mjs
@@ -1,0 +1,5 @@
+script({
+    model: "echo",
+    tests: {},
+})
+$`Write a poem.`


### PR DESCRIPTION
Introduce the "echo" model to the GenAI ecosystem, enabling dry runs without LLM calls. This addition enhances debugging capabilities by allowing users to see the expected output without invoking an actual LLM provider.

<!-- genaiscript begin prd --><hr/>

• ✨ Introduces an "echo" provider that does a dry run by returning messages without calling any external service  
• 🦺 Adds a "hidden" property for providers so some can be excluded from CLI prompts or configuration menus  
• 📚 Updates documentation and CLI references to include the new "echo" provider and to only show non-hidden providers  
• ➿ Improves text rendering by collapsing excessive line breaks  
• 🏗 Adds a sample script demonstrating usage with the "echo" provider for debugging and testing  

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

