### PR TITLE
Azure openai models

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -463,6 +463,11 @@ script({
 
 ### Listing models
 
+There are two ways to list the models in your Azure OpenAI resource: use the Azure Management APIs
+or by calling into a custom `/models` endpoint.
+
+### Using the management APIs (this is the common way)
+
 In order to allow GenAIScript to list deployments in your Azure OpenAI service,
 you need to provide the Subscription ID **and you need to use Microsoft Entra!**.
 
@@ -506,6 +511,17 @@ as the token does not have the proper scope to query the list of deployments.
 </ol>
 
 </Steps>
+
+#### Using the `/models` endpoint
+
+This approach assumes you have set a OpenAI comptaible `/models` enpoint in your subscription
+that returns the list of deployments in a format compatible with the OpenAI API.
+
+You can set the `AZURE_OPENAI_API_MODELS_TYPE` environment variable to point to `openai`.
+
+```txt title=".env"
+AZURE_OPENAI_API_MODELS_TYPE="openai"
+```
 
 ### Custom credentials
 

--- a/packages/cli/src/info.ts
+++ b/packages/cli/src/info.ts
@@ -129,6 +129,7 @@ export async function modelList(
         models: true,
         error: true,
         hide: true,
+        token: true,
     })
 
     if (options?.format === "json")

--- a/packages/cli/src/openaiapi.ts
+++ b/packages/cli/src/openaiapi.ts
@@ -127,7 +127,7 @@ export async function openaiApiModels(
     try {
         logVerbose(`models`)
         const providers = await resolveLanguageModelConfigurations(undefined, {
-            token: false,
+            token: true,
             error: true,
             models: true,
             cancellationToken,

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -212,11 +212,13 @@ export async function startServer(options: {
     const serverEnv = async () => {
         return deleteUndefinedValues({
             ok: true,
-            providers: await resolveLanguageModelConfigurations(undefined, {
-                token: false,
-                error: true,
-                models: true,
-            }),
+            providers: (
+                await resolveLanguageModelConfigurations(undefined, {
+                    token: true,
+                    error: true,
+                    models: true,
+                })
+            ).map(({ token, ...rest }) => rest),
             modelAliases: runtimeHost.modelAliases,
             remote: remote
                 ? {

--- a/packages/core/src/azureopenai.ts
+++ b/packages/core/src/azureopenai.ts
@@ -9,12 +9,22 @@ import {
     OpenAIChatCompletion,
     OpenAIEmbedder,
     OpenAIImageGeneration,
+    OpenAIListModels,
     OpenAISpeech,
     OpenAITranscribe,
 } from "./openai"
 import { runtimeHost } from "./host"
 
-const listModels: ListModelsFunction = async (cfg, options) => {
+const azureManagementOrOpenAIListModels: ListModelsFunction = async (
+    cfg,
+    options
+) => {
+    const modelsApi = process.env.AZURE_OPENAI_API_MODELS_TYPE
+    if (modelsApi === "openai") return await OpenAIListModels(cfg, options)
+    else return await azureManagementListModels(cfg, options)
+}
+
+const azureManagementListModels: ListModelsFunction = async (cfg, options) => {
     try {
         // Create a fetch instance to make HTTP requests
         const { base } = cfg
@@ -99,7 +109,7 @@ const listModels: ListModelsFunction = async (cfg, options) => {
 export const AzureOpenAIModel = Object.freeze<LanguageModel>({
     id: MODEL_PROVIDER_AZURE_OPENAI,
     completer: OpenAIChatCompletion,
-    listModels,
+    listModels: azureManagementOrOpenAIListModels,
     transcriber: OpenAITranscribe,
     speaker: OpenAISpeech,
     imageGenerator: OpenAIImageGeneration,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -17,13 +17,13 @@ import {
     LanguageModelInfo,
     ResolvedLanguageModelConfiguration,
 } from "./server/messages"
-import { parseTokenFromEnv } from "./connection"
 import { resolveLanguageModel } from "./lm"
 import { arrayify, deleteEmptyValues } from "./cleaners"
 import { errorMessage } from "./error"
 import schema from "../../../docs/public/schemas/config.json"
 import defaultConfig from "./config.json"
 import { CancellationOptions } from "./cancellation"
+import { host } from "./host"
 
 export async function resolveGlobalConfiguration(
     dotEnvPaths?: string[]
@@ -114,7 +114,6 @@ export async function resolveLanguageModelConfigurations(
 ): Promise<ResolvedLanguageModelConfiguration[]> {
     const { token, error, models, hide } = options || {}
     const res: ResolvedLanguageModelConfiguration[] = []
-    const env = process.env
 
     // Iterate through model providers, filtering if a specific provider is given
     for (const modelProvider of MODEL_PROVIDERS.filter(
@@ -124,7 +123,10 @@ export async function resolveLanguageModelConfigurations(
             // Attempt to parse connection token from environment variables
             const conn: LanguageModelConfiguration & {
                 models?: LanguageModelInfo[]
-            } = await parseTokenFromEnv(env, `${modelProvider.id}:*`)
+            } = await host.getLanguageModelConfiguration(
+                modelProvider.id + ":*",
+                options
+            )
             if (conn) {
                 // Mask the token if the option is set
                 let listError = ""

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -130,7 +130,7 @@ export async function resolveLanguageModelConfigurations(
             if (conn) {
                 // Mask the token if the option is set
                 let listError = ""
-                if (models) {
+                if (models && token) {
                     const lm = await resolveLanguageModel(modelProvider.id)
                     if (lm.listModels) {
                         const models = await lm.listModels(conn, options)

--- a/packages/core/src/openai.ts
+++ b/packages/core/src/openai.ts
@@ -522,7 +522,13 @@ export const OpenAIChatCompletion: ChatCompletionHandler = async (
 export const OpenAIListModels: ListModelsFunction = async (cfg, options) => {
     try {
         const fetch = await createFetch({ retries: 0, ...(options || {}) })
-        const res = await fetch(cfg.base + "/models", {
+        let url = trimTrailingSlash(cfg.base) + "/models"
+        if (cfg.provider === MODEL_PROVIDER_AZURE_OPENAI) {
+            url =
+                trimTrailingSlash(cfg.base).replace(/deployments$/, "") +
+                "/models"
+        }
+        const res = await fetch(url, {
             method: "GET",
             headers: {
                 ...getConfigHeaders(cfg),

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -260,18 +260,18 @@ type ModelType = OptionsOrString<
 >
 
 type EmbeddingsModelType = OptionsOrString<
-    "openai:text-embedding-3-small",
-    "openai:text-embedding-3-large",
-    "openai:text-embedding-ada-002",
-    "github:text-embedding-3-small",
-    "github:text-embedding-3-large",
-    "azure:text-embedding-3-small",
-    "azure:text-embedding-3-large",
-    "azure_ai_inference:text-embedding-3-small",
-    "azure_ai_inference:text-embedding-3-large",
-    "ollama:nomic-embed-text",
-    "google:text-embedding-004",
-    "huggingface:nomic-ai/nomic-embed-text-v1.5"
+    | "openai:text-embedding-3-small"
+    | "openai:text-embedding-3-large"
+    | "openai:text-embedding-ada-002"
+    | "github:text-embedding-3-small"
+    | "github:text-embedding-3-large"
+    | "azure:text-embedding-3-small"
+    | "azure:text-embedding-3-large"
+    | "azure_ai_inference:text-embedding-3-small"
+    | "azure_ai_inference:text-embedding-3-large"
+    | "ollama:nomic-embed-text"
+    | "google:text-embedding-004"
+    | "huggingface:nomic-ai/nomic-embed-text-v1.5"
 >
 
 type ModelSmallType = OptionsOrString<
@@ -439,14 +439,12 @@ interface ModelOptions extends ModelConnectionOptions, ModelTemplateOptions {
     modelConcurrency?: Record<string, number>
 }
 
-interface EmbeddingsModelConnectionOptions {
+interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {
     /**
      * LLM model to use for embeddings.
      */
     embeddingsModel?: EmbeddingsModelType
 }
-
-interface EmbeddingsModelOptions extends EmbeddingsModelConnectionOptions {}
 
 interface PromptSystemOptions {
     /**
@@ -3693,13 +3691,9 @@ interface ImageGenerationOptions {
     model?: OptionsOrString<ModelImageGenerationType>
     quality?: "hd"
     size?: OptionsOrString<
-        "256x256",
-        "512x512",
-        "1024x1024",
-        "1024x1792",
-        "1792x1024"
+        "256x256" | "512x512" | "1024x1024" | "1024x1792" | "1792x1024"
     >
-    style?: OptionsOrString<"vivid", "natural">
+    style?: OptionsOrString<"vivid" | "natural">
 }
 
 interface TranscriptionOptions {
@@ -3769,15 +3763,15 @@ interface TranscriptionResult {
 type SpeechModelType = OptionsOrString<"openai:tts-1-hd" | "openai:tts-1">
 
 type SpeechVoiceType = OptionsOrString<
-    "alloy",
-    "ash",
-    "coral",
-    "echo",
-    "fable",
-    "onyx",
-    "nova",
-    "sage",
-    "shimmer"
+    | "alloy"
+    | "ash"
+    | "coral"
+    | "echo"
+    | "fable"
+    | "onyx"
+    | "nova"
+    | "sage"
+    | "shimmer"
 >
 
 interface SpeechOptions {


### PR DESCRIPTION
Support for custom /models endpoint with azure openai

<!-- genaiscript begin prd --><hr/>

## Summary of Changes

### Documentation Updates 📚
- Added instructions for listing models in Azure OpenAI resources using two methods:
  - **Azure Management APIs** (common method).
  - **Custom `/models` endpoint** compatible with the OpenAI API.
- Introduced a new environment variable `AZURE_OPENAI_API_MODELS_TYPE` to configure the `/models` endpoint usage.

### CLI Enhancements 🛠️
- Updated the `modelList` function to include `token` in the options.
- Adjusted the `openaiApiModels` function to enable token usage for listing models.
- Modified the server's `providers` resolution to exclude tokens from the output while still using them internally.

### Core Functionality Improvements ⚙️
- Refactored model listing logic to support both Azure Management APIs and OpenAI-compatible `/models` endpoints:
  - Introduced a new function `azureManagementOrOpenAIListModels` to dynamically choose between the two approaches.
- Updated the `resolveLanguageModelConfigurations` function to retrieve model configurations via the runtime host instead of direct environment variable parsing.
- Enhanced the `OpenAIListModels` function to handle `/models` endpoint URLs for both Azure and OpenAI setups.

### Miscellaneous 🌟
- Improved error handling and configuration parsing for listing models.
- Ensured environment variable-driven flexibility for model listing methods.

These changes introduce greater flexibility in listing models for Azure OpenAI resources, improving compatibility and configurability for various deployment scenarios. 🚀

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

