### PR TITLE
Add suggestion mode for string types

### DIFF
--- a/docs/src/content/docs/reference/scripts/parameters.mdx
+++ b/docs/src/content/docs/reference/scripts/parameters.mdx
@@ -100,6 +100,16 @@ Some additional, non-standard properties are used to provide additional informat
 }
 ```
 
+- `uiSuggestions` to provide a list of suggestions for a `string` type. The suggestions populate the dropdown in the UI
+but allow for other values as well.
+
+```json
+{
+    "type": "string",
+    "uiSuggestions": ["San Francisco", "New York"]
+}
+```
+
 ## Scripts and system Scripts
 
 The `parameters` of a `script` entry is used to populate the `env.vars` entries. The parameters schema

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -320,6 +320,7 @@ export function toStrictJSONSchema(
         switch (n.type) {
             case "string": {
                 delete n.uiType
+                delete n.uiSuggestions
                 break
             }
             case "object": {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1590,6 +1590,7 @@ interface JSONSchemaDescripted {
 interface JSONSchemaString extends JSONSchemaDescripted {
     type: "string"
     uiType?: "textarea"
+    uiSuggestions?: string[]
     enum?: string[]
     default?: string
     pattern?: string

--- a/packages/sample/genaisrc/parameters.genai.mjs
+++ b/packages/sample/genaisrc/parameters.genai.mjs
@@ -17,6 +17,10 @@ script({
             type: "string",
             enum: ["aaa", "bbbb", "bbb"],
         },
+        suggested: {
+            type: "string",
+            uiSuggestions: ["a", "b", "c"],
+        },
         stringSchema: {
             type: "string",
             default: "efg",

--- a/packages/web/src/JSONSchema.tsx
+++ b/packages/web/src/JSONSchema.tsx
@@ -1,0 +1,262 @@
+/// <reference path="../../core/src/types/prompt_template.d.ts" />
+/// <reference path="./vscode-elements.d.ts" />
+import React, {
+    Dispatch,
+    SetStateAction,
+    startTransition,
+    useEffect,
+    useState,
+} from "react"
+
+import { underscore } from "inflection"
+import "@vscode-elements/elements/dist/vscode-textarea"
+import "@vscode-elements/elements/dist/vscode-textfield"
+import "@vscode-elements/elements/dist/vscode-single-select"
+import "@vscode-elements/elements/dist/vscode-option"
+import "@vscode-elements/elements/dist/vscode-checkbox"
+import "@vscode-elements/elements/dist/vscode-form-container"
+import "@vscode-elements/elements/dist/vscode-form-group"
+import "@vscode-elements/elements/dist/vscode-form-helper"
+import "@vscode-elements/elements/dist/vscode-label"
+
+function JSONSchemaString(props: {
+    field: JSONSchemaString
+    value: string
+    required?: boolean
+    onChange: (value: string) => void
+}) {
+    const { field } = props
+    if (field.enum || field.uiSuggestions)
+        return <JSONSchemaStringEnum {...props} />
+    if (field.uiType === "textarea")
+        return <JSONSchemaStringTextArea {...props} />
+    return <JSONSchemaStringTextField {...props} />
+}
+
+function JSONSchemaStringTextField(props: {
+    field: JSONSchemaString
+    value: string
+    required?: boolean
+    onChange: (value: string) => void
+}) {
+    const { field, required, value, onChange } = props
+    const { pattern } = field
+    return (
+        <vscode-textfield
+            pattern={pattern}
+            value={value}
+            required={required}
+            spellCheck={false}
+            placeholder={field.default}
+            autoCapitalize="off"
+            autocomplete="off"
+            onInput={(e) => {
+                const target = e.target as HTMLInputElement
+                onChange(target.value)
+            }}
+        />
+    )
+}
+
+function JSONSchemaStringTextArea(props: {
+    field: JSONSchemaString
+    value: string
+    required?: boolean
+    onChange: (value: string) => void
+}) {
+    const { field, required, value, onChange } = props
+    const rows = (s: string | undefined) =>
+        Math.max(3, s?.split("\n").length ?? 0)
+    return (
+        <vscode-textarea
+            className="vscode-form-wide"
+            value={value}
+            required={required}
+            rows={rows(value)}
+            spellCheck={true}
+            placeholder={field.default}
+            autoCapitalize="off"
+            autocomplete="off"
+            onInput={(e) => {
+                const target = e.target as HTMLTextAreaElement
+                target.rows = rows(target.value)
+                onChange(target.value)
+            }}
+        />
+    )
+}
+
+function JSONSchemaStringEnum(props: {
+    field: JSONSchemaString
+    value: string
+    required?: boolean
+    onChange: (value: string) => void
+}) {
+    const { field, required, value, onChange } = props
+    const { enum: enum_, uiSuggestions } = field
+    const options = enum_ || uiSuggestions
+
+    return (
+        <vscode-single-select
+            value={value}
+            required={required}
+            combobox
+            onvsic-input={(e: CustomEvent) => {
+                if (uiSuggestions) {
+                    const target = e.target as HTMLInputElement
+                    onChange(target.value)
+                }
+            }}
+            onvsc-change={(e: Event) => {
+                if (enum_) {
+                    const target = e.target as HTMLSelectElement
+                    onChange(target.value)
+                }
+            }}
+        >
+            <vscode-option key="empty" value=""></vscode-option>
+            {options.map((option) => (
+                <vscode-option key={option} value={option}>
+                    {option}
+                </vscode-option>
+            ))}
+        </vscode-single-select>
+    )
+}
+
+function JSONSchemaNumber(props: {
+    schema: JSONSchemaNumber
+    value: number
+    required: boolean
+    onChange: (value: number) => void
+}) {
+    const { required, schema, value, onChange } = props
+    const { type, minimum, maximum } = schema
+    const [valueText, setValueText] = useState(
+        isNaN(value) ? "" : String(value)
+    )
+
+    useEffect(() => {
+        const v =
+            type === "number" ? parseFloat(valueText) : parseInt(valueText)
+        if (!isNaN(v) && v !== value) onChange(v)
+    }, [valueText])
+
+    return (
+        <vscode-textfield
+            value={valueText}
+            required={required}
+            placeholder={isNaN(schema.default) ? "" : String(schema.default)}
+            min={minimum}
+            max={maximum}
+            autoCapitalize="off"
+            autocomplete="off"
+            inputMode={type === "number" ? "decimal" : "numeric"}
+            onInput={(e) => {
+                const target = e.target as HTMLInputElement
+                startTransition(() => setValueText(target.value))
+            }}
+        />
+    )
+}
+
+function JSONSchemaSimpleTypeFormField(props: {
+    field: JSONSchemaSimpleType
+    value: string | boolean | number | object
+    required?: boolean
+    onChange: (value: string | boolean | number | object) => void
+}) {
+    const { field, required, value, onChange } = props
+
+    switch (field.type) {
+        case "number":
+        case "integer":
+            return (
+                <JSONSchemaNumber
+                    schema={field}
+                    value={Number(value)}
+                    onChange={onChange}
+                    required={required}
+                />
+            )
+        case "string": {
+            return (
+                <JSONSchemaString
+                    field={field}
+                    value={value as string}
+                    required={required}
+                    onChange={onChange}
+                />
+            )
+        }
+        case "boolean":
+            return (
+                <vscode-checkbox
+                    checked={value as boolean}
+                    required={required}
+                    onChange={(e) => {
+                        const target = e.target as HTMLInputElement
+                        onChange(target.checked)
+                    }}
+                />
+            )
+        default:
+            return (
+                <vscode-textfield
+                    spellCheck={false}
+                    value={value as string}
+                    required={required}
+                    onInput={(e) => {
+                        const target = e.target as HTMLInputElement
+                        onChange(target.value)
+                    }}
+                />
+            )
+    }
+}
+
+export function JSONSchemaObjectForm(props: {
+    schema: JSONSchemaObject
+    value: any
+    onChange: Dispatch<SetStateAction<any>>
+    fieldPrefix: string
+}) {
+    const { schema, value, onChange, fieldPrefix } = props
+    const properties: Record<string, JSONSchemaSimpleType> =
+        schema.properties ?? ({} as any)
+
+    const handleFieldChange = (fieldName: string, value: any) => {
+        onChange((prev: any) => ({
+            ...prev,
+            [fieldName]: value,
+        }))
+    }
+
+    return (
+        <>
+            {Object.entries(properties).map(([fieldName, field]) => (
+                <vscode-form-group key={fieldPrefix + fieldName}>
+                    <vscode-label>
+                        {underscore(
+                            (fieldPrefix ? `${fieldPrefix} / ` : fieldPrefix) +
+                                (field.title || fieldName)
+                        ).replaceAll(/[_\.]/g, " ")}
+                    </vscode-label>
+                    <JSONSchemaSimpleTypeFormField
+                        field={field}
+                        value={value[fieldPrefix + fieldName]}
+                        required={schema.required?.includes(fieldName)}
+                        onChange={(value) =>
+                            handleFieldChange(fieldPrefix + fieldName, value)
+                        }
+                    />
+                    {field?.description && (
+                        <vscode-form-helper>
+                            {field.description}
+                        </vscode-form-helper>
+                    )}
+                </vscode-form-group>
+            ))}
+        </>
+    )
+}


### PR DESCRIPTION
Introduce `uiSuggestions` to provide a list of suggestions for string types, enhancing user experience by populating dropdowns in the UI while allowing other values. Clean up unused code related to number and object forms.

<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- ✨ **Added `uiSuggestions` for string parameters**: Introduced a new property, `uiSuggestions`, to provide dropdown suggestions for `string` types in the UI while allowing custom values. 
- 🛠 **Schema Enhancements**: Updated the JSON schema to support `uiSuggestions` and ensured it is removed during strict schema conversion.
- 🧩 **Refactored UI Components**: 
  - Extracted and modularized JSON schema form components into a new `JSONSchema.tsx` file.
  - Simplified and optimized handling of `string`, `number`, and `boolean` types with reusable components.
  - Added support for `uiSuggestions` and `enum` in dropdowns.
- 🚀 **Improved UI Flexibility**: Enhanced the UI form rendering logic to dynamically handle different JSON schema field types, including text fields, text areas, dropdowns, and checkboxes.
- 🔥 **Code Cleanup**: Removed unused code, including redundant `JSONSchemaNumber` and `JSONSchemaSimpleTypeFormField` implementations in `App.tsx`.

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

