### PR TITLE
✨ feat: add system font handling for PDF parsing on Windows

### DIFF
--- a/packages/core/src/pdf.ts
+++ b/packages/core/src/pdf.ts
@@ -175,6 +175,7 @@ async function PDFTryParse(
         renderAsImage,
         scale = PDF_SCALE,
         cache,
+        useSystemFonts,
     } = options || {}
 
     const folder = await computeHashFolder(fileOrUrl, {
@@ -213,9 +214,11 @@ async function PDFTryParse(
         checkCancelled(cancellationToken)
         const { getDocument } = pdfjs
         const data = content || (await host.readFile(fileOrUrl))
+        // Check if we're running on Windows
+        const isWindows = os.platform() === "win32"
         const loader = await getDocument({
             data,
-            useSystemFonts: true,
+            useSystemFonts: useSystemFonts ?? !isWindows,
             disableFontFace: true,
             standardFontDataUrl,
             CanvasFactory: createCanvas ? CanvasFactory : undefined,

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1810,6 +1810,10 @@ interface ParsePDFOptions {
      * Disable caching with cache: false
      */
     cache?: boolean
+    /**
+     * Force system fonts use
+     */
+    useSystemFonts?: boolean
 }
 
 interface HTMLToTextOptions {


### PR DESCRIPTION
Introduce `useSystemFonts` option to control PDF font rendering.