### PR TITLE
diff object + sg changeset

### DIFF
--- a/docs/src/content/docs/reference/scripts/ast-grep.mdx
+++ b/docs/src/content/docs/reference/scripts/ast-grep.mdx
@@ -89,28 +89,28 @@ If your language is not supported, go to [ast-grep langs](https://github.com/ast
 
 :::
 
-## search and replace
+## Changesets
 
 A common use case is to search for a pattern and replace it with another pattern. The transformation phase can leverage
 [inline prompts](/genaiscript/reference/scripts/inline-prompts) to perform LLM transformations.
 This can be done with the `replace` method.
 
 ```js
-const { matches, replace, commitEdits } = await sg.search("ts", "...")
+const edits = sg.changeset()
 ```
 
 The `replace` method creates an edit that replaces the content of a node with new text.
 The edit is stored internally but not applied until `commitEdits` is called.
 
 ```js
-replace(matches[0], "console.log('replaced')")
+edits.replace(matches[0], "console.log('replaced')")
 ```
 
 Of course, things get more interesting when you use inline prompts to generate the replacement text.
 
 ```js wrap
 const updated = await prompt`... ${matches[0].text()} ...`
-replace(
+edits.replace(
     matches[0].node,
     `console.log
   ('${updated.text}')`
@@ -121,7 +121,7 @@ Next, you can commit the edits to create a set of in-memory files. The changes a
 to the file system yet.
 
 ```js
-const newFiles = await commitEdits()
+const newFiles = edits.commitEdits()
 ```
 
 If you wish to apply the changes to the file system, you can use the `writeFiles` function.

--- a/docs/src/content/docs/reference/scripts/ast-grep.mdx
+++ b/docs/src/content/docs/reference/scripts/ast-grep.mdx
@@ -15,6 +15,11 @@ to surgically target specific parts of the code.
 const sg = await host.astGrep()
 ```
 
+## Search for patterns
+
+The `search` method allows you to search for patterns in the AST of a script.
+The first argument is the language, the second argument is the file globs, and the third argument is the pattern to search for.
+
 - find all TypeScript `console.log` statements. This example uses the 'pattern' syntax.
 
 ```ts
@@ -62,6 +67,54 @@ then copy them back into your GenAIScript script.
 
 :::
 
+## Changesets
+
+A common use case is to search for a pattern and replace it with another pattern. The transformation phase can leverage
+[inline prompts](/genaiscript/reference/scripts/inline-prompts) to perform LLM transformations.
+This can be done with the `replace` method.
+
+```js
+const edits = sg.changeset()
+```
+
+The `replace` method creates an edit that replaces the content of a node with new text.
+The edit is stored internally but not applied until `commit` is called.
+
+```js
+edits.replace(matches[0], "console.log('replaced')")
+```
+
+Of course, things get more interesting when you use inline prompts to generate the replacement text.
+
+```js wrap
+for(const match of matches) {
+  const updated = await prompt`... ${match.text()} ...`
+  edits.replace(
+    match.node,
+    `console.log
+  ('${updated.text}')`
+}
+```
+
+Next, you can commit the edits to create a set of in-memory files. The changes are not applied
+to the file system yet.
+
+```js
+const newFiles = edits.commit()
+```
+
+If you wish to apply the changes to the file system, you can use the `writeFiles` function.
+
+```js
+await workspace.writeFiles(newFiles)
+```
+
+::caution
+
+Do not mix matches from different searches in the same changeset.
+
+:::
+
 ## Supported languages
 
 This version of `ast-grep` [supports the following built-in languages](https://ast-grep.github.io/reference/api.html#supported-languages):
@@ -88,47 +141,6 @@ npm install -D @ast-grep/lang-c
 If your language is not supported, go to [ast-grep langs](https://github.com/ast-grep/langs/issues), and add a request!
 
 :::
-
-## Changesets
-
-A common use case is to search for a pattern and replace it with another pattern. The transformation phase can leverage
-[inline prompts](/genaiscript/reference/scripts/inline-prompts) to perform LLM transformations.
-This can be done with the `replace` method.
-
-```js
-const edits = sg.changeset()
-```
-
-The `replace` method creates an edit that replaces the content of a node with new text.
-The edit is stored internally but not applied until `commitEdits` is called.
-
-```js
-edits.replace(matches[0], "console.log('replaced')")
-```
-
-Of course, things get more interesting when you use inline prompts to generate the replacement text.
-
-```js wrap
-const updated = await prompt`... ${matches[0].text()} ...`
-edits.replace(
-    matches[0].node,
-    `console.log
-  ('${updated.text}')`
-)
-```
-
-Next, you can commit the edits to create a set of in-memory files. The changes are not applied
-to the file system yet.
-
-```js
-const newFiles = edits.commitEdits()
-```
-
-If you wish to apply the changes to the file system, you can use the `writeFiles` function.
-
-```js
-await workspace.writeFiles(newFiles)
-```
 
 ## Learning ast-grep
 

--- a/docs/src/content/docs/reference/scripts/diff.md
+++ b/docs/src/content/docs/reference/scripts/diff.md
@@ -1,0 +1,60 @@
+---
+title: Diff
+description: Learn how to create and interpret file diffs within GenAIScript.
+sidebar:
+  order: 15
+keywords: diff, file comparisons, script execution, concise output, GenAIScript
+---
+
+# Diff
+
+In GenAIScript, the `system.diff` utility generates **concise file diffs** for efficient comparison and updates. This is particularly useful for version control or making precise changes within files. Learn how to create these diffs and best practices for interpreting them.
+
+## Highlights
+
+- Diffs emphasize only the modified lines.
+- Retains minimal unmodified lines for context.
+- Uses an intuitive syntax tailored for large files with small changes.
+
+## DIFF Syntax
+
+### Guidelines:
+- **Existing lines**: Start with their **original line number**.
+- **Deleted lines**: Begin with `-` followed by the line number.
+- **Added lines**: Prefixed with `+` (no line number).
+- Deleted lines **must exist**, while added lines should be **new**.
+- Preserve indentation and focus on minimal unmodified lines.
+
+## Example Diff
+
+Below is an example of the diff format:
+
+```diff
+[10]  const oldValue = 42;
+- [11]  const removed = 'This line was removed';
++ const added = 'This line was newly added';
+[12]  const unchanged = 'This line remains the same';
+```
+
+### Best Practices For Emitting Diffs:
+1. Limit the surrounding unmodified lines to **2 lines** maximum.
+2. **Omit unchanged files** or identical lines.
+3. Focus on concise changes for efficiency.
+
+## API Reference
+
+When generating diffs within your script, use `system.diff` for streamlined comparisons. Below is an example:
+
+```js
+system({
+    title: "Generate concise diffs",
+});
+
+export default function (ctx) {
+    const { $ } = ctx;
+    $`## DIFF file format`;
+}
+```
+
+## Online Documentation
+For more details on `system.diff`, refer to the [online documentation](https://microsoft.github.io/genaiscript/).

--- a/genaisrc/ast-docs-update.genai.mts
+++ b/genaisrc/ast-docs-update.genai.mts
@@ -64,7 +64,7 @@ for (const match of matches) {
             model: "large",
             responseType: "text",
             flexTokens: 12000,
-            label: match.child(0).text(),
+            label: match.child(0).text()?.slice(0, 20),
             temperature: 0.2,
             systemSafety: false,
             system: ["system.technical", "system.typescript"],

--- a/genaisrc/ast-docs-update.genai.mts
+++ b/genaisrc/ast-docs-update.genai.mts
@@ -109,7 +109,7 @@ for (const match of matches) {
 }
 
 // apply all edits and write to the file
-const modified = edits.commitEdits()
+const modified = edits.commit()
 if (applyEdits) {
     await workspace.writeFiles(modified)
     // normalize spacing

--- a/genaisrc/ast-docs-update.genai.mts
+++ b/genaisrc/ast-docs-update.genai.mts
@@ -23,7 +23,7 @@ await prettier(file)
 
 // find all exported functions with comments
 const sg = await host.astGrep()
-const { matches, replace, commitEdits } = await sg.search("ts", file.filename, {
+const { matches } = await sg.search("ts", file.filename, {
     rule: {
         kind: "export_statement",
         follows: {
@@ -36,6 +36,7 @@ const { matches, replace, commitEdits } = await sg.search("ts", file.filename, {
     },
 })
 
+const edits = sg.changeset()
 // for each match, generate a docstring for functions not documented
 for (const match of matches) {
     const comment = match.prev()
@@ -104,11 +105,11 @@ for (const match of matches) {
         output.warn("LLM suggests minor adjustments, skipping")
         continue
     }
-    replace(comment, docs)
+    edits.replace(comment, docs)
 }
 
 // apply all edits and write to the file
-const modified = await commitEdits()
+const modified = edits.commitEdits()
 if (applyEdits) {
     await workspace.writeFiles(modified)
     // normalize spacing

--- a/genaisrc/ast-docs.genai.mts
+++ b/genaisrc/ast-docs.genai.mts
@@ -16,94 +16,95 @@ script({
 })
 const { output } = env
 const { applyEdits } = env.vars
-const file = env.files[0]
 
-// normalize spacing
-await prettier(file)
+for (const file of env.files) {
+    // normalize spacing
+    await prettier(file)
 
-// find all exported functions without comments
-const sg = await host.astGrep()
+    // find all exported functions without comments
+    const sg = await host.astGrep()
 
-const { matches } = await sg.search("ts", file.filename, {
-    rule: {
-        kind: "export_statement",
-        not: {
-            follows: {
-                kind: "comment",
-                stopBy: "neighbor",
+    const { matches } = await sg.search("ts", file.filename, {
+        rule: {
+            kind: "export_statement",
+            not: {
+                follows: {
+                    kind: "comment",
+                    stopBy: "neighbor",
+                },
+            },
+            has: {
+                kind: "function_declaration",
             },
         },
-        has: {
-            kind: "function_declaration",
-        },
-    },
-})
-const edits = sg.changeset()
-// for each match, generate a docstring for functions not documented
-for (const match of matches) {
-    const res = await runPrompt(
-        (_) => {
-            _.def("FILE", match.getRoot().root().text())
-            _.def("FUNCTION", match.text())
-            // this needs more eval-ing
-            _.$`Generate a function documentation for <FUNCTION>.
+    })
+    const edits = sg.changeset()
+    // for each match, generate a docstring for functions not documented
+    for (const match of matches) {
+        const res = await runPrompt(
+            (_) => {
+                _.def("FILE", match.getRoot().root().text())
+                _.def("FUNCTION", match.text())
+                // this needs more eval-ing
+                _.$`Generate a function documentation for <FUNCTION>.
             - Make sure parameters are documented.
             - Be concise. Use technical tone.
             - do NOT include types, this is for TypeScript.
             - Use docstring syntax. do not wrap in markdown code section.
 
             The full source of the file is in <FILE> for reference.`
-        },
-        {
-            model: "large",
-            responseType: "text",
-            label: match.text()?.slice(0, 20),
+            },
+            {
+                model: "large",
+                responseType: "text",
+                label: match.text()?.slice(0, 20),
+            }
+        )
+        // if generation is successful, insert the docs
+        if (res.error) {
+            output.warn(res.error.message)
+            continue
         }
-    )
-    // if generation is successful, insert the docs
-    if (res.error) {
-        output.warn(res.error.message)
-        continue
-    }
-    const docs = docify(res.text.trim())
+        const docs = docify(res.text.trim())
 
