### PR TITLE
:sparkles: Improve commit message editing workflow

### DIFF
--- a/packages/sample/genaisrc/samples/gcm.genai.mts
+++ b/packages/sample/genaisrc/samples/gcm.genai.mts
@@ -148,10 +148,9 @@ do {
 
     // Handle user's choice for commit message
     if (choice === "edit") {
-        message = await host.input("Edit commit message", {
-            required: true,
-        })
-        choice = "commit"
+        await host.exec("git", ["commit", "-m", message, "--edit"])
+        cancel("user decided to edit the commit message in the editor")
+        process.exit(0)
     }
     // If user chooses to commit, execute the git commit and optionally push changes
     if (choice === "commit" && message) {


### PR DESCRIPTION
Refactor commit message editing to use Git's editor directly

The console-based editing experience is not great; and opened the default git editor leads to a better experience.