### PR TITLE
docx parse caching

### DIFF
--- a/packages/cli/src/parse.ts
+++ b/packages/cli/src/parse.ts
@@ -77,13 +77,11 @@ export async function parsePDF(
  * Parses the contents of a DOCX file and logs the text.
  * @param file - The DOCX file to parse.
  */
-export async function parseDOCX(
-    file: string,
-    options: { format: "text" | "html" }
-) {
+export async function parseDOCX(file: string, options: DocxParseOptions) {
     // Uses DOCXTryParse to extract text from the DOCX file
-    const text: string = await DOCXTryParse(file, options)
-    console.log(text)
+    const res = await DOCXTryParse(file, options)
+    if (res.error) console.error(res.error)
+    else console.log(res.file.content)
 }
 
 /**

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -253,7 +253,8 @@ export const MODEL_PRICINGS = Object.freeze<
 export const NEW_SCRIPT_TEMPLATE = `$\`Write a short poem in code.\`
 `
 export const PDF_SCALE = 4
-export const PDF_HASH_LENGTH = 12
+export const PDF_HASH_LENGTH = 18
+export const DOCX_HASH_LENGTH = 18
 
 export const PDF_MIME_TYPE = "application/pdf"
 export const DOCX_MIME_TYPE =

--- a/packages/core/src/docx.test.ts
+++ b/packages/core/src/docx.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, test } from "node:test"
+import assert from "node:assert/strict"
+import { DOCXTryParse } from "./docx"
+import { TestHost } from "./testhost"
+
+describe("DOCXTryParse", () => {
+    beforeEach(() => {
+        TestHost.install()
+    })
+
+    test("parse DOCX to markdown", async () => {
+        const file = "../sample/src/rag/Document.docx"
+        const result = await DOCXTryParse(file, { format: "markdown" })
+        assert(result.file.content.includes("Microsoft"))
+    })
+
+    test("parse DOCX to HTML", async () => {
+        const file = "../sample/src/rag/Document.docx"
+        const result = await DOCXTryParse(file, { format: "html" })
+        assert(result.file.content.includes("Microsoft"))
+    })
+
+    test("cache hit", async () => {
+        const file = "../sample/src/rag/Document.docx"
+        const result = await DOCXTryParse(file, { format: "text" })
+        const result2 = await DOCXTryParse(file, { format: "text" })
+        assert(result2.file.content === result.file.content)
+    })
+})

--- a/packages/core/src/docx.ts
+++ b/packages/core/src/docx.ts
@@ -1,39 +1,101 @@
+import { join } from "node:path"
+import { PDF_HASH_LENGTH } from "./constants"
+import { hash } from "./crypto"
 import { host } from "./host"
 import { HTMLToMarkdown } from "./html"
 import { TraceOptions } from "./trace"
-import { logError } from "./util"
+import { dotGenaiscriptPath, logError, logVerbose } from "./util"
+import { readFile, writeFile } from "node:fs/promises"
+import { YAMLStringify } from "./yaml"
+import { serializeError } from "./error"
+
+async function computeHashFolder(
+    filename: string | WorkspaceFile,
+    content: Uint8Array,
+    options: TraceOptions & DocxParseOptions
+) {
+    const { trace, ...rest } = options
+    const h = await hash(
+        [typeof filename === "string" ? { filename } : filename, content, rest],
+        {
+            readWorkspaceFiles: true,
+            version: true,
+            length: PDF_HASH_LENGTH,
+        }
+    )
+    return dotGenaiscriptPath("cache", "docx", h)
+}
 
 /**
  * parses docx, require mammoth to be installed
- * @param fileOrUrl
- * @param content
- * @returns
  */
 export async function DOCXTryParse(
-    file: string,
-    options?: TraceOptions & { format?: "markdown" | "html" | "text" }
-): Promise<string> {
-    const { trace, format = "markdown" } = options || {}
+    filename: string,
+    content?: Uint8Array,
+    options?: TraceOptions & DocxParseOptions
+): Promise<{ content?: string; error?: SerializedError }> {
+    const { trace, cache, format = "markdown" } = options || {}
+
+    const folder = await computeHashFolder(filename, content, options)
+    const resFilename = join(folder, "res.json")
+    const readCache = async () => {
+        if (cache === false) return undefined
+        try {
+            const res = JSON.parse(
+                await readFile(resFilename, {
+                    encoding: "utf-8",
+                })
+            )
+            logVerbose(`docx: cache hit at ${folder}`)
+            return res
+        } catch {
+            return undefined
+        }
+    }
+
+    {
+        // try cache hit
+        const cached = await readCache()
+        if (cached) return cached
+    }
+
     try {
         const { extractRawText, convertToHtml } = await import("mammoth")
-        const path = !/^\//.test(file)
-            ? host.path.join(host.projectFolder(), file)
-            : file
+        const input = content
+            ? { buffer: Buffer.from(content) }
+            : { path: host.resolvePath(filename) }
+
+        let text: string
         if (format === "html" || format === "markdown") {
-            const results = await convertToHtml({ path })
+            const results = await convertToHtml(input)
             if (format === "markdown")
-                return HTMLToMarkdown(results.value, {
+                text = await HTMLToMarkdown(results.value, {
                     trace,
                     disableGfm: true,
                 })
-            return results.value
+            else text = results.value
         } else {
-            const results = await extractRawText({ path })
-            return results.value
+            const results = await extractRawText(input)
+            text = results.value
         }
+
+        await writeFile(join(folder, "content.txt"), text)
+        const res = { content: text }
+        await writeFile(resFilename, JSON.stringify(res))
+
+        return res
     } catch (error) {
-        logError(error)
-        trace?.error(`reading docx`, error)
-        return undefined
+        logVerbose(error)
+        {
+            // try cache hit
+            const cached = await readCache()
+            if (cached) return cached
+        }
+        trace?.error(`reading pdf`, error) // Log error if tracing is enabled
+        await writeFile(
+            join(folder, "error.txt"),
+            YAMLStringify(serializeError(error))
+        )
+        return { error: serializeError(error) }
     }
 }

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -104,9 +104,9 @@ export async function resolveFileContent(
     }
     // Handle DOCX files
     else if (DOCX_REGEX.test(filename)) {
+        const res = await DOCXTryParse(filename, options)
         file.type = DOCX_MIME_TYPE
-        const { content } = await DOCXTryParse(filename, undefined, options)
-        file.content = content
+        file.content = res.file?.content
     }
     // Handle XLSX files
     else if (XLSX_REGEX.test(filename)) {

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -105,7 +105,8 @@ export async function resolveFileContent(
     // Handle DOCX files
     else if (DOCX_REGEX.test(filename)) {
         file.type = DOCX_MIME_TYPE
-        file.content = await DOCXTryParse(filename, options)
+        const { content } = await DOCXTryParse(filename, undefined, options)
+        file.content = content
     }
     // Handle XLSX files
     else if (XLSX_REGEX.test(filename)) {

--- a/packages/core/src/mdchunk.test.ts
+++ b/packages/core/src/mdchunk.test.ts
@@ -179,8 +179,9 @@ There are many variations of passages of Lorem Ipsum available, but the majority
     }
 
     await test(`word: chunks markdown from docx`, async () => {
-        const markdown = await DOCXTryParse(
+        const { content: markdown } = await DOCXTryParse(
             "../../packages/sample/src/rag/Document.docx",
+            undefined,
             {
                 format: "markdown",
             }

--- a/packages/core/src/mdchunk.test.ts
+++ b/packages/core/src/mdchunk.test.ts
@@ -179,13 +179,13 @@ There are many variations of passages of Lorem Ipsum available, but the majority
     }
 
     await test(`word: chunks markdown from docx`, async () => {
-        const { content: markdown } = await DOCXTryParse(
+        const { file } = await DOCXTryParse(
             "../../packages/sample/src/rag/Document.docx",
-            undefined,
             {
                 format: "markdown",
             }
         )
+        const markdown = file.content
         assert(markdown)
         for (let i = 0; i < 12; ++i) {
             const result = await chunkMarkdown(markdown, estimateTokens, 1 << i)

--- a/packages/core/src/parsers.ts
+++ b/packages/core/src/parsers.ts
@@ -84,7 +84,7 @@ export async function createParsers(
             }),
         DOCX: async (file, options) => {
             const filename = typeof file === "string" ? file : file.filename
-            const res = await DOCXTryParse(filename, options)
+            const res = await DOCXTryParse(filename, undefined, options)
             return {
                 file: res
                     ? <WorkspaceFile>{ filename, content: res }

--- a/packages/core/src/parsers.ts
+++ b/packages/core/src/parsers.ts
@@ -82,15 +82,7 @@ export async function createParsers(
                 ...(options || {}),
                 trace,
             }),
-        DOCX: async (file, options) => {
-            const filename = typeof file === "string" ? file : file.filename
-            const res = await DOCXTryParse(filename, undefined, options)
-            return {
-                file: res
-                    ? <WorkspaceFile>{ filename, content: res }
-                    : undefined,
-            }
-        },
+        DOCX: async (file, options) => await DOCXTryParse(file, options),
         PDF: async (file, options) => {
             if (!file) return { file: undefined, pages: [], data: [] }
             const opts = {

--- a/packages/core/src/pdf.ts
+++ b/packages/core/src/pdf.ts
@@ -311,7 +311,6 @@ async function PDFTryParse(
         }
 
         const res = deleteUndefinedValues({
-            ok: true,
             metadata,
             pages,
             content: PDFPagesToString(pages),
@@ -331,7 +330,7 @@ async function PDFTryParse(
             join(folder, "error.txt"),
             YAMLStringify(serializeError(error))
         )
-        return { ok: false, error: serializeError(error) }
+        return { error: serializeError(error) }
     }
 
     async function decodeImage(
@@ -422,12 +421,12 @@ export async function parsePdf(
         typeof filenameOrBuffer === "string"
             ? undefined
             : (filenameOrBuffer as Uint8Array)
-    const { pages, ok, metadata, content } = await PDFTryParse(
+    const { pages, metadata, content, error } = await PDFTryParse(
         filename,
         bytes,
         options
     )
-    if (!ok) return { pages: [], content: "" }
+    if (error) return { pages: [], content: "" }
     return { pages, content, metadata }
 }
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1406,11 +1406,10 @@ interface RangeOptions {
 }
 
 interface GitIgnoreFilterOptions {
-
     /**
      * Disable filtering files based on the `.gitignore` file.
      */
-    ignoreGitIgnore?: false | undefined    
+    ignoreGitIgnore?: false | undefined
 }
 
 interface FileFilterOptions extends GitIgnoreFilterOptions {
@@ -2016,6 +2015,18 @@ interface PDFPage {
     figures?: PDFPageImage[]
 }
 
+interface DocxParseOptions {
+    /**
+     * Desired output format
+     */
+    format?: "markdown" | "text" | "html"
+
+    /**
+     * If true, the transcription will be cached.
+     */
+    cache?: boolean | string
+}
+
 interface Parsers {
     /**
      * Parses text as a JSON5 payload
@@ -2100,7 +2111,7 @@ interface Parsers {
      */
     DOCX(
         content: string | WorkspaceFile,
-        options?: { format: "markdown" | "text" | "html" }
+        options?: DocxParseOptions
     ): Promise<{ file: WorkspaceFile } | undefined>
 
     /**

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -2112,7 +2112,7 @@ interface Parsers {
     DOCX(
         content: string | WorkspaceFile,
         options?: DocxParseOptions
-    ): Promise<{ file: WorkspaceFile } | undefined>
+    ): Promise<{ file?: WorkspaceFile; error?: string }>
 
     /**
      * Parses a CSV file or text


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

## Summary of Changes

### 📝 Enhanced DOCX Parsing
- Refactored `DOCXTryParse` to return a structured result containing `file` and `error` instead of raw content.
- Introduced caching for parsed DOCX files to improve performance and reduce redundant processing.
- Added a hash-based folder mechanism for caching DOCX parsing results, with error handling and logging improvements.
- Updated `DocxParseOptions` to include caching and output format options (`markdown`, `text`, or `html`).

### 🔍 Improved Error Handling
- Enhanced error reporting with detailed serialization and logging for DOCX parsing failures.
- Updated `PDFTryParse` to return an `error` flag instead of a generic `ok` flag for better clarity.

### 🚀 New Tests
- Added a new test suite (`docx.test.ts`) to validate DOCX parsing functionality, including tests for markdown, HTML outputs, and cache hits.

### 🛠️ Refactoring and Cleanup
- Simplified and standardized the `DOCX` parser integration in the `createParsers` function.
- Adjusted `resolveFileContent` to handle new structured results from `DOCXTryParse`.
- Removed unused or redundant variables and code for better readability and maintainability.

### 🔧 Constants and Types Updates
- Introduced `DOCX_HASH_LENGTH` constant for hash-based caching.
- Added a new `DocxParseOptions` interface to define parsing configuration.
- Minor cleanup in type definitions, removing unnecessary spacing.

These changes aim to make DOCX parsing more robust, efficient, and easier to debug while improving overall code quality and test coverage. 🚀

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

