### PR TITLE
Update file inclusion for genaisrc subfolders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -131,6 +131,7 @@
         "modelcontextprotocol",
         "modelid",
         "murl",
+        "mydoc",
         "nameid",
         "namevalue",
         "napi",

--- a/docs/src/content/docs/getting-started/your-first-genai-script.mdx
+++ b/docs/src/content/docs/getting-started/your-first-genai-script.mdx
@@ -1,26 +1,26 @@
 ---
 title: Your first GenAI script
 sidebar:
-  order: 3
+    order: 3
 description: Learn how to create and execute your initial GenAI script to
-  automate interactions with language models.
+    automate interactions with language models.
 keywords: GenAI script creation, language model automation, script execution,
-  LLM prompt generation, genaisrc setup
+    LLM prompt generation, genaisrc setup
 genaiscript:
-  files: src/samples/markdown.md
+    files: src/samples/markdown.md
 hero:
-  image:
-    alt: A clean, pixel-art style image shows a geometric file folder holding
-      several colored file icons, with one icon visibly highlighted as if
-      selected. Nearby are stylized shapes representing documents, a code
-      symbol, a prompt box displaying a sample poem line, and simple icons
-      including a pen and a check mark suggesting proofreading tools. Abstract
-      interface elements hint at creating prompts and running scripts. The
-      artwork uses flat blue, yellow, green, orange, and gray shapes on a plain
-      white background, without any shadows, people, or actual text. The
-      composition is simple and compact, fitting a small square format.
-    file: ./your-first-genai-script.png
-
+    image:
+        alt:
+            A clean, pixel-art style image shows a geometric file folder holding
+            several colored file icons, with one icon visibly highlighted as if
+            selected. Nearby are stylized shapes representing documents, a code
+            symbol, a prompt box displaying a sample poem line, and simple icons
+            including a pen and a check mark suggesting proofreading tools. Abstract
+            interface elements hint at creating prompts and running scripts. The
+            artwork uses flat blue, yellow, green, orange, and gray shapes on a plain
+            white background, without any shadows, people, or actual text. The
+            composition is simple and compact, fitting a small square format.
+        file: ./your-first-genai-script.png
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components"
@@ -30,7 +30,7 @@ import { Content as CreateScript } from "../../../components/CreateScript.mdx"
 import { YouTube } from "astro-embed"
 
 GenAIScript use stylized JavaScript with minimal syntax.
