### PR TITLE
support for mjs test definitions

### DIFF
--- a/docs/src/content/docs/reference/scripts/tests.mdx
+++ b/docs/src/content/docs/reference/scripts/tests.mdx
@@ -46,12 +46,13 @@ This setting can be overriden by the command line `--models` option.
 
 ### External test files
 
-You can also specify the filename of external test files, in JSON, YAML or CSV formats.
+You can also specify the filename of external test files, in JSON, YAML, CSV formats
+as well as `.mjs`, `.mts` JavaScript files will be executed to generate the tests.
 
 ```js title="proofreader.genai.js" wrap "tests"
 script({
   ...,
-  tests: ["tests.json", "more-tests.csv"],
+  tests: ["tests.json", "more-tests.csv", "tests.mjs"],
 })
 ```
 
@@ -64,6 +65,18 @@ The `file` column should be a filename, the `fileContent` column is the content 
 ```csv title="tests.csv"
 content,rubrics,facts
 "const x = 1;",is a report with a list of issues,The report says that the input string should be validated before use.
+```
+
+The JavaScript files should export a list of `PromptTest` objects or a function that generates the list of `PromptTest` objects.
+
+```js title="tests.mjs"
+export default [
+    {
+        content: "const x = 1;",
+        rubrics: "is a report with a list of issues",
+        facts: "The report says that the input string should be validated before use.",
+    },
+]
 ```
 
 ### `files`

