### PR TITLE
Fix output.image in copilot chat

### DIFF
--- a/genaisrc/docs.genai.mts
+++ b/genaisrc/docs.genai.mts
@@ -4,6 +4,21 @@ import { prettier } from "./src/prettier.mts"
 
 script({
     title: "Generate TypeScript function documentation using AST insertion",
+    description: `
+## Docs!
+
+This script generates and updates TypeScript function using an AST/LLM hybrid approach.
+It uses ast-grep to look for undocumented and documented functions,
+then uses a combination of LLM, and LLM-as-a-judge to generate and validate the documentation.
+It also uses prettier to format the code before and after the generation.
+
+By default, 
+
+- no edits are applied on disk. It is recommended to 
+run this script with \`--vars 'applyEdits=true'\` to apply the edits.
+- if a diff is available, it will only process the files with changes.
+    
+    `,
     accept: ".ts",
     files: "src/cowsay.ts",
     parameters: {
@@ -17,7 +32,7 @@ script({
             type: "boolean",
             default: false,
             description:
-                "If true, the script will prettify the files efore analysis.",
+                "If true, the script will prettify the files before analysis.",
         },
         applyEdits: {
             type: "boolean",

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -217,6 +217,8 @@ export async function runScriptInternal(
 ): Promise<{ exitCode: number; result?: GenerationResult }> {
     const runId = options.runId || generateId()
     const runDir = options.out || getRunDir(scriptId, runId)
+    dbg(`run id: `, runId)
+    dbg(`run dir: `, runDir)
     const cancellationToken = options.cancellationToken
     const {
         trace = new MarkdownTrace({ cancellationToken, dir: runDir }),

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -491,6 +491,7 @@ export async function runScriptInternal(
         }
 
         result = await runTemplate(prj, script, fragment, {
+            runId,
             inner: false,
             infoCb: (args) => {
                 const { text } = args

--- a/packages/core/src/filecache.ts
+++ b/packages/core/src/filecache.ts
@@ -78,3 +78,12 @@ export async function fileCacheImage(
     dbg(`image: ${res}`)
     return res
 }
+
+export function patchCachedImages(
+    text: string,
+    patcher: (url: string) => string
+) {
+    const IMG_RX =
+        /\!\[(?<alt>[^\]]*)\]\((?<url>\.genaiscript\/images\/[^)]+)\)/g
+    return text.replace(IMG_RX, (_, alt, url) => `![${alt}](${patcher(url)})`)
+}

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -18,6 +18,7 @@ export interface GenerationOptions
         ContentSafetyOptions,
         ScriptRuntimeOptions {
     inner: boolean // Indicates if the process is an inner operation
+    runId?: string
     runDir?: string
     cancellationToken?: CancellationToken // Token to cancel the operation
     infoCb?: (partialResponse: { text: string }) => void // Callback for providing partial responses

--- a/packages/core/src/promptrunner.ts
+++ b/packages/core/src/promptrunner.ts
@@ -136,8 +136,15 @@ export async function runTemplate(
     assert(options !== undefined)
     assert(options.trace !== undefined)
     assert(options.outputTrace !== undefined)
-    const { label, cliInfo, trace, outputTrace, cancellationToken, model } =
-        options
+    const {
+        label,
+        cliInfo,
+        trace,
+        outputTrace,
+        cancellationToken,
+        model,
+        runId,
+    } = options
     const version = CORE_VERSION
     assert(model !== undefined)
 
@@ -206,6 +213,7 @@ export async function runTemplate(
                 frames: [],
                 schemas: {},
                 usage: undefined,
+                runId,
             } satisfies GenerationResult
         }
 
@@ -246,6 +254,7 @@ export async function runTemplate(
                 frames: [],
                 schemas: {},
                 usage: undefined,
+                runId,
             } satisfies GenerationResult)
         }
 
@@ -363,6 +372,7 @@ export async function runTemplate(
             perplexity: chatResult.perplexity,
             uncertainty: chatResult.uncertainty,
             usage: chatResult.usage,
+            runId,
         }
 
         // If there's an error, provide status text

--- a/packages/core/src/server/messages.ts
+++ b/packages/core/src/server/messages.ts
@@ -226,6 +226,10 @@ export type GenerationStatus = "success" | "error" | "cancelled" | undefined
 // Interface for the result of a generation process
 export interface GenerationResult extends GenerationOutput {
     /**
+     * Run identifier
+     */
+    runId: string
+    /**
      * The environment variables passed to the prompt
      */
     env: Partial<ExpansionVariables>

--- a/packages/sample/genaisrc/poem.genai.mts
+++ b/packages/sample/genaisrc/poem.genai.mts
@@ -1,1 +1,2 @@
-$`Write a short poem.`
+script({ model: "github_copilot_chat:gpt-4o" })
+$`Write a short poem in code.`

--- a/packages/sample/genaisrc/poem.genai.mts
+++ b/packages/sample/genaisrc/poem.genai.mts
@@ -1,2 +1,1 @@
-script({ model: "github_copilot_chat:gpt-4o" })
 $`Write a short poem in code.`

--- a/packages/vscode/src/chatparticipant.ts
+++ b/packages/vscode/src/chatparticipant.ts
@@ -12,7 +12,7 @@ import { deleteUndefinedValues } from "../../core/src/cleaners"
 import { templatesToQuickPickItems } from "./fragmentcommands"
 
 export async function activateChatParticipant(state: ExtensionState) {
-    const { context } = state
+    const { context, host } = state
     const { subscriptions } = context
 
     const resolveReference = (
@@ -160,7 +160,15 @@ export async function activateChatParticipant(state: ExtensionState) {
 
             const { text = "", status, statusText } = res || {}
             if (status !== "success") md("$(error) " + statusText)
-            if (text) md("\n\n" + convertAnnotationsToItems(text))
+            if (text) {
+                const { server } = host
+
+                let patched = convertAnnotationsToItems(text)
+                md("\n\n" + patched)
+                md(
+                    `![image](${server.authority}/.genaiscript/images/42e4c2d32c1123bede480fb06ed84c862d5134e204f7dc0be5f25ac1c2056ad3.jpg)`
+                )
+            }
             // TODO open url
         }
     )

--- a/packages/vscode/src/chatparticipant.ts
+++ b/packages/vscode/src/chatparticipant.ts
@@ -10,6 +10,7 @@ import { Fragment } from "../../core/src/generation"
 import { convertAnnotationsToItems } from "../../core/src/annotations"
 import { deleteUndefinedValues } from "../../core/src/cleaners"
 import { templatesToQuickPickItems } from "./fragmentcommands"
+import { patchCachedImages } from "../../core/src/filecache"
 
 export async function activateChatParticipant(state: ExtensionState) {
     const { context, host } = state
@@ -161,13 +162,12 @@ export async function activateChatParticipant(state: ExtensionState) {
             const { text = "", status, statusText } = res || {}
             if (status !== "success") md("$(error) " + statusText)
             if (text) {
-                const { server } = host
-
                 let patched = convertAnnotationsToItems(text)
-                md("\n\n" + patched)
-                md(
-                    `![image](${server.authority}/.genaiscript/images/42e4c2d32c1123bede480fb06ed84c862d5134e204f7dc0be5f25ac1c2056ad3.jpg)`
+                const dir = state.host.projectUri
+                patched = patchCachedImages(patched, (url) =>
+                    vscode.Uri.joinPath(dir, url).toString()
                 )
+                md("\n\n" + patched)
             }
             // TODO open url
         }

--- a/packages/vscode/src/servermanager.ts
+++ b/packages/vscode/src/servermanager.ts
@@ -91,7 +91,7 @@ export class TerminalServerManager
     }
 
     get authority() {
-        assert(!!this._port)
+        if (!this._port) return undefined
         return `${SERVER_LOCALHOST}:${this._port}`
     }
 

--- a/packages/vscode/src/statusbar.ts
+++ b/packages/vscode/src/statusbar.ts
@@ -30,9 +30,10 @@ export function activateStatusBar(state: ExtensionState) {
             }${tokensSoFar ? ` ${tokensSoFar} tokens` : ""}`
         )
 
+        const authority = server.authority
         const md = new vscode.MarkdownString(
             toMarkdownString(
-                status === "running"
+                authority && status === "running"
                     ? `server: [${server.authority}](${server.browserUrl})`
                     : `server: ${status}`,
                 fragment?.files?.[0],


### PR DESCRIPTION
Enhance the copilot chat functionality by adding a run identifier and improving the handling of output images. This change ensures that the output image is correctly referenced and displayed in the chat interface.

<!-- genaiscript begin pr-describe --><hr/>



**Changes Summary**

- **High-Level Changes**
  🛠️ Added `runId` as a unique identifier across multiple layers:
    - Internal functions
    - Generation options interface
    - Prompt template runner options
    - Generation result type
  
  📝 **Impact:**
    - Better tracking of specific runs in the system  
    - Improved debugging and monitoring with unique identifiers  
    - Consistent unique identifier usage throughout the codebase  

The changes enhance the system's ability to uniquely identify prompts and track their execution across different components, aiding in debugging, monitoring, and reproducibility. The example file demonstrates a clear task intent shift from poetry-based identification to direct code specification for clarity and precision.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/14137214381) may be incorrect



<!-- genaiscript end pr-describe -->