-They are stored as files (`genaisrc/*.genai.mjs` or `genaisrc/*.genai.mts`) in your project.
+They are stored as JavaScript files (`genaisrc/*.genai.mjs)` or TypeScript files (`genaisrc/*.genai.mts`) in your project.
 The execution of a genaiscript creates the prompt that will be sent to the LLM.
 
 <Steps>
@@ -48,8 +48,8 @@ The resulting file will be placed in the `genaisrc` folder in your project.
 - …
 - genaisrc scripts are created here by default
     - genaiscript.d.ts (TypeScript type definitions)
-    - jsconfig.json (TypeScript compiler configuration)
-    - **proofreader.genai.mjs**
+    - tsconfig.json (TypeScript compiler configuration)
+    - **proofreader.genai.mts**
     - …
 - …
 
@@ -75,7 +75,7 @@ that gets sent to the LLM model.
 The ` $``...`` ` template string function formats and write the string to the prompt;
 which gets sent to the LLM.
 
-```js title="poem.genai.mjs" system=false assistant=true
+```js title="poem.genai.mts" system=false assistant=true
 $`Write a one sentence poem.`
 ```
 
@@ -109,7 +109,7 @@ GenAIScript exposes the context through the `env` variable. The context is impli
 - you can right click on or in a file and the `env.files` will contain only that file.
 - you can run the script using the [command line interface](/genaiscript/reference/cli) and specify content of `env.files` in the CLI arguments.
 
-```js title="proofreader.genai.mjs" system=false assistant=false user=true
+```js title="proofreader.genai.mts" system=false assistant=false user=true
 def("FILES", env.files)
 ```
 
@@ -147,7 +147,7 @@ For example, to denote a heading, you add a number sign before it (e.g., # Headi
 The `$` function is used to build the prompt text, it renders and writes the text to the prompt
 (`$` is a [template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)).
 
-```js title="proofreader.genai.mjs"
+```js title="proofreader.genai.mts"
 def("FILES", env.files)
 $`You are an expert technical writer and proofreader.
 Review the documents in FILE and report the 2 most important issues.`
@@ -205,7 +205,7 @@ These are the two most important issues that need to be addressed in the documen
 You can add a call to the `script` function to provides metadata about the script
 and the model. The metadata is used to display the script in the UI and configure the LLM model.
 
-```js title="proofreader.genai.mjs"
+```js title="proofreader.genai.mts"
 // the metadata
 script({
     // user interface

--- a/docs/src/content/docs/reference/scripts/typescript.md
+++ b/docs/src/content/docs/reference/scripts/typescript.md
@@ -1,20 +1,20 @@
 ---
 title: TypeScript
 sidebar:
-  order: 15
+    order: 15
 description: Learn how to use TypeScript for better tooling and scalability in
-  your GenAIScript projects.
+    your GenAIScript projects.
 keywords: TypeScript, JavaScript, ESM, dynamic imports, type checking
 hero:
-  image:
-    alt: 'A simple 8-bit style image shows a blue file icon marked ".mts" linked
-      with dotted lines to two other file icons: a dark gray one representing
-      JavaScript and a light gray one for TypeScript. All icons are arranged on
-      a plain white background with a geometric arrow indicating import, using
-      blue, gray, black, white, and yellow. The design is flat, highly
-      simplified, without people or text, and measures 128 by 128 pixels.'
-    file: ./typescript.png
-
+    image:
+        alt:
+            'A simple 8-bit style image shows a blue file icon marked ".mts" linked
+            with dotted lines to two other file icons: a dark gray one representing
+            JavaScript and a light gray one for TypeScript. All icons are arranged on
+            a plain white background with a geometric arrow indicating import, using
+            blue, gray, black, white, and yellow. The design is flat, highly
+            simplified, without people or text, and measures 128 by 128 pixels.'
+        file: ./typescript.png
 ---
 
 [TypeScript](https://www.typescriptlang.org/) is a strongly typed programming language that builds on JavaScript, giving you better tooling at any scale. GenAIScript scripts can be authored in TypeScript.
@@ -36,8 +36,7 @@ Make sure to use the **`.mts`** file extension - not `.ts` -, which forces Node.
 
 ## Importing TypeScript source files
 
-It is possible to [import](/genaiscript/reference/scripts/imports) TypeScript source file
-using **dynamic** imports.
+It is possible to [import](/genaiscript/reference/scripts/imports) TypeScript source file.
 
 ```js title="summarizer.mts"
 export function summarize(files: string[]) {
@@ -46,18 +45,24 @@ export function summarize(files: string[]) {
 }
 ```
 
--   dynamic import (`async import(...)`)
+- import
 
 ```js
-const { summarize } = await import("./summarizer.mts")
+import { summarize } from "./summarizer.mts"
 summarize(env.generator, env.files)
 ```
 
 ## Does GenAIScript type-check prompts?
 
-No.
-
-GenAIScript converts TypeScript to JavaScript **without type checks** through [tsx](https://tsx.is/usage#no-type-checking).
+Yes and No.
 
 Most modern editors, like Visual Studio Code, will automatically
 type-check TypeScript sources.
+
+You can also run a TypeScript compilation using the `scripts compile` command.
+
+```sh
+genaiscript scripts compile
+```
+
+However, at runtime, GenAIScript converts TypeScript to JavaScript **without type checks** through [tsx](https://tsx.is/usage#no-type-checking).

--- a/packages/core/bundleprompts.js
+++ b/packages/core/bundleprompts.js
@@ -97,7 +97,7 @@ async function main() {
                     resolveJsonModule: true,
                     erasableSyntaxOnly: true,
                 },
-                include: ["*.mjs", "*.mts", "src/*.mts", "./genaiscript.d.ts"],
+                include: ["**/*.mjs", "**/*.mts", "./genaiscript.d.ts"],
             },
             null,
             4


### PR DESCRIPTION
Adjust the TypeScript configuration to include files from subfolders within the `genaisrc` directory, reducing clutter by preventing the creation of helper files in subfolders.

Fixes #1360

<!-- genaiscript begin pr-describe --><hr/>



Here's a high-level summary of the changes:

- **Modified Include Paths**: Changed from `*.mjs`, `*.mts`, and `src/*.mts` to `**/*.mjs`, `**/*.mts`. The wildcard syntax now uses `**` which might mean broader path coverage or improved naming consistency
- **Added genaiscript.d.ts File**: Added this file directly in the include list. This likely means it's necessary for some functionality

The changes appear intentional, possibly improving documentation support or file inclusion logic while maintaining a clean codebase structure.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/14564835120) may be incorrect



<!-- genaiscript end pr-describe -->

