### PR TITLE
Introduce "none" LLM provider for execution control

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -1590,12 +1590,24 @@ You can also override the `transcription` model alias to change the default mode
 
 ## Echo
 
-This is a dry run LLM provider that returns the messages without calling any LLM.
+The `echo` provider is a dry run LLM provider that returns the messages without calling any LLM.
 It is most useful for debugging when you want to see the result LLM request without sending it.
 
 ```js 'model: "echo"'
 script({
     model: "echo",
+})
+```
+
+Echo replies with the chat messages as markdown and JSON, which can be helpful for debugging.
+
+## None
+
+The `none` provider prevents the execution of LLM. It is typically used on a top-level script that exclusively uses inline prompts.
+
+```js 'model: "none"'
+script({
+    model: "none",
 })
 ```
 

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -41,6 +41,7 @@ import {
     MODEL_PROVIDER_WHISPERASR,
     WHISPERASR_API_BASE,
     MODEL_PROVIDER_ECHO,
+    MODEL_PROVIDER_NONE,
 } from "./constants"
 import { host, runtimeHost } from "./host"
 import { parseModelIdentifier } from "./models"
@@ -555,12 +556,12 @@ export async function parseTokenFromEnv(
         }
     }
 
-    if (provider === MODEL_PROVIDER_ECHO) {
+    if (provider === MODEL_PROVIDER_ECHO || provider === MODEL_PROVIDER_NONE) {
         return {
             provider,
             model,
             base: undefined,
-            token: "echo",
+            token: provider,
         }
     }
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -177,6 +177,7 @@ export const MODEL_PROVIDER_JAN = "jan"
 export const MODEL_PROVIDER_DEEPSEEK = "deepseek"
 export const MODEL_PROVIDER_WHISPERASR = "whisperasr"
 export const MODEL_PROVIDER_ECHO = "echo"
+export const MODEL_PROVIDER_NONE = "none"
 
 export const MODEL_PROVIDER_OPENAI_HOSTS = Object.freeze([
     MODEL_PROVIDER_OPENAI,

--- a/packages/core/src/echomodel.ts
+++ b/packages/core/src/echomodel.ts
@@ -2,7 +2,6 @@ import { LanguageModel } from "./chat"
 import { renderMessagesToMarkdown } from "./chatrender"
 import { deleteEmptyValues } from "./cleaners"
 import { MODEL_PROVIDER_ECHO } from "./constants"
-import { logVerbose } from "./util"
 
 export const EchoModel = Object.freeze<LanguageModel>({
     id: MODEL_PROVIDER_ECHO,

--- a/packages/core/src/llms.json
+++ b/packages/core/src/llms.json
@@ -440,6 +440,13 @@
             "detail": "A fake LLM provider that responds with the input messages.",
             "tools": true,
             "tokenless": true
+        },
+        {
+            "id": "none",
+            "tools": true,
+            "tokenless": true,
+            "hidden": true,
+            "detail": "A LLM provider that stops the execution. Used on top level script to prevent LLM execution."
         }
     ],
     "aliases": {

--- a/packages/core/src/lm.ts
+++ b/packages/core/src/lm.ts
@@ -14,6 +14,7 @@ import {
     MODEL_PROVIDER_WHISPERASR,
     MODEL_PROVIDER_AZURE_OPENAI,
     MODEL_PROVIDER_ECHO,
+    MODEL_PROVIDER_NONE,
 } from "./constants"
 import { runtimeHost } from "./host"
 import { OllamaModel } from "./ollama"
@@ -24,6 +25,7 @@ import { LMStudioModel } from "./lmstudio"
 import { WhiserAsrModel } from "./whisperasr"
 import { AzureOpenAIModel } from "./azureopenai"
 import { EchoModel } from "./echomodel"
+import { NoneModel } from "./nonemodel"
 
 export function resolveLanguageModel(provider: string): LanguageModel {
     if (provider === MODEL_PROVIDER_GITHUB_COPILOT_CHAT) {
@@ -42,6 +44,7 @@ export function resolveLanguageModel(provider: string): LanguageModel {
     if (provider === MODEL_PROVIDER_LMSTUDIO) return LMStudioModel
     if (provider === MODEL_PROVIDER_WHISPERASR) return WhiserAsrModel
     if (provider === MODEL_PROVIDER_ECHO) return EchoModel
+    if (provider === MODEL_PROVIDER_NONE) return NoneModel
 
     const features = MODEL_PROVIDERS.find((p) => p.id === provider)
     return LocalOpenAICompatibleModel(provider, {

--- a/packages/core/src/nonemodel.ts
+++ b/packages/core/src/nonemodel.ts
@@ -1,0 +1,13 @@
+import { LanguageModel } from "./chat"
+import { MODEL_PROVIDER_NONE } from "./constants"
+import { serializeError } from "./error"
+
+export const NoneModel = Object.freeze<LanguageModel>({
+    id: MODEL_PROVIDER_NONE,
+    completer: async (req, connection, options) => {
+        return {
+            finishReason: "fail",
+            error: serializeError("No LLM execution allowed in this context."),
+        }
+    },
+})

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -212,6 +212,7 @@ type ModelType = OptionsOrString<
     | "transformers:onnx-community/Qwen2.5-0.5B-Instruct:q4"
     | "transformers:HuggingFaceTB/SmolLM2-1.7B-Instruct:q4f16"
     | "echo"
+    | "none"
 >
 
 type ModelSmallType = OptionsOrString<


### PR DESCRIPTION
Add a new "none" model to prevent LLM execution, enhancing control over script execution with error logging capabilities. This model is useful for scenarios where inline prompts are used exclusively.

<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- ✨ **Introduced the `none` model provider**:
  - Prevents LLM execution, useful for top-level scripts relying solely on inline prompts.
  - Returns an error indicating no LLM execution is allowed in this context.

- 🛠️ **Enhanced `parseTokenFromEnv` logic**:
  - Added support for the `none` provider alongside `echo`.

- 📚 **Documentation Updates**:
  - Updated the "Echo" provider section with additional debugging details.
  - Added a new section for the `none` provider, explaining its purpose and usage.

- 🗂️ **New Model Implementation**:
  - Added `NoneModel` with a custom completer to handle scenarios where LLM execution is disabled.

- 🚀 **Extended Model Resolution**:
  - Integrated `NoneModel` into the language model resolution logic.

- 🛡️ **Updated `llms.json` Configuration**:
  - Registered the `none` provider with relevant metadata, marking it as hidden and tokenless.

These changes enhance debugging capabilities and provide a mechanism to disable LLM execution when necessary.

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

