### PR TITLE
Multi env fix

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -141,7 +141,7 @@ Update the `.env` file with the configuration information (see below).
 
 The `.env` file should never be commited to your source control!
 If the `.gitignore` file is properly configured,
-the `.env` file will appear grayed out in Visual Studio Code.
+the `.env`, `.env.genaiscript` file will appear grayed out in Visual Studio Code.
 
 ```txt title=".gitignore" ".env"
 ...
@@ -153,6 +153,11 @@ the `.env` file will appear grayed out in Visual Studio Code.
 ### Custom .env file location
 
 You can specify a custom `.env` file location through the CLI or an environment variable.
+
+- GenAIScript script loads the following `.env` files in order by default:
+  - `~/.env.genaiscript`
+  - `./.env.genaiscript`
+  - `./.env`
 
 - by adding the `--env <file>` argument to the CLI.
 

--- a/docs/src/content/docs/reference/configuration-files.mdx
+++ b/docs/src/content/docs/reference/configuration-files.mdx
@@ -10,13 +10,17 @@ import schema from "../../../../public/schemas/config.json?raw"
 
 GenAIScript supports local and global configuration files to allow reusing common configuration settings and secrets across multiple scripts.
 
-```json title="genaiscript.config.json"
-{
-    "$schema": "https://microsoft.github.io/genaiscript/schemas/config.json"
-}
-```
+## .env file resolution
 
-## File resolution
+GenAIScript will scan and load the following `.env` files in the following order:
+
+- `~/.env.genaiscript`
+- `~/.env.genaiscript`
+- `./.env`
+
+The list of `.env` files can be overriden by the `--env` command line option or the `envFile` property in the configuration file.
+
+## config file resolution
 
 GenAIScript will scan for the following configuration files
 and merge their content into the final configuration.
@@ -36,7 +40,7 @@ The configuration schema is at https://microsoft.github.io/genaiscript/schemas/c
 
 ## `envFile` property
 
-The final location of `envFile` will be used to load the secret in the environment variables.
+The final location of `envFile` will be used to load the secret in the environment variables. It supports a single
 
 ## `include` property
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -88,7 +88,8 @@ export async function cli() {
     }
 
     program.hook("preAction", async (cmd) => {
-        nodeHost = await NodeHost.install(cmd.opts().env) // Install NodeHost with environment options
+        const { env } = cmd.opts() // Get environment options from command
+        nodeHost = await NodeHost.install(env?.length ? env : undefined) // Install NodeHost with environment options
     })
 
     // Configure CLI program options and commands

--- a/packages/cli/src/nodehost.ts
+++ b/packages/cli/src/nodehost.ts
@@ -79,7 +79,7 @@ class NodeServerManager implements ServerManager {
 
 export class NodeHost extends EventTarget implements RuntimeHost {
     private pulledModels: string[] = []
-    readonly dotEnvPaths: string[]
+    readonly _dotEnvPaths: string[]
     project: Project
     userState: any = {}
     readonly path = createNodePath()
@@ -107,7 +107,7 @@ export class NodeHost extends EventTarget implements RuntimeHost {
 
     constructor(dotEnvPaths: string[]) {
         super()
-        this.dotEnvPaths = dotEnvPaths || []
+        this._dotEnvPaths = dotEnvPaths
         this.azureToken = createAzureTokenResolver(
             "Azure OpenAI",
             "AZURE_OPENAI_TOKEN_SCOPES",
@@ -207,7 +207,7 @@ export class NodeHost extends EventTarget implements RuntimeHost {
     }
 
     async readConfig(): Promise<HostConfiguration> {
-        const config = await resolveGlobalConfiguration(this.dotEnvPaths)
+        const config = await resolveGlobalConfiguration(this._dotEnvPaths)
         const { envFile, modelAliases } = config
         if (modelAliases)
             for (const kv of Object.entries(modelAliases))

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -8,7 +8,7 @@ import {
     MODEL_PROVIDERS,
     TOOL_ID,
 } from "./constants"
-import { resolve } from "path"
+import { join, resolve } from "path"
 import { validateJSONWithSchema } from "./schema"
 import { HostConfiguration } from "./hostconfiguration"
 import { structuralMerge } from "./merge"
@@ -83,11 +83,17 @@ export async function resolveGlobalConfiguration(
     // import for env var
     if (process.env.GENAISCRIPT_ENV_FILE)
         config.envFile = process.env.GENAISCRIPT_ENV_FILE
-
     // override with CLI command
-    if (dotEnvPaths) config.envFile = dotEnvPaths
+    if (dotEnvPaths?.length) config.envFile = dotEnvPaths
+
+    // nothing loaded, use defaults
     if (!config.envFile?.length)
-        config.envFile = [DOT_ENV_FILENAME, DOT_ENV_GENAISCRIPT_FILENAME]
+        config.envFile = [
+            join(homedir(), DOT_ENV_GENAISCRIPT_FILENAME),
+            DOT_ENV_GENAISCRIPT_FILENAME,
+            DOT_ENV_FILENAME,
+        ]
+    // resolve all paths
     config.envFile = arrayify(config.envFile).map((f) => resolve(f))
     return config
 }


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- 🛠️ **Enhanced `.env` file handling**:  
  - Added support for loading `.env` files in a prioritized order:  
    1. `~/.env.genaiscript`  
    2. `./.env.genaiscript`  
    3. `./.env`  
  - Updated documentation to reflect the new `.env` resolution logic.  
  - Introduced the ability to override `.env` file locations via the CLI (`--env`) or the `envFile` property in configuration files.

- 📚 **Documentation updates**:  
  - Clarified `.env` file behavior and added details about the new resolution order.  
  - Improved descriptions of configuration options, such as `envFile` and its role in loading secrets.

- 🧹 **Refactored environment variable handling**:  
  - Renamed internal variables for clarity (e.g., `dotEnvPaths` → `_dotEnvPaths`).  
  - Improved fallback logic for default `.env` file paths when none are explicitly specified.  
  - Ensured all `.env` paths are resolved to absolute paths for consistency.

- ⚙️ **CLI improvements**:  
  - Adjusted CLI behavior to handle empty or undefined `.env` options gracefully.  
  - Streamlined the `NodeHost` installation process to better integrate with the new `.env` handling logic.

- 🔗 **Configuration merging**:  
  - Ensured `.env` file paths are properly merged into the final configuration using the updated resolution logic.  

These changes improve flexibility, clarity, and reliability in handling `.env` files for both local and global configurations. 🚀

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