-    // sanity check
-    const consistent = await classify(
-        (_) => {
-            _.def("FUNCTION", match.text())
-            _.def("DOCS", docs)
-        },
-        {
-            ok: "The content in <DOCS> is an accurate documentation for the code in <FUNCTION>.",
-            err: "The content in <DOCS> does not match with the code in <FUNCTION>.",
-        },
-        {
-            model: "small",
-            responseType: "text",
-            temperature: 0.2,
-            systemSafety: false,
-            system: ["system.technical", "system.typescript"],
+        // sanity check
+        const consistent = await classify(
+            (_) => {
+                _.def("FUNCTION", match.text())
+                _.def("DOCS", docs)
+            },
+            {
+                ok: "The content in <DOCS> is an accurate documentation for the code in <FUNCTION>.",
+                err: "The content in <DOCS> does not match with the code in <FUNCTION>.",
+            },
+            {
+                model: "small",
+                responseType: "text",
+                temperature: 0.2,
+                systemSafety: false,
+                system: ["system.technical", "system.typescript"],
+            }
+        )
+
+        if (consistent.label !== "ok") {
+            output.warn(consistent.label)
+            output.fence(consistent.answer)
+            continue
         }
-    )
 
-    if (consistent.label !== "ok") {
-        output.warn(consistent.label)
-        output.fence(consistent.answer)
-        continue
+        const updated = `${docs}\n${match.text()}`
+        edits.replace(match, updated)
     }
 
-    const updated = `${docs}\n${match.text()}`
-    edits.replace(match, updated)
-}
-
-// apply all edits and write to the file
-const [modified] = edits.commitEdits()
-if (applyEdits) {
-    await workspace.writeFiles(modified)
-    await prettier(file)
-} else {
-    output.diff(file, modified)
-    output.warn(
-        `edit not applied, use --vars 'applyEdits=true' to apply the edits`
-    )
+    // apply all edits and write to the file
+    const [modified] = edits.commitEdits()
+    if (applyEdits) {
+        await workspace.writeFiles(modified)
+        await prettier(file)
+    } else {
+        output.diff(file, modified)
+        output.warn(
+            `edit not applied, use --vars 'applyEdits=true' to apply the edits`
+        )
+    }
 }

--- a/genaisrc/ast-docs.genai.mts
+++ b/genaisrc/ast-docs.genai.mts
@@ -46,6 +46,7 @@ if (diffFiles)
     )
 
 for (const file of env.files) {
+    dbg(file.filename)
     // normalize spacing
     if (pretty) await prettier(file)
 
@@ -66,7 +67,7 @@ for (const file of env.files) {
             },
         },
     })
