### PR TITLE
handle gitignore filtering

### DIFF
--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -109,7 +109,7 @@ export async function convertFiles(
 
     // resolve files
     const applyGitIgnore =
-        options.ignoreGitIgnore !== false && script.ignoreGitIgnore !== false
+        options.ignoreGitIgnore !== true && script.ignoreGitIgnore !== true
     const resolvedFiles = new Set<string>()
     for (let arg of fileGlobs) {
         if (HTTPS_REGEX.test(arg)) {

--- a/packages/cli/src/parse.ts
+++ b/packages/cli/src/parse.ts
@@ -154,7 +154,7 @@ export async function parseAnyToJSON(
  * @param files - An array of files or glob patterns to process.
  */
 export async function jsonl2json(files: string[]) {
-    for (const file of await expandFiles(files)) {
+    for (const file of await expandFiles(files, { applyGitIgnore: false })) {
         if (!isJSONLFilename(file)) {
             // Skips files that are not JSONL
             console.log(`skipping ${file}`)
@@ -175,12 +175,16 @@ export async function jsonl2json(files: string[]) {
  */
 export async function parseTokens(
     filesGlobs: string[],
-    options: { excludedFiles: string[]; model: string }
+    options: {
+        excludedFiles: string[]
+        model: string
+        ignoreGitIgnore: boolean
+    }
 ) {
     const { model } = options || {}
     const { encode: encoder } = await resolveTokenEncoder(model)
 
-    const files = await expandFiles(filesGlobs, options?.excludedFiles)
+    const files = await expandFiles(filesGlobs, options)
     console.log(`parsing ${files.length} files`)
     let text = ""
     for (const file of files) {

--- a/packages/cli/src/retrieval.ts
+++ b/packages/cli/src/retrieval.ts
@@ -31,6 +31,7 @@ export async function retrievalSearch(
         topK: string
         name: string
         embeddingsModel: string
+        ignoreGitIgnore: boolean
     }
 ) {
     // Destructure options with default values
@@ -39,13 +40,17 @@ export async function retrievalSearch(
         name: indexName,
         topK,
         embeddingsModel,
+        ignoreGitIgnore,
     } = options || {}
 
     // Expand file globs and map to WorkspaceFile object
     // Excludes specified files
-    const files = (await expandFiles(filesGlobs, excludedFiles)).map(
-        (filename) => <WorkspaceFile>{ filename }
-    )
+    const files = (
+        await expandFiles(filesGlobs, {
+            excludedFiles,
+            applyGitIgnore: !ignoreGitIgnore,
+        })
+    ).map((filename) => <WorkspaceFile>{ filename })
 
     // Resolve the contents of the files to ensure they can be processed
     await resolveFileContents(files)
@@ -82,6 +87,7 @@ export async function retrievalFuzz(
     options: {
         excludedFiles: string[]
         topK: string
+        ignoreGitIgnore: boolean
     }
 ) {
     // Destructure options with default values
@@ -94,7 +100,7 @@ export async function retrievalFuzz(
     if (!excludedFiles?.length) excludedFiles = ["**/node_modules/**"]
 
     // Expand file globs and resolve the list of files
-    const files = await expandFiles(filesGlobs, excludedFiles)
+    const files = await expandFiles(filesGlobs, options)
 
     // Log the number of files being searched for transparency
     console.log(`searching '${q}' in ${files.length} files`)

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -274,7 +274,7 @@ export async function runScriptInternal(
     )
     if (!script) throw new Error(`script ${scriptId} not found`)
     const applyGitIgnore =
-        options.ignoreGitIgnore !== false && script.ignoreGitIgnore !== false
+        options.ignoreGitIgnore !== true && script.ignoreGitIgnore !== true
     const resolvedFiles = new Set<string>()
     for (let arg of files) {
         if (HTTPS_REGEX.test(arg)) {

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -53,8 +53,10 @@ async function resolveExpansionVars(
         referenceFiles.length || workspaceFiles.length
             ? referenceFiles
             : templateFiles,
-        undefined,
-        template.accept
+        {
+            applyGitIgnore: false,
+            accept: template.accept,
+        }
     )
     for (let filename of filenames) {
         filename = relativePath(root, filename)

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1433,7 +1433,7 @@ interface GitIgnoreFilterOptions {
     /**
      * Disable filtering files based on the `.gitignore` file.
      */
-    ignoreGitIgnore?: false | undefined
+    ignoreGitIgnore?: true | undefined
 }
 
 interface FileFilterOptions extends GitIgnoreFilterOptions {

--- a/packages/sample/genaisrc/ignore-gitignore.genai.mjs
+++ b/packages/sample/genaisrc/ignore-gitignore.genai.mjs
@@ -1,0 +1,9 @@
+script({
+    ignoreGitIgnore: true,
+    files: ".genaiscript/.gitignore",
+    tests: {},
+    model: "echo",
+})
+
+console.log(env.files)
+if (!env.files.length) throw Error("gitignore filter not applied")


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- 🚀 **Enhanced `ignoreGitIgnore` Behavior**: Updated logic across multiple functions to ensure `ignoreGitIgnore` behaves consistently, allowing for explicit control over whether `.gitignore` rules are applied. Default behavior now aligns with `ignoreGitIgnore: true` explicitly bypassing `.gitignore`.

- 🔧 **Expanded `expandFiles` Options**: Refactored `expandFiles` to accept a new `applyGitIgnore` flag, enabling finer control over file resolution behavior.

- 🛠️ **Improved Functionality in File Parsing and Retrieval**:
  - Modified `jsonl2json`, `parseTokens`, `retrievalSearch`, and `retrievalFuzz` to leverage the updated `expandFiles` API, ensuring proper handling of `.gitignore` rules.
  - Added `ignoreGitIgnore` as a configurable option in parsing and retrieval functions.

- ✅ **Template Handling Improvements**: Adjusted `resolveExpansionVars` to explicitly disable `.gitignore` filtering for template file resolution.

- 📂 **New Sample Script**: Added a new sample script (`ignore-gitignore.genai.mjs`) to demonstrate and test the `ignoreGitIgnore: true` functionality.

- 📝 **Type Updates**: Updated type definitions for `GitIgnoreFilterOptions` to reflect the new behavior of `ignoreGitIgnore` as a `true`-enabled flag.

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

