### PR TITLE
Ast grep c

### DIFF
--- a/docs/src/content/docs/reference/scripts/ast-grep.mdx
+++ b/docs/src/content/docs/reference/scripts/ast-grep.mdx
@@ -32,6 +32,13 @@ const { matches } = await asg.search("ts", "src/fib.ts", {
 })
 ```
 
+:::tip
+
+Use the [ast-grep playground](https://ast-grep.github.io/playground.html) to debug your queries,
+then copy them back into your GenAIScript script.
+
+:::
+
 ## Supported languages
 
 This version of `ast-grep` [supports the following built-in languages](https://ast-grep.github.io/reference/api.html#supported-languages):
@@ -42,13 +49,16 @@ This version of `ast-grep` [supports the following built-in languages](https://a
 - Css
 - TypeScript
 
-The following languages languages require installing an additiona package:
+The following languages require installing an additional package:
 
 - C, `@ast-grep/lang-c`
 
 ```sh
 npm install -D @ast-grep/lang-c
 ```
+
+- SQL, `@ast-grep/lang-sql`
+- Angular, `@ast-grep/lang-angular`
 
 :::tip
 

--- a/docs/src/content/docs/reference/scripts/ast-grep.mdx
+++ b/docs/src/content/docs/reference/scripts/ast-grep.mdx
@@ -32,6 +32,19 @@ const { matches } = await asg.search("ts", "src/fib.ts", {
 })
 ```
 
