### PR TITLE
cdp connection support

### DIFF
--- a/docs/src/content/docs/reference/scripts/browser.md
+++ b/docs/src/content/docs/reference/scripts/browser.md
@@ -90,6 +90,14 @@ const videoPath = await page.video().path()
 
 The video file can be further processed using video tools.
 
+### `connectOverCDP`
+
+You can provide an enpoint that uses the [Chrome DevTools Protocol](https://playwright.dev/docs/api/class-browsertype#browser-type-connect-over-cdp) using the `connectOverCDP`.
+
+```js
+const page = await host.browse(url, { connectOverCDP: "endpointurl" })
+```
+
 ## Locators
 
 You can select elements on the page using the `page.get...` or `page.locator` method.

--- a/packages/cli/src/playwright.ts
+++ b/packages/cli/src/playwright.ts
@@ -65,16 +65,28 @@ export class BrowserManager {
      * @param options Optional settings for the browser launch.
      * @returns A promise that resolves to a Browser instance.
      */
-    private async launchBrowser(options?: BrowserOptions): Promise<Browser> {
-        const { browser = PLAYWRIGHT_DEFAULT_BROWSER, ...rest } = options || {}
-        try {
+    private async launchBrowser(
+        options?: BrowseSessionOptions
+    ): Promise<Browser> {
+        const launch = async () => {
             const playwright = await this.init()
-            return await playwright[browser].launch(rest)
+            const engine = playwright[browser]
+            if (connectOverCDP)
+                return await engine.connectOverCDP(connectOverCDP)
+            return await engine.launch(rest)
+        }
+
+        const {
+            browser = PLAYWRIGHT_DEFAULT_BROWSER,
+            connectOverCDP,
+            ...rest
+        } = options || {}
+        try {
+            return await launch()
         } catch {
             logVerbose("trying to install playwright...")
             await this.installDependencies(browser)
-            const playwright = await this.init()
-            return await playwright[browser].launch(rest)
+            return await launch()
         }
     }
 
@@ -140,6 +152,7 @@ export class BrowserManager {
             recordVideo,
             waitUntil,
             referer,
+            connectOverCDP,
             ...rest
         } = options || {}
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -4092,6 +4092,11 @@ interface BrowseSessionOptions
               width: number
               height: number
           }
+
+    /**
+     * CDP connection string
+     */
+    connectOverCDP?: string
 }
 
 interface TimeoutOptions {


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- ✨ **Added support for CDP (Chrome DevTools Protocol) connections**: Introduced a new `connectOverCDP` option in `BrowseSessionOptions` to enable connecting to browsers via CDP.
- 🔄 **Refactored `launchBrowser` logic**: Centralized the browser initialization and launch process into a reusable `launch` function, supporting both CDP connections and standard browser launches.
- 🛠️ **Improved error handling during browser launch**: Ensured fallback to dependency installation and retry logic applies to both CDP connections and regular launches.
- 📄 **Updated TypeScript definitions**: Extended the `BrowseSessionOptions` interface with the new `connectOverCDP` property.

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

