### PR TITLE
Add support for model aliases in script function

### DIFF
--- a/docs/src/content/docs/reference/scripts/model-aliases.mdx
+++ b/docs/src/content/docs/reference/scripts/model-aliases.mdx
@@ -24,7 +24,7 @@ script({
 ```
 
 Model aliases can be defined as environment varialbles (through the `.env` file),
-in a configuration file or through the [cli](/genaiscript/reference/cli/run).
+in a configuration file, through the [cli](/genaiscript/reference/cli/run) or in the `script` function.
 
 This `.env` file defines a `llama32` alias for the `ollama:llama3.2:1b` model.
 
@@ -61,6 +61,17 @@ The following configuration are support in order importance (last one wins):
 genaiscript run --model-alias llama32=ollama:llama3.2:1b
 ```
 
+- in the `script`function
+
+```js
+script({
+    model: "llama32",
+    modelAliases: {
+        llama32: "ollama:llama3.2:1b",
+    },
+})
+```
+
 ## Alias of aliases
 
 An model alias can reference another alias as long as cycles are not created.
@@ -95,4 +106,3 @@ The default aliases for a given provider can be loaded using the `provider` opti
 ```sh
 genaiscript run --provider anthropic
 ```
-

--- a/docs/src/content/docs/reference/scripts/system.mdx
+++ b/docs/src/content/docs/reference/scripts/system.mdx
@@ -471,7 +471,9 @@ defAgent(
     "web",
     "search the web to accomplish tasks.",
     `Your are a helpful LLM agent that can use web search.
-    Answer the question in <QUERY>.`,
+    Search the web and answer the question in <QUERY>.
+    - Expand <QUERY> into an optimized search query for better results.
+    - Answer exclusively with live information from the web.`,
     {
         system: [
             "system.safety_jailbreak",
@@ -3060,7 +3062,8 @@ defTool(
             count,
             ignoreMissingProvider: true,
         })
-        if (!webPages) return "error: no web search provider configured"
+        if (!webPages)
+            return "error: no web search provider configured (https://microsoft.github.io/genaiscript/reference/scripts/web-search/)"
         return YAML.stringify(
             webPages.map((f) => ({
                 url: f.filename,

--- a/packages/cli/src/modelalias.ts
+++ b/packages/cli/src/modelalias.ts
@@ -37,6 +37,14 @@ export function applyModelOptions(
     }
 }
 
+export function applyScriptModelAliases(script: PromptScript) {
+    applyModelOptions(script, "script")
+    if (script.modelAliases)
+        Object.entries(script.modelAliases).forEach(([name, alias]) => {
+            runtimeHost.setModelAlias("script", name, alias)
+        })
+}
+
 export function logModelAliases() {
     const modelAlias = runtimeHost.modelAliases
     if (Object.values(modelAlias).some((m) => m.source !== "default"))

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -85,7 +85,11 @@ import {
     stdout,
 } from "../../core/src/logging"
 import { ensureDotGenaiscriptPath, setupTraceWriting } from "./trace"
-import { applyModelOptions, logModelAliases } from "./modelalias"
+import {
+    applyModelOptions,
+    applyScriptModelAliases,
+    logModelAliases,
+} from "./modelalias"
 import { createCancellationController } from "./cancel"
 import { parsePromptScriptMeta } from "../../core/src/template"
 import { Fragment } from "../../core/src/generation"
@@ -351,7 +355,7 @@ export async function runScriptInternal(
     const stats = new GenerationStats("")
     try {
         if (options.label) trace.heading(2, options.label)
-        applyModelOptions(script, "script")
+        applyScriptModelAliases(script)
         logModelAliases()
         const { info } = await resolveModelConnectionInfo(script, {
             trace,

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -273,6 +273,11 @@ interface ModelAliasesOptions {
      * Configure the `vision` model alias.
      */
     visionModel?: ModelVisionType
+
+    /**
+     * A list of model aliases to use.
+     */
+    modelAliases?: Record<string, string>
 }
 
 interface ModelOptions extends ModelConnectionOptions, ModelTemplateOptions {

--- a/packages/sample/genaisrc/model-alias.genai.mjs
+++ b/packages/sample/genaisrc/model-alias.genai.mjs
@@ -1,0 +1,5 @@
+script({
+    model: "foo",
+    modelAliases: { foo: "small" },
+})
+$`Write a poem.`


### PR DESCRIPTION
Define model aliases directly within the script function, enhancing flexibility in model management. This update allows users to specify aliases in the script, alongside existing methods like environment variables and configuration files.

<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- ✨ **Added support for defining model aliases in the `script` function**:
  - Introduced a `modelAliases` property in the `script` function to define model aliases directly in scripts.
  - Updated related documentation to reflect this new configuration option.

- 🛠️ **Improved error handling for web search**:
  - Enhanced error messages when no web search provider is configured, including a helpful link to the documentation.

- 📖 **Documentation updates**:
  - Expanded examples and explanations for model alias configurations.
  - Clarified guidance on creating optimized web search queries in the system function.

- 🧩 **New helper function**:
  - Added `applyScriptModelAliases` to handle model alias definitions within scripts.

- 🗂️ **Sample script added**:
  - Introduced a sample script (`model-alias.genai.mjs`) showcasing the new `modelAliases` functionality.

These changes enhance flexibility in model alias configuration and improve usability and clarity in both the codebase and documentation. 🚀

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