+or if you copy the rules from the [ast-grep playground](https://ast-grep.github.io/playground.html) using YAML, 
+
+```ts
+const { matches } = await asg.search("ts", "src/fib.ts", YAML`
+rule:
+    kind: function_declaration
+    not:
+        precedes: 
+            kind: comment
+            stopBy: neighbor
+`)
+```
+
 :::tip
 
 Use the [ast-grep playground](https://ast-grep.github.io/playground.html) to debug your queries,

--- a/docs/src/content/docs/reference/scripts/ast-grep.mdx
+++ b/docs/src/content/docs/reference/scripts/ast-grep.mdx
@@ -34,13 +34,21 @@ const { matches } = await asg.search("ts", "src/fib.ts", {
 
 ## Supported languages
 
-This version of `ast-grep` [supports the following languages](https://ast-grep.github.io/reference/api.html#supported-languages):
+This version of `ast-grep` [supports the following built-in languages](https://ast-grep.github.io/reference/api.html#supported-languages):
 
 - Html
 - JavaScript
 - Tsx
 - Css
 - TypeScript
+
+The following languages languages require installing an additiona package:
+
+- C, `@ast-grep/lang-c`
+
+```sh
+npm install -D @ast-grep/lang-c
+```
 
 :::tip
 

--- a/docs/src/content/docs/reference/scripts/yaml.md
+++ b/docs/src/content/docs/reference/scripts/yaml.md
@@ -23,6 +23,7 @@ defData("DATA", data)
 Similarly to the `JSON` class in JavaScript, the `YAML` class in LLM provides methods to parse and stringify YAML data.
 
 ```js
+const obj = YAML`value: ${x}`
 const obj = YAML.parse(`...`)
 const str = YAML.stringify(obj)
 ```

--- a/packages/core/src/astgrep.ts
+++ b/packages/core/src/astgrep.ts
@@ -249,7 +249,7 @@ async function loadDynamicLanguage(langName: string) {
         dbg(`loading language: ${langName}`)
         const { registerDynamicLanguage } = await import("@ast-grep/napi")
         try {
-            const dynamicLang = await import(`@ast-grep/lang-${langName}`)
+            const dynamicLang = (await import(`@ast-grep/lang-${langName}`)).default
             registerDynamicLanguage({ [langName]: dynamicLang })
             loadedDynamicLanguages.add(langName)
             dbg(`language ${langName} registered `)

--- a/packages/core/src/astgrep.ts
+++ b/packages/core/src/astgrep.ts
@@ -39,7 +39,7 @@ export async function astGrepFindFiles(
         throw new Error("matcher is required")
     }
 
-    dbg(`finding files with ${lang}`)
+    dbg(`finding files with ${lang} %O`, matcher)
     const { findInFiles } = await import("@ast-grep/napi")
     checkCancelled(cancellationToken)
     const sglang = await resolveLang(lang)
@@ -249,7 +249,8 @@ async function loadDynamicLanguage(langName: string) {
         dbg(`loading language: ${langName}`)
         const { registerDynamicLanguage } = await import("@ast-grep/napi")
         try {
-            const dynamicLang = (await import(`@ast-grep/lang-${langName}`)).default
+            const dynamicLang = (await import(`@ast-grep/lang-${langName}`))
+                .default
             registerDynamicLanguage({ [langName]: dynamicLang })
             loadedDynamicLanguages.add(langName)
             dbg(`language ${langName} registered `)

--- a/packages/core/src/astgrep.ts
+++ b/packages/core/src/astgrep.ts
@@ -7,6 +7,7 @@ import { resolveFileContent } from "./file"
 import { host } from "./host"
 import { uniq } from "es-toolkit"
 import { readText, writeText } from "./fs"
+import { extname } from "node:path"
 
 /**
  * Searches for files matching specific criteria based on file patterns and match rules,
@@ -236,7 +237,7 @@ async function resolveLang(lang: SgLang, filename?: string) {
             return Lang.Css
         }
         return await loadDynamicLanguage(
-            path.extname(filename).slice(1).toLowerCase()
+            extname(filename).slice(1).toLowerCase()
         )
     }
 

--- a/packages/core/src/globals.ts
+++ b/packages/core/src/globals.ts
@@ -1,7 +1,7 @@
 import debug from "debug"
 const dbg = debug("globals")
 // Import various parsing and stringifying utilities
-import { YAMLParse, YAMLStringify } from "./yaml"
+import { createYAML, YAMLParse, YAMLStringify } from "./yaml"
 import { CSVParse, dataToMarkdownTable, CSVStringify, CSVChunk } from "./csv"
 import { INIParse, INIStringify } from "./ini"
 import { XMLParse } from "./xml"
@@ -49,10 +49,7 @@ export function installGlobals() {
     const glb = resolveGlobal() // Get the global context
 
     // Freeze YAML utilities to prevent modification
-    glb.YAML = Object.freeze<YAML>({
-        stringify: YAMLStringify, // Convert objects to YAML string
-        parse: YAMLParse, // Parse YAML string to objects
-    })
+    glb.YAML = createYAML()
 
     // Freeze CSV utilities
     glb.CSV = Object.freeze<CSV>({

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -2407,6 +2407,11 @@ interface Parsers {
 
 interface YAML {
     /**
+    * Parses a YAML string into a JavaScript object using JSON5.
+      */
+    (strings: TemplateStringsArray, ...values: any[]): any;
+
+    /**
      * Converts an object to its YAML representation
      * @param obj
      */

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -4201,7 +4201,7 @@ interface SgRoot {
     filename(): string
 }
 
-type SgLang = OptionsOrString<"html" | "js" | "ts" | "tsx" | "css">
+type SgLang = OptionsOrString<"html" | "js" | "ts" | "tsx" | "css" | "c" | "sql">
 
 interface Sg {
     parse(file: WorkspaceFile, options: { lang?: SgLang }): Promise<SgRoot>

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -357,3 +357,4 @@ declare function generateImage(
     prompt: string,
     options?: ImageGenerationOptions
 ): Promise<{ image: WorkspaceFile; revisedPrompt?: string }>
+

--- a/packages/core/src/yaml.test.ts
+++ b/packages/core/src/yaml.test.ts
@@ -1,4 +1,4 @@
-import { YAMLTryParse, YAMLParse, YAMLStringify } from "./yaml"
+import { YAMLTryParse, YAMLParse, YAMLStringify, createYAML } from "./yaml"
 import { describe, test, beforeEach } from "node:test"
 import assert from "node:assert/strict"
 
@@ -42,6 +42,31 @@ describe("YAML utilities", () => {
             const expectedResult = `name: test\nage: 30\n`
             const result = YAMLStringify(obj)
             assert.strictEqual(result, expectedResult)
+        })
+    })
+    describe("createYAML", () => {
+        test("should parse a YAML template string", () => {
+            const yaml = createYAML()
+            const template = yaml`name: test\nage: 30`
+            const expectedResult = { name: "test", age: 30 }
+            assert.deepEqual(template, expectedResult)
+        })
+
+        test("should parse a YAML template string with embedded expressions", () => {
+            const yaml = createYAML()
+            const name = "test"
+            const age = 30
+            const template = yaml`name: ${name}\nage: ${age}`
+            const expectedResult = { name: "test", age: 30 }
+            assert.deepEqual(template, expectedResult)
+        })
+
+        test("should provide parse and stringify methods", () => {
+            const yaml = createYAML()
+            const obj = { name: "test", age: 30 }
+            const yamlString = yaml.stringify(obj)
+            const parsedObj = yaml.parse(yamlString)
+            assert.deepEqual(parsedObj, obj)
         })
     })
 })

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -6,6 +6,8 @@
 
 import { parse, stringify } from "yaml"
 import { filenameOrFileToContent } from "./unwrappers"
+import { JSON5parse } from "./json5"
+import { dedent } from "./indent"
 
 /**
  * Safely attempts to parse a YAML string into a JavaScript object.
@@ -66,4 +68,18 @@ export function YAMLParse(text: string | WorkspaceFile): any {
  */
 export function YAMLStringify(obj: any): string {
     return stringify(obj, undefined, 2)
+}
+
+export function createYAML(): YAML {
+    const res = (strings: TemplateStringsArray, ...values: any[]): any => {
+        let result = strings[0]
+        values.forEach((value, i) => {
+            result += String(value) + strings[i + 1]
+        })
+        const res = YAMLParse(dedent(result))
+        return res
+    }
+    res.parse = YAMLParse
+    res.stringify = YAMLStringify
+    return Object.freeze<YAML>(res) satisfies YAML
 }

--- a/packages/sample/genaisrc/astgrep.genai.mjs
+++ b/packages/sample/genaisrc/astgrep.genai.mjs
@@ -46,3 +46,13 @@ for (const match of matches2) {
 const modified = await commitEdits()
 console.log(modified)
 //await workspace.writeFiles(files)
+
+const { matches: cmatches } = await sg.search("c", "src/fib.ts", {
+    rule: {
+        kind: "function_declaration",
+    },
+})
+for (const match of matches) {
+    const t = match.text()
+    console.log(t)
+}

--- a/packages/sample/genaisrc/astgrep.genai.mjs
+++ b/packages/sample/genaisrc/astgrep.genai.mjs
@@ -47,12 +47,14 @@ const modified = await commitEdits()
 console.log(modified)
 //await workspace.writeFiles(files)
 
-const { matches: cmatches } = await sg.search("c", "src/fib.ts", {
+const { matches: cmatches } = await sg.search("c", "src/main.c", {
     rule: {
-        kind: "function_declaration",
+        kind: "function_definition",
     },
 })
-for (const match of matches) {
+for (const match of cmatches) {
     const t = match.text()
     console.log(t)
 }
+
+if (cmatches.length === 0) throw new Error("No matches found")

--- a/packages/sample/genaisrc/astgrep.genai.mjs
+++ b/packages/sample/genaisrc/astgrep.genai.mjs
@@ -47,11 +47,14 @@ const modified = await commitEdits()
 console.log(modified)
 //await workspace.writeFiles(files)
 
-const { matches: cmatches } = await sg.search("c", "src/main.c", {
-    rule: {
-        kind: "function_definition",
-    },
-})
+const { matches: cmatches } = await sg.search(
+    "c",
+    "src/main.c",
+    YAML`
+rule:
+  kind: function_definition
+`
+)
 for (const match of cmatches) {
     const t = match.text()
     console.log(t)

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -18,6 +18,7 @@
     "@agentic/calculator": "v7.5.3",
     "@agentic/core": "v7.5.3",
     "@agentic/weather": "v7.5.3",
+    "@ast-grep/lang-c": "^0.0.1",
     "@azure/identity": "^4.8.0",
     "@azure/storage-blob": "^12.27.0",
     "@huggingface/transformers": "^3.4.0",

--- a/packages/sample/src/main.c
+++ b/packages/sample/src/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello, World!\n");
+    return 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,6 +75,13 @@
     formdata-node "^4.3.2"
     node-fetch "^2.6.7"
 
+"@ast-grep/lang-c@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@ast-grep/lang-c/-/lang-c-0.0.1.tgz#67042ac2ca3ae2b6a72babf0fd6f032c4e86eb24"
+  integrity sha512-CthuZUqgDHX3dsQmBRvKzyHGPLI8LbO6KHjwtG7T2BOVp+0/CoZ7kd9dMi4RIw9Q79nUU/mD4t6PfH2le8yOag==
+  dependencies:
+    "@ast-grep/setup-lang" "0.0.3"
+
 "@ast-grep/napi-darwin-arm64@0.36.2":
   version "0.36.2"
   resolved "https://registry.yarnpkg.com/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.36.2.tgz#4d0344c05852824f047785b19f6a49fd005b7c63"
@@ -134,6 +141,11 @@
     "@ast-grep/napi-win32-arm64-msvc" "0.36.2"
     "@ast-grep/napi-win32-ia32-msvc" "0.36.2"
     "@ast-grep/napi-win32-x64-msvc" "0.36.2"
+
+"@ast-grep/setup-lang@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@ast-grep/setup-lang/-/setup-lang-0.0.3.tgz#b817fb38905ddf12f612e767d0ad2abb8d05085b"
+  integrity sha512-+ZNOuf0r7ABVwOANrrQpUrUv7xyuhsZGyQ88WZCH/euQmIEvSH3JsUFevg/60M7hi8NVh4vfSQs6ajTpumSzxg==
 
 "@aws-crypto/crc32@3.0.0":
   version "3.0.0"


### PR DESCRIPTION


<!-- genaiscript begin pr-describe --><hr/>



Here's a high-level summary of the changes as an engineered software developer would understand them:

- **Expanded Support**: The `ast-grep` tool now supports **TypeScript** directly (`@agentic/react` package now included). It also adds support for other languages like `C`, `SQL`, and even custom languages (`@ast-grep/lang-c`). For these languages, additional setup instructions are provided.

- **Dynamic Language Loading**: Added a new function `loadDynamicLanguage()` which likely allows loading of custom or additional supported languages beyond the built-in options. This is accompanied by better error handling (e.g., when SQL support isn't present).

- **Type System Enhancement**: The type definitions were updated to include more languages, such as `C` and `SQL`, making it easier to work with different programming languages in your code.

- **Custom Language Support**: Added specific functionality for custom TypeScript language features through the new `lang-c` package. This includes better warnings if any other supported languages are missing at runtime.

- **New Search Functionality**: introduced a method to search for function definitions specifically in C files, with corresponding error handling to inform developers about unsupported language combinations or missing features.

---

This pull request enhances `ast-grep`'s capabilities by expanding its supported languages and improving cross-language functionality while also adding new features that simplify working with TypeScript and SQL.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/14063986219) may be incorrect



<!-- genaiscript end pr-describe -->



<!-- genaiscript begin prd --><hr/>

### Summary of Changes

#### **Enhancements to `ast-grep`**
- 🔍 Added support for dynamic language loading in `ast-grep`, enabling the use of additional languages like C and SQL by installing corresponding packages (e.g., `@ast-grep/lang-c`).
- 🛠️ Updated the `resolveLang` function to dynamically load languages based on file extensions or specified language names.
- 📝 Improved debug logs to include matcher details when finding files.

#### **Documentation Updates**
- 📚 Added a tip to use the [ast-grep playground](https://ast-grep.github.io/playground.html) for debugging queries.
- 🗂️ Clarified the distinction between built-in and additional language support in `ast-grep` documentation.
- 🛠️ Updated YAML examples to include template string parsing.

#### **YAML Utilities**
- ✨ Introduced a `createYAML` function that provides a tagged template literal for parsing YAML strings directly, along with `parse` and `stringify` methods.
- ✅ Added unit tests for `createYAML` to ensure proper parsing and functionality.

#### **Sample Project Enhancements**
- 🆕 Added a C language example (`src/main.c`) to demonstrate `ast-grep` functionality with dynamically loaded languages.
- 🛠️ Updated the sample script to include a search example for C functions using the new YAML template feature.
- 📦 Included `@ast-grep/lang-c` in the sample project's dependencies.

#### **TypeScript Type Updates**
- 🔧 Extended `SgLang` types to include `c` and `sql` for dynamic language support.
- 📝 Updated the `YAML` interface to support tagged template literals for parsing YAML.

---

These changes enhance the flexibility of `ast-grep` with dynamic language support, improve YAML handling, and provide better documentation and examples for users. 🚀

> AI-generated content by prd may be incorrect



<!-- genaiscript end prd -->