-    dbg(`sg matches ${matches.length} for ${file.filename}`)
+    dbg(`sg matches ${matches.length}`)
     if (matches?.length && diffFiles?.length) {
         const newMatches = matches.filter((m) => {
             const chunk = DIFF.findChunk(
@@ -84,7 +85,7 @@ for (const file of env.files) {
         continue
     }
 
-    dbg(`process ${matches.length} matches in ${file.filename}`)
+    dbg(`found ${matches.length} matches`)
     const edits = sg.changeset()
     // for each match, generate a docstring for functions not documented
     for (const match of matches) {

--- a/genaisrc/ast-docs.genai.mts
+++ b/genaisrc/ast-docs.genai.mts
@@ -54,7 +54,11 @@ for (const match of matches) {
 
             The full source of the file is in <FILE> for reference.`
         },
-        { model: "large", responseType: "text", label: match.text() }
+        {
+            model: "large",
+            responseType: "text",
+            label: match.text()?.slice(0, 20),
+        }
     )
     // if generation is successful, insert the docs
     if (res.error) {

--- a/genaisrc/ast-docs.genai.mts
+++ b/genaisrc/ast-docs.genai.mts
@@ -145,7 +145,7 @@ for (const file of env.files) {
     }
 
     // apply all edits and write to the file
-    const [modified] = edits.commitEdits()
+    const [modified] = edits.commit()
     if (!modified) continue
 
     if (applyEdits) {

--- a/genaisrc/ast-docs.genai.mts
+++ b/genaisrc/ast-docs.genai.mts
@@ -24,7 +24,7 @@ await prettier(file)
 // find all exported functions without comments
 const sg = await host.astGrep()
 
-const { matches, replace, commitEdits } = await sg.search("ts", file.filename, {
+const { matches } = await sg.search("ts", file.filename, {
     rule: {
         kind: "export_statement",
         not: {
@@ -38,7 +38,7 @@ const { matches, replace, commitEdits } = await sg.search("ts", file.filename, {
         },
     },
 })
-
+const edits = sg.changeset()
 // for each match, generate a docstring for functions not documented
 for (const match of matches) {
     const res = await runPrompt(
@@ -89,11 +89,11 @@ for (const match of matches) {
     }
 
     const updated = `${docs}\n${match.text()}`
-    replace(match, updated)
+    edits.replace(match, updated)
 }
 
 // apply all edits and write to the file
-const [modified] = await commitEdits()
+const [modified] = edits.commitEdits()
 if (applyEdits) {
     await workspace.writeFiles(modified)
     await prettier(file)

--- a/genaisrc/ast-docs.genai.mts
+++ b/genaisrc/ast-docs.genai.mts
@@ -38,6 +38,8 @@ for (const file of env.files) {
             },
         },
     })
+    if (!matches.length) continue
+    
     const edits = sg.changeset()
     // for each match, generate a docstring for functions not documented
     for (const match of matches) {
@@ -98,6 +100,8 @@ for (const file of env.files) {
 
     // apply all edits and write to the file
     const [modified] = edits.commitEdits()
+    if (!modified) continue
+
     if (applyEdits) {
         await workspace.writeFiles(modified)
         await prettier(file)

--- a/packages/core/src/astgrep.ts
+++ b/packages/core/src/astgrep.ts
@@ -7,8 +7,7 @@ import { resolveFileContent } from "./file"
 import { host } from "./host"
 import { uniq } from "es-toolkit"
 import { readText, writeText } from "./fs"
-import { extname, resolve } from "node:path"
-import { arrayify } from "./cleaners"
+import { extname } from "node:path"
 
 class SgChangeSetImpl implements SgChangeSet {
     private pending: Record<string, { root: SgRoot; edits: SgEdit[] }> = {}
@@ -138,32 +137,6 @@ export async function astGrepFindFiles(
     checkCancelled(cancellationToken)
 
     return { files: scanned, matches }
-}
-
-export function astGrepFindDiffChunk(
-    node: SgNode,
-    diff: DiffFile[]
-): {
-    file: DiffFile
-    chunk: DiffChunk
-} {
-    const root = node.getRoot()
-    const filename = resolve(root.filename())
-    const file = diff.find((f) => resolve(f.to) === filename)
-    if (!file) return undefined // file not found in diff
-
-    const range = node.range()
-    const startLine = range.start.line // 0-based
-    const endLine = range.end.line // 0-based
-
-    const inRange = (line: number) => line >= startLine && line <= endLine
-
-    const { chunks } = file
-    for (const chunk of chunks) {
-        if (inRange(chunk.newStart) || inRange(chunk.newStart + chunk.newLines))
-            return { file, chunk }
-    }
-    return undefined
 }
 
 /**

--- a/packages/core/src/astgrep.ts
+++ b/packages/core/src/astgrep.ts
@@ -11,6 +11,18 @@ import { extname } from "node:path"
 
 class SgChangeSetImpl implements SgChangeSet {
     private pending: Record<string, { root: SgRoot; edits: SgEdit[] }> = {}
+
+    toString() {
+        return `changeset ${this.count} edits`
+    }
+
+    get count(): number {
+        return Object.values(this.pending).reduce(
+            (acc, { edits }) => acc + edits.length,
+            0
+        )
+    }
+
     replace(node: SgNode, text: string) {
         const edit = node.replace(text)
         const root = node.getRoot()

--- a/packages/core/src/astgrep.ts
+++ b/packages/core/src/astgrep.ts
@@ -93,12 +93,14 @@ export async function astGrepFindFiles(
     dbg(`resolving language: ${lang}`)
 
     const paths = await host.findFiles(glob, options)
-    if (!paths?.length)
+    if (!paths?.length) {
+        dbg(`no files found for glob`, glob)
         return {
             files: 0,
             matches: [],
         }
-    dbg(`found ${paths.length} files`, paths.slice(0, 10))
+    }
+    dbg(`found ${paths.length} files`, paths)
 
     const matches: SgNode[] = []
     const p = new Promise<number>(async (resolve, reject) => {

--- a/packages/core/src/astgrep.ts
+++ b/packages/core/src/astgrep.ts
@@ -7,7 +7,8 @@ import { resolveFileContent } from "./file"
 import { host } from "./host"
 import { uniq } from "es-toolkit"
 import { readText, writeText } from "./fs"
-import { extname } from "node:path"
+import { extname, resolve } from "node:path"
+import { arrayify } from "./cleaners"
 
 class SgChangeSetImpl implements SgChangeSet {
     private pending: Record<string, { root: SgRoot; edits: SgEdit[] }> = {}
@@ -137,6 +138,32 @@ export async function astGrepFindFiles(
     checkCancelled(cancellationToken)
 
     return { files: scanned, matches }
+}
+
+export function astGrepFindDiffChunk(
+    node: SgNode,
+    diff: DiffFile[]
+): {
+    file: DiffFile
+    chunk: DiffChunk
+} {
+    const root = node.getRoot()
+    const filename = resolve(root.filename())
+    const file = diff.find((f) => resolve(f.to) === filename)
+    if (!file) return undefined // file not found in diff
+
+    const range = node.range()
+    const startLine = range.start.line // 0-based
+    const endLine = range.end.line // 0-based
+
+    const inRange = (line: number) => line >= startLine && line <= endLine
+
+    const { chunks } = file
+    for (const chunk of chunks) {
+        if (inRange(chunk.newStart) || inRange(chunk.newStart + chunk.newLines))
+            return { file, chunk }
+    }
+    return undefined
 }
 
 /**

--- a/packages/core/src/astgrep.ts
+++ b/packages/core/src/astgrep.ts
@@ -43,6 +43,11 @@ class SgChangeSetImpl implements SgChangeSet {
     }
 }
 
+/**
+ * Creates and returns a new instance of a change set for tracking and managing edits in abstract syntax trees (ASTs).
+ *
+ * @returns A new change set instance to handle editing operations such as replacements and commit edits.
+ */
 export function astGrepCreateChangeSet(): SgChangeSet {
     return new SgChangeSetImpl()
 }

--- a/packages/core/src/diff.test.ts
+++ b/packages/core/src/diff.test.ts
@@ -1,0 +1,111 @@
+import { describe, test } from "node:test"
+import assert from "node:assert/strict"
+import { diffParse, tryDiffParse, diffCreatePatch, diffFindChunk } from "./diff"
+
+describe("diff", () => {
+    test("diffParse - valid input", () => {
+        const input = `
+diff --git a/file1.txt b/file1.txt
+index 83db48f..bf269f4 100644
+--- a/file1.txt
++++ b/file1.txt
+@@ -1,3 +1,3 @@
+-Hello World
++Hello Universe
+`
+        const result = diffParse(input)
+        assert(result.length > 0, "Should parse diff into files")
+        assert(result[0].chunks.length > 0, "Should parse chunks")
+    })
+
+    test("diffParse - empty input", () => {
+        const input = ""
+        const result = diffParse(input)
+        assert.deepEqual(
+            result,
+            [],
+            "Should return an empty array for empty input"
+        )
+    })
+
+    test("tryDiffParse - valid input", () => {
+        const input = `
+diff --git a/file1.txt b/file1.txt
+index 83db48f..bf269f4 100644
+--- a/file1.txt
++++ b/file1.txt
+@@ -1,3 +1,3 @@
+-Hello World
++Hello Universe
+`
+        const result = tryDiffParse(input)
+        assert(result, "Should parse diff successfully")
+    })
+
+    test("diffCreatePatch - valid input", () => {
+        const left = { filename: "file1.txt", content: "Hello World\n" }
+        const right = { filename: "file1.txt", content: "Hello Universe\n" }
+        const patch = diffCreatePatch(left, right)
+        assert(
+            patch.includes("--- file1.txt"),
+            "Should include original file header"
+        )
+        assert(
+            patch.includes("+++ file1.txt"),
+            "Should include modified file header"
+        )
+        assert(patch.includes("-Hello World"), "Should include removed line")
+        assert(patch.includes("+Hello Universe"), "Should include added line")
+    })
+
+    test("diffFindChunk - find chunk by line", () => {
+        const diff = [
+            {
+                to: "file1.txt",
+                chunks: [
+                    {
+                        newStart: 1,
+                        newLines: 3,
+                    },
+                ],
+            },
+        ]
+        const result = diffFindChunk("file1.txt", 2, diff as any)
+        assert(result?.chunk, "Should find the chunk containing the line")
+    })
+
+    test("diffFindChunk - file not found", () => {
+        const diff = [
+            {
+                to: "file1.txt",
+            },
+        ]
+        const result = diffFindChunk("file2.txt", 1, diff as any)
+        assert.strictEqual(
+            result,
+            undefined,
+            "Should return undefined if file is not found"
+        )
+    })
+
+    test("diffFindChunk - line not in any chunk", () => {
+        const diff = [
+            {
+                to: "file1.txt",
+                chunks: [
+                    {
+                        newStart: 10,
+                        newLines: 5,
+                    },
+                ],
+            },
+        ]
+        const result = diffFindChunk("file1.txt", 2, diff as any)
+        assert(result?.file, "Should return the file even if no chunk matches")
+        assert.strictEqual(
+            result?.chunk,
+            undefined,
+            "Should not return a chunk if line is not in range"
+        )
+    })
+})

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -45,10 +45,10 @@ export function diffCreatePatch(
     if (typeof left === "string") left = { filename: "left", content: left }
     if (typeof right === "string") right = { filename: "right", content: right }
     const res = createTwoFilesPatch(
-        left.filename || "",
-        right.filename || "",
-        left.content || "",
-        right.content || "",
+        left?.filename || "",
+        right?.filename || "",
+        left?.content || "",
+        right?.content || "",
         undefined,
         undefined,
         {

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -6,6 +6,12 @@ import { createTwoFilesPatch } from "diff"
 import { resolve } from "node:path"
 const dbg = debug("genaiscript:diff")
 
+/**
+ * Parses a diff string into a structured format.
+ *
+ * @param input - The diff string to parse. Should be in a valid diff format.
+ * @returns An array of parsed file objects. If the input is empty or invalid, returns an empty array.
+ */
 export function diffParse(input: string) {
     if (isEmptyString(input)) return []
     const files = parseDiff(input)
@@ -60,6 +66,14 @@ export function diffCreatePatch(
     return res.replace(/^[^=]*={10,}\n/, "")
 }
 
+/**
+ * Finds a chunk in a diff corresponding to a specified file and line number.
+ *
+ * @param file - The file path to search for in the diff. Can be empty to search all files.
+ * @param line - The line number or numbers (zero-based) to locate in the specified file's diff.
+ * @param diff - The diff data, containing an array of file diffs.
+ * @returns An object containing the matching file and the chunk if found, or undefined if no match exists.
+ */
 export function diffFindChunk(
     file: string,
     line: ElementOrArray<number>,

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -62,7 +62,7 @@ export function diffCreatePatch(
 
 export function diffFindChunk(
     file: string,
-    line: number,
+    line: ElementOrArray<number>,
     diff: ElementOrArray<DiffFile>
 ): { file?: DiffFile; chunk?: DiffChunk } | undefined {
     // line is zero-based
@@ -73,9 +73,14 @@ export function diffFindChunk(
     if (!df) return undefined // file not found in diff
 
     const { chunks } = df
+    const lines = arrayify(line)
     for (const chunk of chunks) {
-        if (line >= chunk.newStart && line <= chunk.newStart + chunk.newLines)
-            return { file: df, chunk }
+        for (const line of lines)
+            if (
+                line >= chunk.newStart &&
+                line <= chunk.newStart + chunk.newLines
+            )
+                return { file: df, chunk }
     }
     return { file: df }
 }

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -1,0 +1,60 @@
+import parseDiff from "parse-diff"
+import { isEmptyString } from "./cleaners"
+import debug from "debug"
+import { errorMessage } from "./error"
+import { createTwoFilesPatch } from "diff"
+const dbg = debug("genaiscript:diff")
+
+export function diffParse(input: string) {
+    if (isEmptyString(input)) return []
+    const files = parseDiff(input)
+    return files
+}
+
+/**
+ * Parses a diff string into a structured format using the parse-diff library.
+ * @param diff - The diff string to parse. Must be in a supported diff format.
+ * @returns A parsed array of file objects if successful, or undefined if parsing fails or no files are found.
+ */
+export function tryDiffParse(diff: string) {
+    try {
+        return diffParse(diff)
+    } catch (e) {
+        dbg(`diff parsing failed: ${errorMessage(e)}`)
+        return undefined
+    }
+}
+
+/**
+ * Creates a unified diff between two workspace files.
+ * @param left - The original workspace file or its content.
+ * @param right - The modified workspace file or its content.
+ * @param options - Optional parameters, such as the number of context lines.
+ * @returns The diff as a string, with redundant headers removed.
+ */
+export function diffCreatePatch(
+    left: string | WorkspaceFile,
+    right: string | WorkspaceFile,
+    options?: {
+        context?: number
+        ignoreCase?: boolean
+        ignoreWhitespace?: boolean
+    }
+) {
+    if (typeof left === "string") left = { filename: "left", content: left }
+    if (typeof right === "string") right = { filename: "right", content: right }
+    const res = createTwoFilesPatch(
+        left.filename || "",
+        right.filename || "",
+        left.content || "",
+        right.content || "",
+        undefined,
+        undefined,
+        {
+            ignoreCase: true,
+            ignoreWhitespace: true,
+            ...(options ?? {}),
+        }
+    )
+    return res.replace(/^[^=]*={10,}\n/, "")
+}

--- a/packages/core/src/fileedits.ts
+++ b/packages/core/src/fileedits.ts
@@ -1,6 +1,6 @@
 import { applyChangeLog, parseChangeLogs } from "./changelog"
 import { dataToMarkdownTable } from "./csv"
-import { applyLLMDiff, applyLLMPatch, createDiff, parseLLMDiffs } from "./llmdiff"
+import { applyLLMDiff, applyLLMPatch, parseLLMDiffs } from "./llmdiff"
 import { errorMessage } from "./error"
 import { unquote } from "./unwrappers"
 import { fileExists, readText } from "./fs"
@@ -13,6 +13,7 @@ import { MarkdownTrace, TraceOptions } from "./trace"
 import { logError, logVerbose, relativePath } from "./util"
 import { YAMLParse } from "./yaml"
 import { writeText } from "./fs"
+import { diffCreatePatch } from "./diff"
 
 /**
  * Computes file edits based on the specified runtime prompt result and processing options.
@@ -340,7 +341,7 @@ export async function writeFileEdits(
             )
             trace.detailsFenced(
                 `updating ${fn}`,
-                createDiff(
+                diffCreatePatch(
                     { filename: fn, content: before },
                     { filename: fn, content: after }
                 ),

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -20,7 +20,7 @@ import { shellRemoveAsciiColors } from "./shell"
 import { isGlobMatch } from "./glob"
 import { fetchText } from "./fetch"
 import { concurrentLimit } from "./concurrency"
-import { createDiff, llmifyDiff } from "./llmdiff"
+import { llmifyDiff } from "./llmdiff"
 import { JSON5TryParse } from "./json5"
 import { link } from "./mkmd"
 import { LanguageModelInfo } from "./server/messages"
@@ -28,6 +28,7 @@ import { LanguageModel, ListModelsFunction } from "./chat"
 import { OpenAIChatCompletion, OpenAIEmbedder } from "./openai"
 import { errorMessage, serializeError } from "./error"
 import { normalizeInt } from "./cleaners"
+import { diffCreatePatch } from "./diff"
 
 export interface GithubConnectionInfo {
     token: string
@@ -1055,7 +1056,7 @@ export class GitHubClient implements GitHub {
         job.content = parseJobLog(job.content)
         other.content = parseJobLog(other.content)
 
-        const diff = createDiff(job, other)
+        const diff = diffCreatePatch(job, other)
         return llmifyDiff(diff)
     }
 

--- a/packages/core/src/gitignore.ts
+++ b/packages/core/src/gitignore.ts
@@ -45,9 +45,10 @@ export async function createGitIgnorer(): Promise<GitIgnorer> {
  * @returns An array of files that are not ignored according to the .gitignore patterns.
  */
 export async function filterGitIgnore(files: string[]) {
-    dbg("creating git ignorer")
     const ignorer = await createGitIgnorer()
-    return ignorer(files)
+    const newFiles = ignorer(files)
+    dbg(`files ${files.length} -> ${newFiles.length}`)
+    return newFiles
 }
 
 /**

--- a/packages/core/src/globals.ts
+++ b/packages/core/src/globals.ts
@@ -25,7 +25,7 @@ import { promptParametersSchemaToJSONSchema } from "./parameters"
 import { chunkMarkdown } from "./mdchunk"
 import { resolveGlobal } from "./global"
 import { MarkdownStringify } from "./markdown"
-import { diffCreatePatch, tryDiffParse } from "./diff"
+import { diffCreatePatch, diffFindChunk, tryDiffParse } from "./diff"
 
 /**
  * Installs global utilities for various data formats and operations.
@@ -164,6 +164,7 @@ export function installGlobals() {
     glb.diff = Object.freeze<Diff>({
         parse: tryDiffParse,
         createPatch: diffCreatePatch,
+        findChunk: diffFindChunk,
     })
 
     // these are overriden, ignored

--- a/packages/core/src/globals.ts
+++ b/packages/core/src/globals.ts
@@ -25,6 +25,7 @@ import { promptParametersSchemaToJSONSchema } from "./parameters"
 import { chunkMarkdown } from "./mdchunk"
 import { resolveGlobal } from "./global"
 import { MarkdownStringify } from "./markdown"
+import { diffCreatePatch, tryDiffParse } from "./diff"
 
 /**
  * Installs global utilities for various data formats and operations.
@@ -159,6 +160,11 @@ export function installGlobals() {
 
     // ffmpeg
     glb.ffmpeg = new FFmepgClient()
+
+    glb.diff = Object.freeze<Diff>({
+        parse: tryDiffParse,
+        createPatch: diffCreatePatch,
+    })
 
     // these are overriden, ignored
     glb.script = () => {}

--- a/packages/core/src/globals.ts
+++ b/packages/core/src/globals.ts
@@ -161,7 +161,7 @@ export function installGlobals() {
     // ffmpeg
     glb.ffmpeg = new FFmepgClient()
 
-    glb.diff = Object.freeze<Diff>({
+    glb.DIFF = Object.freeze<DIFF>({
         parse: tryDiffParse,
         createPatch: diffCreatePatch,
         findChunk: diffFindChunk,

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -203,7 +203,7 @@ export interface RuntimeHost extends Host {
      * Instantiates a python evaluation environment
      */
     python(
-        options?: PythonRuntimeOptions & TraceOptions
+        options?: PythonRuntimeOptions & TraceOptions & CancellationOptions
     ): Promise<PythonRuntime>
 
     /**

--- a/packages/core/src/liner.ts
+++ b/packages/core/src/liner.ts
@@ -1,8 +1,9 @@
 // This module provides functions to add and remove line numbers from text.
 // It includes special handling for "diff" formatted text.
 
-import { llmifyDiff, tryParseDiff } from "./llmdiff"
+import { llmifyDiff } from "./llmdiff"
 import { MIN_LINE_NUMBER_LENGTH } from "./constants"
+import { tryDiffParse } from "./diff"
 
 /**
  * Adds 1-based line numbers to each line of the input text.
@@ -19,7 +20,7 @@ export function addLineNumbers(
     options?: { language?: string; startLine?: number }
 ) {
     const { language, startLine = 1 } = options || {}
-    if (language === "diff" || tryParseDiff(text)) {
+    if (language === "diff" || tryDiffParse(text)) {
         const diffed = llmifyDiff(text) // Process the text with a special function for diffs
         if (diffed !== undefined) return diffed // Return processed text if diff handling was successful
     }

--- a/packages/core/src/llmdiff.test.ts
+++ b/packages/core/src/llmdiff.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from "node:test"
 import assert from "node:assert/strict"
-import { createDiff, parseLLMDiffs } from "./llmdiff"
+import { parseLLMDiffs } from "./llmdiff"
+import { diffCreatePatch } from "./diff"
 
 describe("llmdiff", () => {
     test("is_valid_email", () => {
@@ -296,7 +297,7 @@ test("createDiff with context", () => {
         filename: "file1.txt",
         content: "line1\nline2\nline3\nline4 modified\nline5\n",
     }
-    const diff = createDiff(left, right, { context: 2 })
+    const diff = diffCreatePatch(left, right, { context: 2 })
     assert(diff.includes("@@ -2,4 +2,4 @@"))
     assert(diff.includes("-line4"))
     assert(diff.includes("+line4 modified"))
@@ -311,7 +312,7 @@ test("createDiff without context", () => {
         filename: "file1.txt",
         content: "line1\nline2\nline3\nline4 modified\nline5\n",
     }
-    const diff = createDiff(left, right)
+    const diff = diffCreatePatch(left, right)
     console.log(diff)
     assert(diff.includes("@@ -1,5 +1,5 @@"))
     assert(diff.includes("-line4"))

--- a/packages/core/src/parsers.ts
+++ b/packages/core/src/parsers.ts
@@ -29,7 +29,7 @@ import { resolveFileContent } from "./file"
 import { resolveTokenEncoder } from "./encoders"
 import { mustacheRender } from "./mustache"
 import { jinjaRender } from "./jinja"
-import { createDiff, llmifyDiff } from "./llmdiff"
+import { llmifyDiff } from "./llmdiff"
 import { tidyData } from "./tidy"
 import { hash } from "./crypto"
 import { GROQEvaluate } from "./groq"
@@ -38,6 +38,7 @@ import { CancellationOptions } from "./cancellation"
 import { dedent } from "./indent"
 import { vttSrtParse } from "./transcription"
 import { encodeIDs } from "./cleaners"
+import { diffCreatePatch } from "./diff"
 
 /**
  * Asynchronously creates a set of parsers for handling various file formats, data operations,
@@ -173,7 +174,7 @@ export async function createParsers(
             const f = filenameOrFileToContent(file)
             return jinjaRender(f, data)
         },
-        diff: (f1, f2) => llmifyDiff(createDiff(f1, f2)),
+        diff: (f1, f2) => llmifyDiff(diffCreatePatch(f1, f2)),
         tidyData: (rows, options) => tidyData(rows, options),
         hash: async (text, options) => await hash(text, options),
         unfence: unfence,

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -341,6 +341,7 @@ export async function createPromptContext(
                 changeset: astGrepCreateChangeSet,
                 search: (lang, glob, matcher) =>
                     astGrepFindFiles(lang, glob, matcher, {
+                        ...(options || {}),
                         cancellationToken,
                     }),
                 parse: (file, options) =>

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -31,7 +31,11 @@ import { fileWriteCached } from "./filecache"
 import { join } from "node:path"
 import { createMicrosoftTeamsChannelClient } from "./teams"
 import { dotGenaiscriptPath } from "./workdir"
-import { astGrepFindFiles, astGrepParse } from "./astgrep"
+import {
+    astGrepCreateChangeSet,
+    astGrepFindFiles,
+    astGrepParse,
+} from "./astgrep"
 
 const dbg = debug("genaiscript:promptcontext")
 
@@ -334,6 +338,7 @@ export async function createPromptContext(
         teamsChannel: async (url) => createMicrosoftTeamsChannelClient(url),
         astGrep: async () =>
             Object.freeze<Sg>({
+                changeset: astGrepCreateChangeSet,
                 search: (lang, glob, matcher) =>
                     astGrepFindFiles(lang, glob, matcher, {
                         cancellationToken,

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -333,20 +333,24 @@ export async function createPromptContext(
             await runtimeHost.contentSafety(id || options?.contentSafety, {
                 trace,
             }),
-        python: async (options) =>
-            await runtimeHost.python({ trace, ...(options || {}) }),
+        python: async (pyOptions) =>
+            await runtimeHost.python({
+                trace,
+                cancellationToken,
+                ...(pyOptions || {}),
+            }),
         teamsChannel: async (url) => createMicrosoftTeamsChannelClient(url),
         astGrep: async () =>
             Object.freeze<Sg>({
                 changeset: astGrepCreateChangeSet,
-                search: (lang, glob, matcher) =>
+                search: (lang, glob, matcher, sgOptions) =>
                     astGrepFindFiles(lang, glob, matcher, {
-                        ...(options || {}),
+                        ...(sgOptions || {}),
                         cancellationToken,
                     }),
-                parse: (file, options) =>
+                parse: (file, sgOptions) =>
                     astGrepParse(file, {
-                        ...(options || {}),
+                        ...(sgOptions || {}),
                         cancellationToken,
                     }),
             }),

--- a/packages/core/src/promptdom.ts
+++ b/packages/core/src/promptdom.ts
@@ -37,7 +37,7 @@ import { ChatCompletionMessageParam } from "./chattypes"
 import { resolveTokenEncoder } from "./encoders"
 import { expandFileOrWorkspaceFiles } from "./fs"
 import { interpolateVariables } from "./mustache"
-import { createDiff } from "./llmdiff"
+import { diffCreatePatch } from "./diff"
 import { promptyParse } from "./prompty"
 import { jinjaRenderChatMessage } from "./jinja"
 import { runtimeHost } from "./host"
@@ -295,7 +295,7 @@ export function createDefDiff(
         const l = await renderFileContent(left, options)
         await resolveFileContent(right, options)
         const r = await renderFileContent(right, options)
-        return { filename: "", content: createDiff(l, r) }
+        return { filename: "", content: diffCreatePatch(l, r) }
     }
     const value = render()
     return { type: "def", name, value, ...(options || {}) }

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -27,7 +27,7 @@ import { parseTraceTree, TraceTree } from "./traceparser"
 import { fileCacheImage, fileWriteCached } from "./filecache"
 import { CancellationOptions } from "./cancellation"
 import { generateId } from "./id"
-import { createDiff } from "./llmdiff"
+import { diffCreatePatch } from "./diff"
 import { prettyBytes } from "./pretty"
 
 export class TraceChunkEvent extends Event {
@@ -125,7 +125,7 @@ export class MarkdownTrace extends EventTarget implements OutputTrace {
         right: string | WorkspaceFile,
         options?: { context?: number }
     ) {
-        const d = createDiff(left, right, options)
+        const d = diffCreatePatch(left, right, options)
         this.fence(d, "diff")
     }
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -2407,9 +2407,9 @@ interface Parsers {
 
 interface YAML {
     /**
-    * Parses a YAML string into a JavaScript object using JSON5.
-      */
-    (strings: TemplateStringsArray, ...values: any[]): any;
+     * Parses a YAML string into a JavaScript object using JSON5.
+     */
+    (strings: TemplateStringsArray, ...values: any[]): any
 
     /**
      * Converts an object to its YAML representation
@@ -2420,6 +2420,78 @@ interface YAML {
      * Parses a YAML string to object
      */
     parse(text: string | WorkspaceFile): any
+}
+
+interface DiffFile {
+    chunks: DiffChunk[]
+    deletions: number
+    additions: number
+    from?: string
+    to?: string
+    oldMode?: string
+    newMode?: string
+    index?: string[]
+    deleted?: true
+    new?: true
+}
+
+interface DiffChunk {
+    content: string
+    changes: Change[]
+    oldStart: number
+    oldLines: number
+    newStart: number
+    newLines: number
+}
+
+interface DiffNormalChange {
+    type: "normal"
+    ln1: number
+    ln2: number
+    normal: true
+    content: string
+}
+
+interface DiffAddChange {
+    type: "add"
+    add: true
+    ln: number
+    content: string
+}
+
+interface DiffDeleteChange {
+    type: "del"
+    del: true
+    ln: number
+    content: string
+}
+
+type ChangeType = "normal" | "add" | "del"
+
+type Change = DiffNormalChange | DiffAddChange | DiffDeleteChange
+
+interface Diff {
+    /**
+     * Parses a diff string into a structured object
+     * @param input
+     */
+    parse(input: string): DiffFile[]
+
+    /**
+     * Creates a two file path
+     * @param left
+     * @param right
+     * @param options
+     */
+    createPatch(
+        left: string | WorkspaceFile,
+        right: string | WorkspaceFile,
+        options?: {
+            context?: number
+            ignoreCase?: boolean
+            ignoreWhitespace?: boolean
+        }
+    ): string
 }
 
 interface XML {
@@ -4206,7 +4278,9 @@ interface SgRoot {
     filename(): string
 }
 
-type SgLang = OptionsOrString<"html" | "js" | "ts" | "tsx" | "css" | "c" | "sql">
+type SgLang = OptionsOrString<
+    "html" | "js" | "ts" | "tsx" | "css" | "c" | "sql"
+>
 
 interface Sg {
     parse(file: WorkspaceFile, options: { lang?: SgLang }): Promise<SgRoot>

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -4279,10 +4279,11 @@ interface SgRoot {
 }
 
 type SgLang = OptionsOrString<
-    "html" | "js" | "ts" | "tsx" | "css" | "c" | "sql"
+    "html" | "js" | "ts" | "tsx" | "css" | "c" | "sql" | "angular"
 >
 
 interface SgChangeSet {
+    count: number
     replace(node: SgNode, text: string): SgEdit
     commitEdits(): WorkspaceFile[]
 }

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -2470,7 +2470,7 @@ type DiffChangeType = "normal" | "add" | "del"
 
 type DiffChange = DiffNormalChange | DiffAddChange | DiffDeleteChange
 
-interface Diff {
+interface DIFF {
     /**
      * Parses a diff string into a structured object
      * @param input
@@ -2485,7 +2485,7 @@ interface Diff {
      */
     findChunk(
         file: string,
-        line: number,
+        line: ElementOrArray<number>,
         diff: ElementOrArray<DiffFile>
     ): { file?: DiffFile; chunk?: DiffChunk } | undefined
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -2437,7 +2437,7 @@ interface DiffFile {
 
 interface DiffChunk {
     content: string
-    changes: Change[]
+    changes: DiffChange[]
     oldStart: number
     oldLines: number
     newStart: number
@@ -2466,9 +2466,9 @@ interface DiffDeleteChange {
     content: string
 }
 
-type ChangeType = "normal" | "add" | "del"
+type DiffChangeType = "normal" | "add" | "del"
 
-type Change = DiffNormalChange | DiffAddChange | DiffDeleteChange
+type DiffChange = DiffNormalChange | DiffAddChange | DiffDeleteChange
 
 interface Diff {
     /**

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -2478,6 +2478,18 @@ interface Diff {
     parse(input: string): DiffFile[]
 
     /**
+     * Given a filename and line number (0-based), finds the chunk in the diff
+     * @param file
+     * @param line
+     * @param diff
+     */
+    findChunk(
+        file: string,
+        line: number,
+        diff: ElementOrArray<DiffFile>
+    ): { file?: DiffFile; chunk?: DiffChunk } | undefined
+
+    /**
      * Creates a two file path
      * @param left
      * @param right

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -4282,7 +4282,16 @@ type SgLang = OptionsOrString<
     "html" | "js" | "ts" | "tsx" | "css" | "c" | "sql"
 >
 
+interface SgChangeSet {
+    replace(node: SgNode, text: string): SgEdit
+    commitEdits(): WorkspaceFile[]
+}
+
 interface Sg {
+    /**
+     * Create a change set
+     */
+    changeset(): SgChangeSet
     parse(file: WorkspaceFile, options: { lang?: SgLang }): Promise<SgRoot>
     search(
         lang: SgLang,
@@ -4297,16 +4306,6 @@ interface Sg {
          * Each individual file matches as a node
          */
         matches: SgNode[]
-        /**
-         * Queues an edit that replaces the node text with the provided text.
-         * The node must be part of the matches array.
-         */
-        replace: (node: SgNode, text: string) => SgEdit
-        /**
-         * Applies all the edits queued by the replace method and returns the updated files.
-         * Use `workspace.writeFiles` to save the changes to the workspace.
-         */
-        commitEdits: () => Promise<WorkspaceFile[]>
     }>
 }
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -4309,7 +4309,8 @@ interface Sg {
     search(
         lang: SgLang,
         glob: ElementOrArray<string>,
-        matcher: string | SgMatcher
+        matcher: string | SgMatcher,
+        options?: FindFilesOptions
     ): Promise<{
         /**
          * Number of files found

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -4297,7 +4297,7 @@ type SgLang = OptionsOrString<
 interface SgChangeSet {
     count: number
     replace(node: SgNode, text: string): SgEdit
-    commitEdits(): WorkspaceFile[]
+    commit(): WorkspaceFile[]
 }
 
 interface Sg {

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -212,7 +212,7 @@ declare var JSONSchema: JSONSchemaUtilities
 /**
  * Diff utilities
  */
-declare var diff: Diff
+declare var DIFF: DIFF
 
 /**
  * Access to current LLM chat session information

--- a/packages/core/src/types/prompt_type.d.ts
+++ b/packages/core/src/types/prompt_type.d.ts
@@ -210,6 +210,11 @@ declare var JSON5: JSON5
 declare var JSONSchema: JSONSchemaUtilities
 
 /**
+ * Diff utilities
+ */
+declare var diff: Diff
+
+/**
  * Access to current LLM chat session information
  */
 declare var host: PromptHost
@@ -357,4 +362,3 @@ declare function generateImage(
     prompt: string,
     options?: ImageGenerationOptions
 ): Promise<{ image: WorkspaceFile; revisedPrompt?: string }>
-

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -6,7 +6,6 @@
 
 import { parse, stringify } from "yaml"
 import { filenameOrFileToContent } from "./unwrappers"
-import { JSON5parse } from "./json5"
 import { dedent } from "./indent"
 
 /**

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -69,6 +69,15 @@ export function YAMLStringify(obj: any): string {
     return stringify(obj, undefined, 2)
 }
 
+/**
+ * Creates a YAML handler with template string support for parsing and stringifying YAML content.
+ * Combines the functionality to parse YAML strings, stringify objects to YAML,
+ * and process template string inputs into parsed YAML objects.
+ *
+ * @param strings - An array of template string literals.
+ * @param values - Corresponding interpolated values.
+ * @returns A parsed object generated from the combined template strings and values.
+ */
 export function createYAML(): YAML {
     const res = (strings: TemplateStringsArray, ...values: any[]): any => {
         let result = strings[0]

--- a/packages/sample/genaisrc/astgrep.genai.mjs
+++ b/packages/sample/genaisrc/astgrep.genai.mjs
@@ -13,11 +13,7 @@ for (const match of matches) {
     if (!t.includes("console.log")) throw new Error("console.log found")
 }
 
-const {
-    matches: matches2,
-    replace,
-    commitEdits,
-} = await sg.search("ts", "src/fib.ts", {
+const { matches: matches2 } = await sg.search("ts", "src/fib.ts", {
     rule: {
         kind: "function_declaration",
         not: {
@@ -29,6 +25,7 @@ const {
     },
 })
 if (matches2.length !== 1) throw new Error("No matches found")
+const cs = sg.changeset()
 for (const match of matches2) {
     console.log(match.getRoot().filename() + " " + match.text())
     const fn = match.parent()
@@ -41,9 +38,9 @@ for (const match of matches2) {
         },
         { model: "small", responseType: "text" }
     )
-    replace(match, `/**\n* ${res.text}\n**/\n${match.text()}`)
+    cs.replace(match, `/**\n* ${res.text}\n**/\n${match.text()}`)
 }
-const modified = await commitEdits()
+const modified = cs.commitEdits()
 console.log(modified)
 //await workspace.writeFiles(files)
 

--- a/packages/sample/genaisrc/astgrep.genai.mjs
+++ b/packages/sample/genaisrc/astgrep.genai.mjs
@@ -40,8 +40,8 @@ for (const match of matches2) {
     )
     cs.replace(match, `/**\n* ${res.text}\n**/\n${match.text()}`)
 }
-const modified = cs.commitEdits()
-console.log(modified)
+const modifiedFiles = cs.commit()
+console.log(modifiedFiles)
 //await workspace.writeFiles(files)
 
 const { matches: cmatches } = await sg.search(

--- a/packages/sample/genaisrc/docify.genai.mts
+++ b/packages/sample/genaisrc/docify.genai.mts
@@ -1,17 +1,49 @@
-script({    
-    tools: ["agent"],
+script({
+    tools: ["md_find_files", "fs_read_file"],
+    parameters: {
+        api: {
+            type: "string",
+            description: "The API to document.",
+            required: true,
+        },
+    },
 })
+const { dbg } = env
+const { api } = env.vars
+if (!api) cancel("missing 'api' parameter")
+dbg(`api: ${api}`)
 
-const api = env.vars.api + ""
+const sg = await host.astGrep()
+const { matches } = await sg.search(
+    "ts",
+    ".genaiscript/genaiscript.d.ts",
+    YAML`
+rule:
+  inside:
+    kind: interface_declaration
+  kind: type_identifier  
+  regex: ^${api}$
+`,
+    { applyGitIgnore: false }
+)
+dbg(`found ${matches.length} matches for ${api}`)
+if (!matches?.length) cancel(`no matches found for ${api}`)
 
 $`You are an expert technical writer for the GenAIScript language.
 
 ## Task
 
 Generate a documentation page about the ${api}.
-Save to file in the docs/src/content/docs/reference/scripts folder.
+Save to file in the docs/src/content/docs/reference/scripts folder.`
 
-## Information
+if (matches?.length) {
+    $`## Code
+    
+    `
+    for (const match of matches) fence(match.text())
+}
+
+$`## Information
 
 - use markdown, with Astro Starlight syntax
 - the genaiscript type definition: genaisrc/genaiscript.d.ts. Assume that all globals are ambient. Do not import or require genaiscript module.
@@ -26,4 +58,7 @@ Save to file in the docs/src/content/docs/reference/scripts folder.
 - minimize changes to existing documentation
 `
 
-defFileOutput("docs/src/content/docs/reference/scripts/*.md", "Documentation pages")
+defFileOutput(
+    "docs/src/content/docs/reference/scripts/*.md",
+    "Documentation pages"
+)


### PR DESCRIPTION
Breaking change for cleaner sg apis

<!-- genaiscript begin pr-describe --><hr/>



Here's the high-level summary of the changes from the provided GIT_DIFF:

- **Imports**: Several files had their `import` statements filtered out or updated to `unfiltered`, such as:
  - `git <package>.git/diff` 🛠️
  - `git <package>.git/typelist` 🔧

- **Types**: The type `Change` was renamed to `ChangeType` in `prompt_type.d.ts`. ✅

- **Public API**:
  - In `prompt_diff.d.ts`, a new **private module diff** was created and exported as `publicDiff: @makeModule`. 🗣️
  - The function `generateImage()` now accepts an optional `ignoreWhitespace` parameter. 😊
  - Imports for JSON5 were added, indicated by the `@-import json5` macro. 💡

- **Code Structure**: Changes reflect better organization and encapsulation of functionality across files. 📦

These changes contribute to improved code modularity, type clarity, and maintainability.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/14076391664) may be incorrect



<!-- genaiscript end pr-describe -->

