### PR TITLE
Add refresh command and improve API key handling

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -779,7 +779,7 @@ window.vscodeWebviewPlaygroundNonce = ${JSON.stringify(nonce)};
         } else socket.destroy()
     })
     // Start the HTTP server on the specified port.
-    const serverhash = apiKey ? `?api-key:${encodeURIComponent(apiKey)}` : ""
+    const serverhash = apiKey ? `#api-key:${encodeURIComponent(apiKey)}` : ""
     httpServer.listen(port, serverHost, () => {
         console.log(`GenAIScript server v${CORE_VERSION}`)
         console.log(`┃ Local http://${serverHost}:${port}/${serverhash}`)

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -436,6 +436,12 @@
                 "icon": "$(repo-forked)"
             },
             {
+                "command": "genaiscript.refresh",
+                "title": "Refresh Type Definition files",
+                "category": "GenAIScript",
+                "icon": "$(refresh)"
+            },
+            {
                 "command": "genaiscript.request.open",
                 "title": "Open request or response",
                 "category": "GenAIScript"

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -48,6 +48,10 @@ export async function activate(context: ExtensionContext) {
         registerCommand("genaiscript.server.show", async () => {
             await state.host.server.show()
         }),
+        registerCommand("genaiscript.refresh", async () => {
+            await state.parseWorkspace()
+            await state.fixPromptDefinitions()
+        }),
         registerCommand("genaiscript.request.abort", async () => {
             await state.cancelAiRequest()
             await vscode.window.showInformationMessage(

--- a/packages/vscode/src/state.ts
+++ b/packages/vscode/src/state.ts
@@ -401,7 +401,7 @@ export class ExtensionState extends EventTarget {
         )
         const githubCopilotPrompt = !!config.get("githubCopilotPrompt")
         if (githubCopilotChat && githubCopilotPrompt)
-            fixCustomPrompts({ githubCopilotPrompt: true }) // finish async
+            await fixCustomPrompts({ githubCopilotPrompt: true }) // finish async
     }
 
     async parseWorkspace() {


### PR DESCRIPTION
Introduce a `refresh` command to GenAIScript for updating type definition files and enhance API key handling by changing the delimiter from `?` to `#`.