### PR TITLE
adding annotations to exposed tools

### DIFF
--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -78,7 +78,14 @@ export async function startMcpServer(
         dbg(`fetching scripts from watcher`)
         const scripts = await watcher.scripts()
         const tools = scripts.map((script) => {
-            const { id, title, description, inputSchema, accept } = script
+            const {
+                id,
+                title,
+                description,
+                inputSchema,
+                accept,
+                annotations = {},
+            } = script
             const scriptSchema = (inputSchema?.properties
                 .script as JSONSchemaObject) || {
                 type: "object",
@@ -94,9 +101,13 @@ export async function startMcpServer(
                 }
             return {
                 name: id,
-                description: toStringList(title, description),
+                description,
                 inputSchema:
                     scriptSchema as ListToolsResult["tools"][0]["inputSchema"],
+                annotations: {
+                    ...annotations,
+                    title,
+                },
             } satisfies ListToolsResult["tools"][0]
         })
         dbg(`returning tool list with ${tools.length} tools`)

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -752,6 +752,31 @@ interface ModelTemplateOptions extends FenceFormatOptions {
     flexTokens?: number
 }
 
+interface McpToolAnnotations {
+    /**
+     * Annotations for MCP tools
+     * @link https://modelcontextprotocol.io/docs/concepts/tools#available-tool-annotations
+     */
+    annotations?: {
+        /**
+         * If true, indicates the tool does not modify its environment
+         */
+        readOnlyHint?: boolean
+        /**
+         * If true, the tool may perform destructive updates (only meaningful when readOnlyHint is false)
+         */
+        destructiveHint?: boolean
+        /**
+         * If true, calling the tool repeatedly with the same arguments has no additional effect (only meaningful when readOnlyHint is false)
+         */
+        idempotentHint?: boolean
+        /**
+         * If true, the tool may interact with an “open world” of external entities
+         */
+        openWorldHint?: boolean
+    }
+}
+
 interface PromptScript
     extends PromptLike,
         ModelOptions,
@@ -761,7 +786,8 @@ interface PromptScript
         ContentSafetyOptions,
         SecretDetectionOptions,
         GitIgnoreFilterOptions,
-        ScriptRuntimeOptions {
+        ScriptRuntimeOptions,
+        McpToolAnnotations {
     /**
      * Which provider to prefer when picking a model.
      */


### PR DESCRIPTION


<!-- genaiscript begin pr-describe --><hr/>



Here's a high-level summary of the changes in the provided Git Diff:

1. **In `mcpserver.ts`:**
   - **Added Annotations Handling:** The code now collects additional tool annotations (like ReadOnlyHint) when fetching available scripts from a watcher (`script.map`).
   - **Updated Tool Returning Logic:** The returned tool list now includes an `annotations` property populated with these new fields.
   - **Focus on MCP Server Functionality:** This change enhances how MCP tools are exposed and managed within the server context.

2. **In `prompt_template.d.ts`:**
   - **New Interface Introduced:** The `McpToolAnnotations` interface allows defining tool annotations that can be used by MCP public API endpoints.
   - **Enhanced Metadata Support:** Tools can now provide metadata (like OpenWorldHint) that may influence their behavior or detection in the context of MCP usage.

The changes are part of the MCP public API and likely aim to enhance tool interoperability, annotation handling, and detection within the framework.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/14461312028) may be incorrect



<!-- genaiscript end pr-describe -->

