### PR TITLE
Enhance file extension support in writeCached functionality

### DIFF
--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -261,7 +261,7 @@ export function dataUriToBuffer(filename: string) {
  */
 export async function resolveFileBytes(
     filename: string | WorkspaceFile,
-    options?: TraceOptions
+    options?: TraceOptions & CancellationOptions
 ): Promise<Uint8Array> {
     if (typeof filename === "object") {
         if (filename.encoding && filename.content) {

--- a/packages/core/src/filecache.test.ts
+++ b/packages/core/src/filecache.test.ts
@@ -3,8 +3,14 @@ import test, { beforeEach, describe } from "node:test"
 import { dirname, join } from "node:path"
 import { stat, readdir, rm } from "fs/promises"
 import { existsSync } from "fs"
-import { fileWriteCached } from "./filecache"
+import {
+    fileCacheImage,
+    fileWriteCached,
+    fileWriteCachedJSON,
+    patchCachedImages,
+} from "./filecache"
 import { TestHost } from "./testhost"
+import { readFile } from "node:fs/promises"
 
 describe("fileWriteCached", () => {
     const tempDir = join(dirname(__filename), "temp")
@@ -28,5 +34,46 @@ describe("fileWriteCached", () => {
         assert(stats.isFile())
 
         assert.equal(filePath, writtenFile)
+    })
+    test("should write JSON to cache and return correct filename", async () => {
+        const testData = { test: "content" }
+        const filePath = await fileWriteCachedJSON(tempDir, testData)
+
+        const files = await readdir(tempDir)
+        assert.equal(files.length, 1)
+        const writtenFile = join(tempDir, files[0])
+
+        const stats = await stat(writtenFile)
+        assert(stats.isFile())
+        assert.equal(filePath, writtenFile)
+
+        const content = JSON.parse(await readFile(writtenFile, "utf-8"))
+        assert.deepEqual(content, testData)
+    })
+
+    test("fileCacheImage should return empty string for falsy input", async () => {
+        assert.equal(await fileCacheImage(""), "")
+        assert.equal(await fileCacheImage(null), "")
+        assert.equal(await fileCacheImage(undefined), "")
+    })
+
+    test("fileCacheImage should return URL unchanged when input is HTTPS URL", async () => {
+        const url = "https://example.com/image.jpg"
+        assert.equal(await fileCacheImage(url), url)
+    })
+
+    test("fileCacheImage should cache local image and return relative path", async () => {
+        const imageBuffer = Buffer.from("fake image data")
+        const result = await fileCacheImage(imageBuffer, { dir: tempDir })
+
+        assert(result.startsWith("./"))
+        const files = await readdir(tempDir)
+        assert.equal(files.length, 1)
+    })
+
+    test("patchCachedImages should replace image paths", () => {
+        const input = "![alt](.genaiscript/images/test.jpg)"
+        const output = patchCachedImages(input, (url) => "newpath/" + url)
+        assert.equal(output, "![alt](newpath/.genaiscript/images/test.jpg)")
     })
 })

--- a/packages/core/src/filecache.ts
+++ b/packages/core/src/filecache.ts
@@ -1,5 +1,4 @@
-import { fileTypeFromBuffer } from "./filetype"
-import { resolveBufferLike } from "./bufferlike"
+import { resolveBufferLikeAndExt } from "./bufferlike"
 import { hash } from "./crypto"
 import { TraceOptions } from "./trace"
 import { basename, dirname, join, relative } from "node:path"
@@ -27,23 +26,31 @@ const dbg = debug("genaiscript:filecache")
 export async function fileWriteCached(
     dir: string,
     bufferLike: BufferLike,
-    options?: TraceOptions & CancellationOptions
+    options?: TraceOptions &
+        CancellationOptions & {
+            /**
+             * Generate file name extension
+             */
+            ext?: string
+        }
 ): Promise<string> {
-    const { cancellationToken } = options || {}
-    const bytes = await resolveBufferLike(bufferLike, options)
-    checkCancelled(cancellationToken)
-    const { ext } = (await fileTypeFromBuffer(bytes)) || { ext: "bin" }
+    const { bytes, ext: sourceExt } = await resolveBufferLikeAndExt(
+        bufferLike,
+        options
+    )
+    const { cancellationToken, ext = sourceExt } = options || {}
     checkCancelled(cancellationToken)
     const filename = await hash(bytes, { length: FILE_HASH_LENGTH })
     checkCancelled(cancellationToken)
-    const f = filename + "." + ext
+    const f = filename + "." + ext.replace(/^\./, "")
     const fn = join(dir, f)
-    try {
-        const r = await stat(fn)
-        if (r.isFile()) return fn
-    } catch {}
+    const r = await tryStat(fn)
+    if (r?.isFile()) {
+        dbg(`hit %s`, fn)
+        return fn
+    }
 
-    dbg(`image cache: ${fn} (${prettyBytes(bytes.length)})`)
+    dbg(`miss %s`, fn)
     await ensureDir(dirname(fn))
     await writeFile(fn, bytes)
 

--- a/packages/core/src/promptcontext.ts
+++ b/packages/core/src/promptcontext.ts
@@ -93,7 +93,11 @@ export async function createPromptContext(
                 scope === "run"
                     ? join(runDir, "files")
                     : dotGenaiscriptPath("cache", "files")
-            return await fileWriteCached(dir, f)
+            return await fileWriteCached(dir, f, {
+                ...(options || {}),
+                cancellationToken,
+                trace,
+            })
         },
         copyFile: (src, dest) => runtimeHost.workspace.copyFile(src, dest),
         cache: (n) => runtimeHost.workspace.cache(n),

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1348,7 +1348,11 @@ interface WorkspaceFileSystem {
      */
     writeCached(
         bytes: BufferLike,
-        options?: { scope?: "workspace" | "run" }
+        options?: { scope?: "workspace" | "run", 
+            /**
+             * Filename extension
+             */
+            ext?: string }
     ): Promise<string>
 
     /**


### PR DESCRIPTION
Improve handling of various file extensions in the writeCached function by introducing a new method to resolve buffer-like objects and their extensions. This change allows for better detection and assignment of file types based on the provided input.

<!-- genaiscript begin pr-describe --><hr/>

- ✨ **Enhanced buffer handling**: Introduced a new utility `resolveBufferLikeAndExt` to determine both the buffer bytes and an appropriate file extension in a single call.  
- 🛠 **Improved filename extension resolution**: Added logic to better infer file extensions from buffer-like inputs, filenames, or fallback defaults (`.txt` or `.bin`).  
- 🚀 **Optimized caching implementation**: Updated `fileWriteCached` to rely on the new utility (`resolveBufferLikeAndExt`) for more consistent and extensible file extension handling, with fallback extension overrides via new options.  
- 🔧 **User-facing API update**: Extended the `writeCached` method in `WorkspaceFileSystem` to accept an optional `ext` parameter for custom file extensions.  
- ⚡ **Performance improvement**: Ensured better cache hit/miss logging and fallback behavior by reorganizing checks and leveraging utility functions like `tryStat`.  
- ✅ **Extended cancellation support**: Broadened the `resolveFileBytes` method’s options to include `CancellationOptions`.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/14776629159) may be incorrect. Use reactions to eval.



<!-- genaiscript end pr-describe -->



<!-- genaiscript begin prd-sketch --><hr/>



![sketch](https://raw.githubusercontent.com/microsoft/genaiscript/refs/heads/genai-assets/f4451b0ce6d8f1813a9699d3f0e5c649be93df0ce1b3211829e4dbf133fbcd24.jpg)



> AI-generated content by prd-sketch may be incorrect. Use reactions to eval.



<!-- genaiscript end prd-sketch -->

