### PR TITLE
Refresh dependencies to latest versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/ghcr.io/devcontainers/features/github-cli:1.0.13": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/devcontainers/features/azure-cli:1.2.5": {},
+        "ghcr.io/devcontainers/features/azure-cli:1.2.6": {},
         "ghcr.io/devcontainers/features/python:1.7.0": {},
         "ghcr.io/devcontainers-extra/features/ffmpeg-apt-get:1.0.16": {}
     }

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1615,8 +1615,8 @@ Apache License
 
 The following npm packages may be included in this product:
 
- - playwright-core@1.51.0
- - playwright@1.51.0
+ - playwright-core@1.51.1
+ - playwright@1.51.1
 
 These packages each contain the following license:
 
@@ -2955,7 +2955,7 @@ MIT License
 
 The following npm package may be included in this product:
 
- - genaiscript-vscode@1.116.2
+ - genaiscript-vscode@1.117.0
 
 This package contains the following license:
 
@@ -8918,10 +8918,10 @@ The following npm packages may be included in this product:
  - @tokenizer/token@0.3.0
  - agent-base@6.0.2
  - eastasianwidth@0.2.0
- - genaiscript-core-internal@1.116.2
- - genaiscript-sample@1.116.2
- - genaiscript-web@1.116.2
- - genaiscript@1.116.2
+ - genaiscript-core-internal@1.117.0
+ - genaiscript-sample@1.117.0
+ - genaiscript-web@1.117.0
+ - genaiscript@1.117.0
  - https-proxy-agent@5.0.1
  - isarray@1.0.0
  - javascript-natural-sort@0.7.1

--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -166,7 +166,7 @@ Options:
   -td, --test-delay <string>          delay between tests in seconds
   --cache                             enable LLM result cache
   -v, --verbose                       verbose output
-  -pv, --promptfoo-version [version]  promptfoo version, default is 0.106.3
+  -pv, --promptfoo-version [version]  promptfoo version, default is 0.107.1
   -os, --out-summary <file>           append output summary in file
   -g, --groups <groups...>            groups to include or exclude. Use :!
                                       prefix to exclude

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         }
     },
     "devDependencies": {
-        "@inquirer/prompts": "^7.3.3",
+        "@inquirer/prompts": "^7.4.0",
         "glob": "^11.0.1",
         "npm-check-updates": "^17.1.15",
         "npm-run-all": "^4.1.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@azure/identity": "^4.8.0",
     "@azure/search-documents": "^12.1.0",
-    "@inquirer/prompts": "^7.3.3",
+    "@inquirer/prompts": "^7.4.0",
     "@modelcontextprotocol/sdk": "^1.7.0",
     "@octokit/plugin-paginate-rest": "^11.4.3",
     "@octokit/plugin-retry": "^7.1.4",
@@ -88,7 +88,7 @@
     "@huggingface/transformers": "^3.4.0",
     "@lvce-editor/ripgrep": "^1.6.0",
     "pdfjs-dist": "4.10.38",
-    "playwright": "^1.51.0",
+    "playwright": "^1.51.1",
     "skia-canvas": "^2.0.2",
     "tree-sitter-wasms": "^0.1.11",
     "web-tree-sitter": "0.22.2"
@@ -97,7 +97,7 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "promptfoo": "0.106.3"
+    "promptfoo": "0.107.1"
   },
   "devDependencies": {
     "@types/diff": "^6.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,7 +77,7 @@
     "minimatch": "^10.0.1",
     "minisearch": "^7.1.2",
     "mustache": "^4.2.0",
-    "nanoid": "^5.1.3",
+    "nanoid": "^5.1.4",
     "object-inspect": "^1.13.4",
     "openai": "^4.87.3",
     "p-limit": "^6.2.0",

--- a/packages/sample/genaisrc/browse.genai.mjs
+++ b/packages/sample/genaisrc/browse.genai.mjs
@@ -17,11 +17,16 @@ const page2 = await host.browse(
     }
 )
 
