### PR TITLE
Support 'accept' option for file extensions

### DIFF
--- a/docs/src/content/docs/reference/scripts/parameters.mdx
+++ b/docs/src/content/docs/reference/scripts/parameters.mdx
@@ -119,6 +119,24 @@ Some additional, non-standard properties are used to provide additional informat
 }
 ```
 
+## `accept`
+
+You can specify the comma-separated list of supported file extensions for the `env.files` variables.
+
+```js
+script({
+    accept: ".md,.txt",
+})
+```
+
+If remove all files support, set `accept` to `none`.
+
+```js
+script({
+    accept: "none",
+})
+```
+
 ## Scripts and system Scripts
 
 The `parameters` of a `script` entry is used to populate the `env.vars` entries. The parameters schema

--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -47,23 +47,26 @@ export async function startMcpServer(
     server.setRequestHandler(ListToolsRequestSchema, async (req) => {
         const scripts = await watcher.scripts()
         const tools = scripts.map((script) => {
-            const { id, title, description, inputSchema } = script
+            const { id, title, description, inputSchema, accept } = script
             return {
                 name: id,
                 description: toStringList(title, description),
                 inputSchema: {
                     type: "object",
-                    properties: {
-                        files: {
-                            type: "array",
-                            items: {
-                                type: "string",
-                                description:
-                                    "File paths to be passed to the script",
-                            },
-                        },
-                        ...(inputSchema.properties || {}),
-                    },
+                    properties:
+                        accept !== "none"
+                            ? {
+                                  files: {
+                                      type: "array",
+                                      items: {
+                                          type: "string",
+                                          description:
+                                              "File paths to be passed to the script",
+                                      },
+                                  },
+                                  ...(inputSchema.properties || {}),
+                              }
+                            : inputSchema.properties,
                     required: inputSchema.required || [],
                 },
             }

--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -61,9 +61,9 @@ export async function expandFiles(
         applyGitIgnore?: boolean
     }
 ) {
-    if (!files.length) return []
-
     const { excludedFiles = [], accept, applyGitIgnore } = options || {}
+    if (!files.length || accept === "none") return []
+
     const urls = files
         .filter((f) => HTTPS_REGEX.test(f))
         .filter((f) => !excludedFiles.includes(f))

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -743,7 +743,7 @@ interface PromptScript
     /**
      * A comma separated list of file extensions to accept.
      */
-    accept?: string
+    accept?: OptionsOrString<".md,.mdx" | "none">
 
     /**
      * Extra variable values that can be used to configure system prompts.

--- a/packages/sample/genaisrc/plaintext.genai.mjs
+++ b/packages/sample/genaisrc/plaintext.genai.mjs
@@ -1,4 +1,5 @@
 script({
+    accept: "none",
     model: "small",
     system: ["system", "system.output_plaintext"],
     tests: {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1371,8 +1371,16 @@ function acceptToAccept(accept: string | undefined) {
     return res
 }
 
-function FilesDropZone() {
+function FilesFormInput() {
     const script = useScript()
+    const { accept } = script || {}
+    if (!script || accept === "none") return null
+
+    return <FilesDropZone script={script} />
+}
+
+function FilesDropZone(props: { script: PromptScript }) {
+    const { script } = props
     const { accept } = script || {}
     const { acceptedFiles, isDragActive, getRootProps, getInputProps } =
         useDropzone({ multiple: true, accept: acceptToAccept(accept) })
@@ -1506,7 +1514,7 @@ function ScriptForm() {
         <vscode-collapsible open title="Script">
             <RefreshButton />
             <ScriptSelect />
-            <FilesDropZone />
+            <FilesFormInput />
             <PromptParametersFields />
             <RunScriptButton />
         </vscode-collapsible>


### PR DESCRIPTION
Introduce the ability to specify supported file extensions for scripts, including a mechanism to disable file support by setting `accept` to `none`. Update related components to handle this new option effectively.

<!-- genaiscript begin prd --><hr/>

## Summary of Changes

### ✨ New Features
- Introduced an `accept` parameter in scripts to specify supported file extensions for `env.files` variables.  
  - Example: `accept: ".md,.txt"` to allow specific extensions.  
  - Added support for disabling file uploads entirely by setting `accept: "none"`.  

### 🛠️ Backend Enhancements
- Updated the `startMcpServer` logic to respect the `accept` parameter:
  - If `accept` is `"none"`, the `files` property is excluded from the input schema.
- Modified `expandFiles` function to skip processing files if `accept` is `"none"`.

### 🖥️ Frontend Updates
- Added a conditional rendering mechanism in the UI:
  - If `accept` is `"none"`, the file input (`FilesDropZone`) is not displayed.
  - Introduced a new `FilesFormInput` component to manage this logic.

### 📜 Type Improvements
- Enhanced the `accept` property type definition in `PromptScript` to support predefined values like `".md,.mdx"` or `"none"`.

### 🔧 Sample Configuration
- Updated the `plaintext.genai.mjs` sample script to demonstrate the use of `accept: "none"`.

These changes provide greater flexibility and control over file handling in scripts, including the ability to restrict or disable file uploads. 🚀

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

