### PR TITLE
Add userState management to agent memory logic

### DIFF
--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -353,6 +353,7 @@ export async function runScriptInternal(
         ? parseOptionsVars(options.vars, process.env)
         : structuredClone(options.vars || {})
     const stats = new GenerationStats("")
+    const userState: Record<string, any> = {}
     try {
         if (options.label) trace.heading(2, options.label)
         applyScriptModelAliases(script)
@@ -416,6 +417,7 @@ export async function runScriptInternal(
                   }
                 : undefined,
             stats,
+            userState,
         })
     } catch (err) {
         stats.log()
@@ -426,7 +428,7 @@ export async function runScriptInternal(
     }
 
     await aggregateResults(scriptId, outTrace, stats, result)
-    await traceAgentMemory(trace)
+    await traceAgentMemory({ userState, trace })
 
     if (outAnnotations && result.annotations?.length) {
         if (isJSONLFilename(outAnnotations))

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -39,14 +39,15 @@ export class MemoryCache<K, V>
      */
     static byName<K, V>(
         name: string,
-        options?: { lookupOnly?: boolean }
+        options?: { userState?: Record<string, any>; lookupOnly?: boolean }
     ): MemoryCache<K, V> {
         name = name.replace(/[^a-z0-9_]/gi, "_") // Sanitize name
         const key = "memorycache." + name
-        if (host.userState[key]) return host.userState[key] // Return if exists
+        const userState = options?.userState || host.userState
+        if (userState[key]) return userState[key] // Return if exists
         if (options?.lookupOnly) return undefined
         const r = new MemoryCache<K, V>(name)
-        host.userState[key] = r
+        userState[key] = r
         return r
     }
 

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -32,4 +32,5 @@ export interface GenerationOptions
     }
     vars?: PromptParameters // Variables for prompt customization
     stats: GenerationStats // Statistics of the generation
+    userState: Record<string, any>
 }

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -96,7 +96,7 @@ export type ModelConfigurations = {
 } & Record<string, ModelConfiguration>
 
 export interface Host {
-    userState: any
+    userState: Record<string, any>
     server: ServerManager
     path: Path
 

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -326,7 +326,7 @@ export function createChatGenerationContext(
         env: ExpansionVariables
     }
 ): RunPromptContextNode {
-    const { cancellationToken, infoCb } = options || {}
+    const { cancellationToken, infoCb, userState } = options || {}
     const { prj, env } = projectOptions
     assert(!!env.output, "output missing")
     const turnCtx = createChatTurnGenerationContext(options, trace)
@@ -481,7 +481,8 @@ export function createChatGenerationContext(
                         query +
                             (hasExtraArgs
                                 ? `\n${YAMLStringify(argsNoQuery)}`
-                                : "")
+                                : ""),
+                        { userState, trace }
                     )
 
                 const res = await ctx.runPrompt(
@@ -519,7 +520,7 @@ export function createChatGenerationContext(
                                         agentName,
                                         query,
                                         text,
-                                        trace
+                                        { userState, trace }
                                     )
                             })
                     },


### PR DESCRIPTION
Introduce userState for improved contextual memory tracking within the agent's memory logic. This enhancement allows for better management and retrieval of user-specific data during interactions.

<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- 🧠 **Introduced `userState` for State Management**  
  - Added a `userState` object to enable better state management across various components.
  - Passed `userState` throughout key functions, including `runScriptInternal`, `agentQueryMemory`, `agentAddMemory`, and `traceAgentMemory`.

- 🔄 **Enhanced Memory Cache Handling**  
  - Updated `MemoryCache.byName` to accept `userState` as an optional parameter for more flexible cache allocation and retrieval.
  - Ensured `userState` is used for managing memory cache instances instead of relying solely on the global `host.userState`.

- 🛠️ **Refactored Agent Memory Operations**  
  - Modified `agentQueryMemory` and `agentAddMemory` to include `userState` in their options for more contextual memory operations.
  - Updated `loadMemories` to accept `userState` for scoped memory retrieval.

- 📊 **Improved Traceability**  
  - Enhanced `traceAgentMemory` to include `userState` in its processing, improving debugging and trace details for agent memory.

- 🔧 **Updated Interfaces**  
  - Augmented `GenerationOptions` and `Host` interfaces to include a typed `userState` field (`Record<string, any>`), ensuring consistency across the codebase.

- 🤖 **Improved Chat Context Handling**  
  - Extended `createChatGenerationContext` to propagate `userState` for better context management during chat generation.

These changes collectively improve state management, memory operations, and traceability in the system, enabling more robust and flexible workflows.

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