-const page3 = await host.browse(
-    "https://microsoft.github.io/genaiscript/reference/scripts/browser/",
-    {
-        headless: false,
-    }
+await runPrompt(
+    async (_) => {
+        const page3 = await host.browse(
+            "https://microsoft.github.io/genaiscript/reference/scripts/browser/",
+            {
+                headless: false,
+            }
+        )
+    },
+    { model: "echo" }
 )
 
 await delay(5000)

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -488,7 +488,7 @@
     "devDependencies": {
         "@types/markdown-it": "^14.1.2",
         "@types/vscode": "^1.98.0",
-        "@vscode/vsce": "^3.2.2",
+        "@vscode/vsce": "^3.3.0",
         "assert": "^2.1.0",
         "es-toolkit": "^1.33.0",
         "markdown-it-github-alerts": "0.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,7 +22,7 @@
     "esbuild": "^0.25.1",
     "html-escaper": "3.0.3",
     "mermaid": "^11.5.0",
-    "nanoid": "^5.1.3",
+    "nanoid": "^5.1.4",
     "pretty-bytes": "^6.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/slides/yarn.lock
+++ b/slides/yarn.lock
@@ -2564,9 +2564,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.73:
-  version "1.5.119"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.119.tgz#4e105e419209b33e1c44b4d1b5fc6fb27fac0209"
-  integrity sha512-Ku4NMzUjz3e3Vweh7PhApPrZSS4fyiCIbcIrG9eKrriYVLmbMepETR/v6SU7xPm98QTqMSYiCwfO89QNjXLkbQ==
+  version "1.5.120"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.120.tgz#ccfdd28e9795fb8c2221cefa2c9a071501c86247"
+  integrity sha512-oTUp3gfX1gZI+xfD2djr2rzQdHCwHzPQrrK0CD7WpTdF0nPdQ/INcRVjWgLdCT4a9W3jFObR9DAfsuyFQnI8CQ==
 
 emoji-regex-xs@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,7 +1258,7 @@
     "@inquirer/type" "^3.0.5"
     ansi-escapes "^4.3.2"
 
-"@inquirer/prompts@^7.3.3":
+"@inquirer/prompts@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-7.4.0.tgz#bd9be38372be8db75afb04776eb0cf096ae9814b"
   integrity sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==
@@ -3427,7 +3427,7 @@
     "@vscode/vsce-sign-win32-arm64" "2.0.2"
     "@vscode/vsce-sign-win32-x64" "2.0.2"
 
-"@vscode/vsce@^3.2.2":
+"@vscode/vsce@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-3.3.0.tgz#803e41368a95d35693ce049076503f34f89fde09"
   integrity sha512-HA/pUyvh/TQWkc4wG7AudPIWUvsR8i4jiWZZgM/a69ncPi9Nm5FDogf/wVEk4EWJs4/UdxU7J6X18dfAwfPbxA==
@@ -7980,7 +7980,7 @@ nanoid@^3.3.8:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.10.tgz#7bc882237698ef787d5cbba109e3b0168ba6e7b1"
   integrity sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==
 
-nanoid@^5.1.3:
+nanoid@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.4.tgz#10b15a91d2f727b1f200faf0ff73656fd96c497d"
   integrity sha512-GTFcMIDgR7tqji/LpSY8rtg464VnJl/j6ypoehYnuGb+Y8qZUdtKB8WVCXon0UEZgFDbuUxpIl//6FHLHgXSNA==
@@ -8695,17 +8695,17 @@ platform@^1.3.6:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-playwright-core@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.51.0.tgz#bb23ea6bb6298242d088ae5e966ffcf8dc9827e8"
-  integrity sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==
+playwright-core@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.51.1.tgz#d57f0393e02416f32a47cf82b27533656a8acce1"
+  integrity sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==
 
-playwright@^1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.51.0.tgz#9ba154497ba62bc6dc199c58ee19295eb35a4707"
-  integrity sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==
+playwright@^1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.51.1.tgz#ae1467ee318083968ad28d6990db59f47a55390f"
+  integrity sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==
   dependencies:
-    playwright-core "1.51.0"
+    playwright-core "1.51.1"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -10569,9 +10569,9 @@ unist-util-visit@^5.0.0:
     unist-util-visit-parents "^6.0.0"
 
 universal-github-app-jwt@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/universal-github-app-jwt/-/universal-github-app-jwt-2.2.0.tgz#dc6c8929e76f1996a766ba2a08fb420f73365d77"
-  integrity sha512-G5o6f95b5BggDGuUfKDApKaCgNYy2x7OdHY0zSMF081O0EJobw+1130VONhrA7ezGSV2FNOGyM+KQpQZAr9bIQ==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/universal-github-app-jwt/-/universal-github-app-jwt-2.2.1.tgz#8f6ca9b9fa8fbca831cf25826a46e9193917ed3f"
+  integrity sha512-O4z+c9zZM4eNZMAx1lanAzaj2bvyJW5kC5PZ/H25D86sd2WujACASCOEZEQXUpZm8H+y7CGhCaB0aPP2kPAtkg==
 
 universal-user-agent@^7.0.0, universal-user-agent@^7.0.2:
   version "7.0.2"


### PR DESCRIPTION
Update various npm packages to their latest versions, ensuring compatibility and access to new features and fixes.

<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- 🔄 **CLI Updates**: 
  - Updated the default `promptfoo` version in CLI options from `0.106.3` to `0.107.1`.
  - Minor enhancements to CLI dependencies, including `@inquirer/prompts` and `playwright`.

- 🛠️ **Dependency Upgrades**:
  - Bumped versions for several dependencies across packages (`nanoid`, `@vscode/vsce`, etc.) to ensure compatibility and improved functionality.

- 🌐 **Core Enhancements**:
  - Updated a sample script (`browse.genai.mjs`) to include a new `runPrompt` function call with a model configuration.

- 📦 **Package Maintenance**:
  - Adjusted peer dependencies and dev dependencies to align with the latest updates for `promptfoo` and other tools.

These changes collectively improve the stability, compatibility, and functionality of the project. 🚀

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

