### PR TITLE
Add markdown chunking command

### DIFF
--- a/docs/src/content/docs/reference/cli/commands.md
+++ b/docs/src/content/docs/reference/cli/commands.md
@@ -571,6 +571,7 @@ Commands:
   prompty [options] <file...>   Converts .prompty files to genaiscript
   jinja2 [options] <file>       Renders Jinj2 or prompty template
   secrets <file...>             Applies secret scanning and redaction to files
+  markdown [options] <file>     Chunks markdown files
 ```
 
 ### `parse data`
@@ -715,6 +716,22 @@ Arguments:
 
 Options:
   -h, --help  display help for command
+```
+
+### `parse markdown`
+
+```
+Usage: genaiscript parse markdown [options] <file>
+
+Chunks markdown files
+
+Arguments:
+  file                        input markdown file
+
+Options:
+  -m, --model <string>        encoding model
+  -mt, --max-tokens <number>  maximum tokens per chunk
+  -h, --help                  display help for command
 ```
 
 ## `info`

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,6 +18,7 @@ import {
     parseFence,
     parseHTMLToText,
     parseJinja2,
+    parseMarkdown,
     parsePDF,
     parseSecrets,
     parseTokens,
@@ -584,6 +585,13 @@ export async function cli() {
         .description("Applies secret scanning and redaction to files")
         .argument("<file...>", "input files")
         .action(parseSecrets)
+    parser
+        .command("markdown")
+        .description("Chunks markdown files")
+        .argument("<file>", "input markdown file")
+        .option("-m, --model <string>", "encoding model")
+        .option("-mt, --max-tokens <number>", "maximum tokens per chunk")
+        .action(parseMarkdown)
 
     // Define 'info' command group for utility information tasks
     const info = program.command("info").description("Utility tasks")

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -313,7 +313,10 @@ async function runToolCall(
                     name: call.name,
                     description: "unknown tool",
                 },
-                impl: async () => "unknown tool",
+                impl: async () => {
+                    def("tool_not_found", call.name)
+                    return `unknown tool ${call.name}`
+                },
             }
         }
         todos = [{ tool, args: callArgs }]

--- a/packages/core/src/mdchunk.ts
+++ b/packages/core/src/mdchunk.ts
@@ -13,16 +13,15 @@ export async function chunkMarkdown(
     estimateTokens: (text: string) => number,
     options?: {
         maxTokens?: number
-        pageSeperator?: string
+        pageSeparator?: string
     }
 ): Promise<TextChunk[]> {
-    const { maxTokens = 4096, pageSeperator: pageSeparator = "======" } = options || {}
+    const { maxTokens = 4096, pageSeparator = "======" } = options || {}
     if (!markdown) return []
 
     type Section = { heading: string; lines: string[]; level: number }
 
-    const filename =
-        typeof markdown === "object" ? markdown.filename : undefined
+    const filename = typeof markdown === "object" ? markdown.filename : ""
     if (typeof markdown === "object") {
         if (markdown.encoding === "base64")
             throw new Error("base64 encoding not supported")

--- a/packages/sample/genaisrc/pr-describe.genai.mjs
+++ b/packages/sample/genaisrc/pr-describe.genai.mjs
@@ -5,9 +5,7 @@ script({
         "system",
         "system.output_markdown",
         "system.assistant",
-        "system.fs_find_files",
-        "system.fs_read_file",
-        "system.english"
+        "system.english",
     ],
     parameters: {
         defaultBranch: {


### PR DESCRIPTION
Introduce a new command to chunk markdown files, allowing users to specify encoding models and maximum token limits for processing.