--- a/packages/cli/src/cache.ts
+++ b/packages/cli/src/cache.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path"
-import { dotGenaiscriptPath } from "../../core/src/util"
+import { dotGenaiscriptPath } from "../../core/src/workdir"
 import { emptyDir } from "fs-extra"
 
 /**

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -11,12 +11,7 @@ import {
 import { filePathOrUrlToWorkspaceFile, tryReadText } from "../../core/src/fs"
 import { host } from "../../core/src/host"
 import { MarkdownTrace } from "../../core/src/trace"
-import {
-    dotGenaiscriptPath,
-    logError,
-    logInfo,
-    logVerbose,
-} from "../../core/src/util"
+import { logError, logInfo, logVerbose } from "../../core/src/util"
 import { buildProject } from "./build"
 import { run } from "./api"
 import { writeText } from "../../core/src/fs"
@@ -25,26 +20,16 @@ import { PLimitPromiseQueue } from "../../core/src/concurrency"
 import { createPatch } from "diff"
 import { unfence } from "../../core/src/unwrappers"
 import { applyModelOptions } from "../../core/src/modelalias"
-import { ensureDotGenaiscriptPath, setupTraceWriting } from "./trace"
+import { setupTraceWriting } from "./trace"
 import { tracePromptResult } from "../../core/src/chat"
 import { dirname, join } from "node:path"
 import { link } from "../../core/src/mkmd"
-import { hash, randomHex } from "../../core/src/crypto"
+import { hash } from "../../core/src/crypto"
 import { createCancellationController } from "./cancel"
 import { toSignal } from "../../core/src/cancellation"
 import { normalizeInt } from "../../core/src/cleaners"
 import { YAMLStringify } from "../../core/src/yaml"
-
-function getConvertDir(scriptId: string) {
-    const runId =
-        new Date().toISOString().replace(/[:.]/g, "-") + "-" + randomHex(6)
-    const out = dotGenaiscriptPath(
-        CONVERTS_DIR_NAME,
-        host.path.basename(scriptId).replace(GENAI_ANYTS_REGEX, ""),
-        runId
-    )
-    return out
-}
+import { ensureDotGenaiscriptPath, getConvertDir } from "../../core/src/workdir"
 
 export async function convertFiles(
     scriptId: string,

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -10,13 +10,8 @@ import {
 import { hash, randomHex } from "../../core/src/crypto"
 import { errorMessage } from "../../core/src/error"
 import { host } from "../../core/src/host"
-import { MarkdownTrace, TraceOptions } from "../../core/src/trace"
-import {
-    logError,
-    dotGenaiscriptPath,
-    logVerbose,
-    arrayify,
-} from "../../core/src/util"
+import { TraceOptions } from "../../core/src/trace"
+import { logError, logVerbose, arrayify } from "../../core/src/util"
 import { CORE_VERSION } from "../../core/src/version"
 import { isQuiet } from "./log"
 import Dockerode, { Container } from "dockerode"
@@ -24,6 +19,7 @@ import { shellParse, shellQuote } from "../../core/src/shell"
 import { PLimitPromiseQueue } from "../../core/src/concurrency"
 import { delay } from "es-toolkit"
 import { generateId } from "../../core/src/id"
+import { dotGenaiscriptPath } from "../../core/src/workdir"
 
 type DockerodeType = import("dockerode")
 

--- a/packages/cli/src/playwright.ts
+++ b/packages/cli/src/playwright.ts
@@ -10,8 +10,7 @@ import { runtimeHost } from "../../core/src/host"
 import { PLAYWRIGHT_VERSION } from "./version"
 import { ellipseUri } from "../../core/src/url"
 import { PLAYWRIGHT_DEFAULT_BROWSER } from "../../core/src/constants"
-import { ensureDir } from "fs-extra"
-import { getVideoDir } from "../../core/src/workdir"
+import { createVideoDir } from "../../core/src/workdir"
 
 /**
  * Manages browser instances using Playwright, including launching,
@@ -165,8 +164,7 @@ export class BrowserManager {
         if (incognito || recordVideo) {
             const options = { ...rest } as BrowserContextOptions
             if (recordVideo) {
-                const dir = getVideoDir()
-                await ensureDir(dir)
+                const dir = await createVideoDir()
                 trace?.itemValue(`video dir`, dir)
                 options.recordVideo = { dir }
                 if (typeof recordVideo === "object")

--- a/packages/cli/src/playwright.ts
+++ b/packages/cli/src/playwright.ts
@@ -5,12 +5,13 @@ import type {
     Page,
 } from "playwright"
 import { TraceOptions } from "../../core/src/trace"
-import { dotGenaiscriptPath, logError, logVerbose } from "../../core/src/util"
+import { logError, logVerbose } from "../../core/src/util"
 import { runtimeHost } from "../../core/src/host"
 import { PLAYWRIGHT_VERSION } from "./version"
 import { ellipseUri } from "../../core/src/url"
 import { PLAYWRIGHT_DEFAULT_BROWSER } from "../../core/src/constants"
 import { ensureDir } from "fs-extra"
+import { getVideoDir } from "../../core/src/workdir"
 
 /**
  * Manages browser instances using Playwright, including launching,
@@ -164,10 +165,7 @@ export class BrowserManager {
         if (incognito || recordVideo) {
             const options = { ...rest } as BrowserContextOptions
             if (recordVideo) {
-                const dir = dotGenaiscriptPath(
-                    "videos",
-                    `${new Date().toISOString().replace(/[:.]/g, "-")}`
-                )
+                const dir = getVideoDir()
                 await ensureDir(dir)
                 trace?.itemValue(`video dir`, dir)
                 options.recordVideo = { dir }

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -108,7 +108,7 @@ import { generateId } from "../../core/src/id"
 import {
     ensureDotGenaiscriptPath,
     getRunDir,
-    getStatsDir,
+    createStatsDir,
 } from "../../core/src/workdir"
 
 export async function runScriptWithExitCode(
@@ -758,8 +758,7 @@ async function aggregateResults(
     stats: GenerationStats,
     result: GenerationResult
 ) {
-    const statsDir = getStatsDir()
-    await ensureDir(statsDir)
+    const statsDir = await createStatsDir()
     const statsFile = host.path.join(statsDir, "runs.csv")
     if (!(await exists(statsFile)))
         await writeFile(

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -63,7 +63,6 @@ import {
 import {
     logVerbose,
     logError,
-    dotGenaiscriptPath,
     logInfo,
     logWarn,
     assert,
@@ -86,7 +85,7 @@ import { appendFile } from "node:fs/promises"
 import { parseOptionsVars } from "./vars"
 import { logprobColor } from "../../core/src/logprob"
 import { overrideStdoutWithStdErr, stderr, stdout } from "../../core/src/stdio"
-import { ensureDotGenaiscriptPath, setupTraceWriting } from "./trace"
+import { setupTraceWriting } from "./trace"
 import {
     applyModelOptions,
     applyScriptModelAliases,
@@ -106,16 +105,11 @@ import {
     wrapRgbColor,
 } from "../../core/src/consolecolor"
 import { generateId } from "../../core/src/id"
-
-function getRunDir(scriptId: string, runId: string) {
-    const name = new Date().toISOString().replace(/[:.]/g, "-") + "-" + runId
-    const out = dotGenaiscriptPath(
-        RUNS_DIR_NAME,
-        host.path.basename(scriptId).replace(GENAI_ANYTS_REGEX, ""),
-        name
-    )
-    return out
-}
+import {
+    ensureDotGenaiscriptPath,
+    getRunDir,
+    getStatsDir,
+} from "../../core/src/workdir"
 
 export async function runScriptWithExitCode(
     scriptId: string,
@@ -764,7 +758,7 @@ async function aggregateResults(
     stats: GenerationStats,
     result: GenerationResult
 ) {
-    const statsDir = dotGenaiscriptPath(STATS_DIR_NAME)
+    const statsDir = getStatsDir()
     await ensureDir(statsDir)
     const statsFile = host.path.join(statsDir, "runs.csv")
     if (!(await exists(statsFile)))

--- a/packages/cli/src/runs.ts
+++ b/packages/cli/src/runs.ts
@@ -1,8 +1,9 @@
 import { readdir } from "fs/promises"
 import { join } from "path"
 import { RUNS_DIR_NAME, SERVER_PORT } from "../../core/src/constants"
-import { dotGenaiscriptPath, groupBy } from "../../core/src/util"
+import { groupBy } from "../../core/src/util"
 import { runtimeHost } from "../../core/src/host"
+import { dotGenaiscriptPath } from "../../core/src/workdir"
 
 export async function collectRuns(options?: { scriptid?: string }) {
     const { scriptid } = options || {}

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -198,7 +198,7 @@ npx --yes genaiscript@${CORE_VERSION} test view
         const config = await generatePromptFooConfiguration(script, {
             out,
             cli,
-            models: models,
+            models,
             provider: "provider.mjs",
             chatInfo,
             embeddingsInfo,

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -6,7 +6,7 @@ import { buildProject } from "./build"
 import { readFile, writeFile, appendFile } from "node:fs/promises"
 import { execa } from "execa"
 import { dirname, join, resolve } from "node:path"
-import { emptyDir, ensureDir, exists } from "fs-extra"
+import { emptyDir, exists } from "fs-extra"
 import { PROMPTFOO_VERSION } from "./version"
 import {
     PROMPTFOO_CACHE_PATH,
@@ -18,19 +18,13 @@ import {
     EMOJI_FAIL,
     TEST_RUNS_DIR_NAME,
     PROMPTFOO_REMOTE_API_PORT,
-    PROMPTFOO_TEST_MAX_CONCURRENCY,
 } from "../../core/src/constants"
 import { promptFooDriver } from "../../core/src/default_prompts"
 import { serializeError } from "../../core/src/error"
 import { runtimeHost } from "../../core/src/host"
 import { JSON5TryParse } from "../../core/src/json5"
 import { MarkdownTrace } from "../../core/src/trace"
-import {
-    logInfo,
-    logVerbose,
-    toStringList,
-    dotGenaiscriptPath,
-} from "../../core/src/util"
+import { logInfo, logVerbose, toStringList } from "../../core/src/util"
 import { YAMLStringify } from "../../core/src/yaml"
 import {
     PromptScriptTestRunOptions,
@@ -56,6 +50,8 @@ import {
     objectToMarkdownTableRow,
 } from "../../core/src/csv"
 import { roundWithPrecision } from "../../core/src/precision"
+import { ensureDir } from "../../core/src/fs"
+import { dotGenaiscriptPath } from "../../core/src/workdir"
 
 /**
  * Parses model specifications from a string and returns a ModelOptions object.

--- a/packages/cli/src/trace.ts
+++ b/packages/cli/src/trace.ts
@@ -1,17 +1,12 @@
-import { ensureDir, exists } from "fs-extra"
+import { ensureDir } from "fs-extra"
 import { MarkdownTrace, TraceChunkEvent } from "../../core/src/trace"
-import { dotGenaiscriptPath, logVerbose } from "../../core/src/util"
-import { dirname, join } from "node:path"
+import { logVerbose } from "../../core/src/util"
+import { dirname } from "node:path"
 import { writeFileSync, WriteStream } from "node:fs"
-import {
-    GIT_IGNORE,
-    TRACE_CHUNK,
-    TRACE_DETAILS,
-} from "../../core/src/constants"
+import { TRACE_CHUNK, TRACE_DETAILS } from "../../core/src/constants"
 import { writeFile } from "node:fs/promises"
 import { measure } from "../../core/src/performance"
 import { createWriteStream } from "node:fs"
-import { gitIgnoreEnsure } from "../../core/src/gitignore"
 
 export async function setupTraceWriting(
     trace: MarkdownTrace,
@@ -59,10 +54,4 @@ export async function setupTraceWriting(
     })
 
     return filename
-}
-
-export async function ensureDotGenaiscriptPath() {
-    const dir = dotGenaiscriptPath(".")
-    await ensureDir(dir)
-    await gitIgnoreEnsure(dir, ["*"])
 }

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,10 +1,10 @@
 // Import necessary modules and types
 import { appendJSONL, JSONLTryParse, writeJSONL } from "./jsonl"
 import { host } from "./host"
-import { dotGenaiscriptPath } from "./util"
 import { CHANGE } from "./constants"
 import { tryReadText } from "./fs"
 import { hash } from "./crypto"
+import { dotGenaiscriptPath } from "./workdir"
 
 /**
  * Represents a cache entry with a hashed identifier (`sha`), `key`, and `val`.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -58,6 +58,7 @@ export const PDF_REGEX = /\.pdf$/i
 export const MD_REGEX = /\.md$/i
 export const MDX_REGEX = /\.mdx$/i
 export const MJS_REGEX = /\.mjs$/i
+export const MJTS_REGEX = /\.m(j|t)s$/i
 export const JS_REGEX = /\.js$/i
 export const JSON5_REGEX = /\.json5?$/i
 export const JSONL_REGEX = /\.jsonl$/i

--- a/packages/core/src/docx.ts
+++ b/packages/core/src/docx.ts
@@ -4,7 +4,7 @@ import { hash } from "./crypto"
 import { host } from "./host"
 import { HTMLToMarkdown } from "./html"
 import { TraceOptions } from "./trace"
-import { dotGenaiscriptPath, logVerbose } from "./util"
+import { logVerbose } from "./util"
 import { readFile, writeFile } from "node:fs/promises"
 import { YAMLStringify } from "./yaml"
 import { errorMessage, serializeError } from "./error"
@@ -12,6 +12,7 @@ import { resolveFileBytes } from "./file"
 import { filenameOrFileToFilename } from "./unwrappers"
 import { ensureDir } from "fs-extra"
 import { mark, measure } from "./performance"
+import { dotGenaiscriptPath } from "./workdir"
 
 async function computeHashFolder(
     filename: string,

--- a/packages/core/src/ffmpeg.ts
+++ b/packages/core/src/ffmpeg.ts
@@ -1,4 +1,4 @@
-import { arrayify, dotGenaiscriptPath, logVerbose } from "./util"
+import { logVerbose } from "./util"
 import { TraceOptions } from "./trace"
 import { lookupMime } from "./mime"
 import pLimit from "p-limit"
@@ -18,6 +18,8 @@ import { Stats } from "node:fs"
 import { roundWithPrecision } from "./precision"
 import { parseTimestamps } from "./transcription"
 import { mark } from "./performance"
+import { dotGenaiscriptPath } from "./workdir"
+import { arrayify } from "./cleaners"
 
 const ffmpegLimit = pLimit(1)
 const WILD_CARD = "%06d"
@@ -265,8 +267,7 @@ export class FFmepgClient implements Ffmpeg {
                 cmd.seekInput(start)
                 if (duration !== undefined) cmd.duration(duration)
                 if (end !== undefined) cmd.inputOptions(`-to ${end}`)
-                if (!options?.size)
-                    cmd.outputOptions("-c copy")
+                if (!options?.size) cmd.outputOptions("-c copy")
                 return `clip-${start}-${duration || end}.mp4`
             },
             {

--- a/packages/core/src/filecache.ts
+++ b/packages/core/src/filecache.ts
@@ -6,8 +6,9 @@ import { basename, dirname, join, relative } from "node:path"
 import { stat, writeFile } from "fs/promises"
 import { ensureDir } from "fs-extra"
 import { CancellationOptions, checkCancelled } from "./cancellation"
-import { dotGenaiscriptPath, logVerbose } from "./util"
+import { logVerbose } from "./util"
 import prettyBytes from "pretty-bytes"
+import { dotGenaiscriptPath } from "./workdir"
 
 export async function fileWriteCached(
     dir: string,

--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -29,6 +29,11 @@ export async function tryReadText(fn: string) {
     }
 }
 
+export async function ensureDir(dir: string) {
+    dbg(`ensuring directory exists ${dir}`)
+    await mkdir(dir, { recursive: true })
+}
+
 export async function writeText(fn: string, content: string) {
     dbg(`writing text to file ${fn}`)
     await mkdir(dirname(fn), { recursive: true })

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -12,13 +12,14 @@ import { resolveFileContents } from "./file"
 import { readText, tryReadText, tryStat } from "./fs"
 import { host, runtimeHost } from "./host"
 import { shellParse } from "./shell"
-import { arrayify, dotGenaiscriptPath, logVerbose } from "./util"
+import { arrayify, logVerbose } from "./util"
 import { approximateTokens, truncateTextToTokens } from "./tokens"
 import { resolveTokenEncoder } from "./encoders"
 import { underscore } from "inflection"
 import { rm, lstat } from "node:fs/promises"
 import { packageResolveInstall } from "./packagemanagers"
 import { normalizeInt } from "./cleaners"
+import { dotGenaiscriptPath } from "./workdir"
 
 async function checkDirectoryExists(directory: string): Promise<boolean> {
     const stat = await tryStat(directory)

--- a/packages/core/src/importprompt.ts
+++ b/packages/core/src/importprompt.ts
@@ -4,17 +4,15 @@ import { TraceOptions } from "./trace"
 import { pathToFileURL } from "url"
 import { mark } from "./performance"
 
-export async function importPrompt(
-    ctx0: PromptContext,
-    r: PromptScript,
+export async function importFile<T = void>(
+    filename: string,
     options?: {
+        onImported?: (module: any) => Awaitable<T>
         logCb?: (msg: string) => void
     } & TraceOptions
-) {
-    mark("prompt.import")
-    const { filename } = r
+): Promise<T> {
+    const { trace, onImported } = options || {}
     if (!filename) throw new Error("filename is required")
-    const { trace } = options || {}
 
     let unregister: () => void = undefined
     try {
@@ -38,17 +36,36 @@ export async function importPrompt(
             //tsconfig: false,
             onImport,
         })
-        const main = module.default
-        if (typeof main === "function") await main(ctx0)
-        else if (r.isSystem)
-            throw new Error(
-                "system prompt using esm JavaScript (mjs, mts) must have a default function."
-            )
+        const result = await onImported?.(module)
         unregister?.()
+
+        return result
     } catch (err) {
         unregister?.()
         logError(err)
         trace?.error(err)
         throw err
     }
+}
+
+export async function importPrompt(
+    ctx0: PromptContext,
+    r: PromptScript,
+    options?: {
+        logCb?: (msg: string) => void
+    } & TraceOptions
+) {
+    mark("prompt.import")
+    const { filename } = r
+    return await importFile(filename, {
+        ...(options || {}),
+        onImported: async (module) => {
+            const main = module.default
+            if (typeof main === "function") await main(ctx0)
+            else if (r.isSystem)
+                throw new Error(
+                    "system prompt using esm JavaScript (mjs, mts) must have a default function."
+                )
+        },
+    })
 }

--- a/packages/core/src/pdf.ts
+++ b/packages/core/src/pdf.ts
@@ -4,7 +4,7 @@ import { host } from "./host"
 import { TraceOptions } from "./trace"
 import os from "os"
 import { serializeError } from "./error"
-import { dotGenaiscriptPath, logVerbose, logWarn } from "./util"
+import { logVerbose, logWarn } from "./util"
 import { INVALID_FILENAME_REGEX, PDF_HASH_LENGTH, PDF_SCALE } from "./constants"
 import { resolveGlobal } from "./global"
 import { isUint8Array, isUint8ClampedArray } from "util/types"
@@ -16,6 +16,7 @@ import { YAMLStringify } from "./yaml"
 import { deleteUndefinedValues } from "./cleaners"
 import { CancellationOptions, checkCancelled } from "./cancellation"
 import { measure } from "./performance"
+import { dotGenaiscriptPath } from "./workdir"
 
 let standardFontDataUrl: string
 

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -2,7 +2,7 @@
 // like file operations, web search, fuzzy search, vector search, and more.
 // The context is essential for executing prompts within a project environment.
 
-import { arrayify, assert, dotGenaiscriptPath } from "./util"
+import { arrayify, assert } from "./util"
 import { runtimeHost } from "./host"
 import { MarkdownTrace } from "./trace"
 import { createParsers } from "./parsers"
@@ -30,6 +30,7 @@ import { fetch, fetchText } from "./fetch"
 import { fileWriteCached } from "./filecache"
 import { join } from "node:path"
 import { createMicrosoftTeamsChannelClient } from "./teams"
+import { dotGenaiscriptPath } from "./workdir"
 
 /**
  * Creates a prompt context for the given project, variables, trace, options, and model.

--- a/packages/core/src/pyodide.ts
+++ b/packages/core/src/pyodide.ts
@@ -1,5 +1,5 @@
 import type { PyodideInterface } from "pyodide"
-import { dotGenaiscriptPath } from "./util"
+import { dotGenaiscriptPath } from "./workdir"
 import { TraceOptions } from "./trace"
 import { hash } from "./crypto"
 import { deleteUndefinedValues } from "./cleaners"

--- a/packages/core/src/runpromptcontext.ts
+++ b/packages/core/src/runpromptcontext.ts
@@ -33,7 +33,6 @@ import { isGlobMatch } from "./glob"
 import {
     arrayify,
     assert,
-    dotGenaiscriptPath,
     ellipse,
     logError,
     logVerbose,
@@ -104,6 +103,7 @@ import { toBase64 } from "@smithy/util-base64"
 import { consoleColors } from "./consolecolor"
 import { terminalSize } from "./terminal"
 import { stderr, stdout } from "./stdio"
+import { dotGenaiscriptPath } from "./workdir"
 
 export function createChatTurnGenerationContext(
     options: GenerationOptions,

--- a/packages/core/src/scripts.ts
+++ b/packages/core/src/scripts.ts
@@ -7,12 +7,12 @@ import {
 import { githubCopilotCustomPrompt, promptDefinitions } from "./default_prompts"
 import { tryReadText, writeText } from "./fs"
 import { host } from "./host"
-import { dotGenaiscriptPath, logVerbose } from "./util"
-import { dedent } from "./indent"
+import { logVerbose } from "./util"
 import { Project } from "./server/messages"
 import { fetchText } from "./fetch"
 import { collapseNewlines } from "./cleaners"
 import { gitIgnoreEnsure } from "./gitignore"
+import { dotGenaiscriptPath } from "./workdir"
 
 export function createScript(
     name: string,

--- a/packages/core/src/transformers.ts
+++ b/packages/core/src/transformers.ts
@@ -11,12 +11,13 @@ import type {
 } from "@huggingface/transformers"
 import { NotSupportedError } from "./error"
 import { ChatCompletionMessageParam, ChatCompletionResponse } from "./chattypes"
-import { dotGenaiscriptPath, logVerbose } from "./util"
+import { logVerbose } from "./util"
 import { parseModelIdentifier } from "./models"
 import prettyBytes from "pretty-bytes"
 import { hash } from "./crypto"
 import { PLimitPromiseQueue } from "./concurrency"
 import { deleteUndefinedValues } from "./cleaners"
+import { dotGenaiscriptPath } from "./workdir"
 
 function progressBar(): ProgressCallback {
     const progress: Record<string, number> = {}

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -89,14 +89,6 @@ export function utf8Decode(buf: Uint8Array) {
     return host.createUTF8Decoder().decode(buf)
 }
 
-export function dotGenaiscriptPath(...segments: string[]) {
-    return host.resolvePath(
-        host.projectFolder(),
-        GENAISCRIPT_FOLDER,
-        ...segments
-    )
-}
-
 export function relativePath(root: string, fn: string) {
     // ignore empty path or urls
     if (!fn || HTTPS_REGEX.test(fn)) return fn

--- a/packages/core/src/vectra.ts
+++ b/packages/core/src/vectra.ts
@@ -6,12 +6,13 @@
 import { encode, decode } from "gpt-tokenizer"
 import type { EmbeddingsModel, EmbeddingsResponse } from "vectra/lib/types"
 import { LanguageModelConfiguration } from "./server/messages"
-import { dotGenaiscriptPath, logVerbose } from "./util"
+import { logVerbose } from "./util"
 import { TraceOptions } from "./trace"
 import { CancellationOptions, checkCancelled } from "./cancellation"
 import { arrayify } from "./cleaners"
 import { resolveFileContent } from "./file"
 import { EmbeddingFunction, WorkspaceFileIndexCreator } from "./chat"
+import { dotGenaiscriptPath } from "./workdir"
 
 /**
  * Class for creating embeddings using the OpenAI API.

--- a/packages/core/src/workdir.ts
+++ b/packages/core/src/workdir.ts
@@ -1,0 +1,59 @@
+import {
+    CONVERTS_DIR_NAME,
+    GENAI_ANYTS_REGEX,
+    GENAISCRIPT_FOLDER,
+    RUNS_DIR_NAME,
+    STATS_DIR_NAME,
+} from "./constants"
+import { randomHex } from "./crypto"
+import { ensureDir } from "./fs"
+import { gitIgnoreEnsure } from "./gitignore"
+import { host } from "./host"
+
+export function dotGenaiscriptPath(...segments: string[]) {
+    return host.resolvePath(
+        host.projectFolder(),
+        GENAISCRIPT_FOLDER,
+        ...segments
+    )
+}
+
+export async function ensureDotGenaiscriptPath() {
+    const dir = dotGenaiscriptPath(".")
+    await ensureDir(dir)
+    await gitIgnoreEnsure(dir, ["*"])
+}
+
+export function getRunDir(scriptId: string, runId: string) {
+    const name = new Date().toISOString().replace(/[:.]/g, "-") + "-" + runId
+    const out = dotGenaiscriptPath(
+        RUNS_DIR_NAME,
+        host.path.basename(scriptId).replace(GENAI_ANYTS_REGEX, ""),
+        name
+    )
+    return out
+}
+
+export function getConvertDir(scriptId: string) {
+    const runId =
+        new Date().toISOString().replace(/[:.]/g, "-") + "-" + randomHex(6)
+    const out = dotGenaiscriptPath(
+        CONVERTS_DIR_NAME,
+        host.path.basename(scriptId).replace(GENAI_ANYTS_REGEX, ""),
+        runId
+    )
+    return out
+}
+
+export function getVideoDir() {
+    const dir = dotGenaiscriptPath(
+        "videos",
+        `${new Date().toISOString().replace(/[:.]/g, "-")}`
+    )
+    return dir
+}
+
+export function getStatsDir() {
+    const statsDir = dotGenaiscriptPath(STATS_DIR_NAME)
+    return statsDir
+}

--- a/packages/core/src/workdir.ts
+++ b/packages/core/src/workdir.ts
@@ -24,8 +24,17 @@ export async function ensureDotGenaiscriptPath() {
     await gitIgnoreEnsure(dir, ["*"])
 }
 
+function friendlyDate() {
+    return new Date().toISOString().replace(/[:.]/g, "-")
+}
+
+function createDatedFolder(id: string) {
+    const name = friendlyDate() + "-" + id
+    return name
+}
+
 export function getRunDir(scriptId: string, runId: string) {
-    const name = new Date().toISOString().replace(/[:.]/g, "-") + "-" + runId
+    const name = createDatedFolder(runId)
     const out = dotGenaiscriptPath(
         RUNS_DIR_NAME,
         host.path.basename(scriptId).replace(GENAI_ANYTS_REGEX, ""),
@@ -35,25 +44,23 @@ export function getRunDir(scriptId: string, runId: string) {
 }
 
 export function getConvertDir(scriptId: string) {
-    const runId =
-        new Date().toISOString().replace(/[:.]/g, "-") + "-" + randomHex(6)
+    const name = createDatedFolder(randomHex(6))
     const out = dotGenaiscriptPath(
         CONVERTS_DIR_NAME,
         host.path.basename(scriptId).replace(GENAI_ANYTS_REGEX, ""),
-        runId
+        name
     )
     return out
 }
 
-export function getVideoDir() {
-    const dir = dotGenaiscriptPath(
-        "videos",
-        `${new Date().toISOString().replace(/[:.]/g, "-")}`
-    )
+export async function createVideoDir() {
+    const dir = dotGenaiscriptPath("videos", friendlyDate())
+    await ensureDir(dir)
     return dir
 }
 
-export function getStatsDir() {
+export async function createStatsDir() {
     const statsDir = dotGenaiscriptPath(STATS_DIR_NAME)
+    await ensureDir(statsDir)
     return statsDir
 }

--- a/packages/vscode/src/fragmentcommands.ts
+++ b/packages/vscode/src/fragmentcommands.ts
@@ -7,14 +7,10 @@ import { GENAI_ANY_REGEX, TOOL_ID, TOOL_NAME } from "../../core/src/constants"
 import { NotSupportedError } from "../../core/src/error"
 import { promptParameterTypeToJSONSchema } from "../../core/src/parameters"
 import { Fragment } from "../../core/src/generation"
-import {
-    dotGenaiscriptPath,
-    groupBy,
-    logInfo,
-    logVerbose,
-} from "../../core/src/util"
+import { groupBy, logInfo, logVerbose } from "../../core/src/util"
 import { resolveCli } from "./config"
 import { YAMLStringify } from "../../core/src/yaml"
+import { dotGenaiscriptPath } from "../../core/src/workdir"
 
 type TemplateQuickPickItem = {
     template?: PromptScript


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

## Summary of Changes

- 📄 **Documentation Update**: Enhanced the documentation to support external test files in `.mjs` and `.mts` formats, allowing JavaScript files to be executed for test generation.
  
- 🚀 **Code Refactoring**: 
  - Moved the `dotGenaiscriptPath` function and related path management functions to a new `workdir.ts` module for better organization and modularity.
  - Introduced utility functions in `workdir.ts` to manage directories for runs, conversions, stats, and videos, improving code maintainability and readability.
  
- 🛠️ **Functionality Enhancement**: 
  - Added support for `.mjs` and `.mts` files in the prompt testing configuration by updating the `generatePromptFooConfiguration` function.
  - Implemented a new `importFile` function to handle file imports with optional callbacks, enhancing flexibility in module imports.
  
- 🧹 **Code Cleanup**: 
  - Removed redundant code and consolidated similar functionalities to reduce duplication and improve code cleanliness.
  - Streamlined the import statements across various modules by centralizing path-related functions.
  
These changes aim to improve the codebase's organization, enhance functionality, and update documentation to reflect new capabilities.

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

