### PR TITLE
✨ feat: add paragraph utility and package overrides

### DIFF
--- a/genaisrc/docs.genai.mts
+++ b/genaisrc/docs.genai.mts
@@ -121,6 +121,7 @@ for (const file of files) {
             judgeCost: 0,
             edits: 0,
             updated: 0,
+            nits: 0,
         })
         await generateDocs(file, stats.at(-1))
     }
@@ -213,6 +214,7 @@ async function generateDocs(file: WorkspaceFile, fileStats: any) {
         const updated = `${docs}\n${missingDoc.text()}`
         edits.replace(missingDoc, updated)
         fileStats.edits++
+        fileStats.nits++
     }
 
     // apply all edits and write to the file

--- a/genaisrc/docs.genai.mts
+++ b/genaisrc/docs.genai.mts
@@ -311,7 +311,7 @@ rule:
             },
             {
                 APPLY: "The <NEW_DOCS> is a significant improvement to <ORIGINAL_DOCS>.",
-                NIT: "The <NEW_DOCS> contains nits (minor adjustments) to <ORIGINAL_DOCS>.",
+                NIT: "The <NEW_DOCS> contains nitpicks (minor adjustments) to <ORIGINAL_DOCS>.",
             },
             {
                 model: "large",

--- a/genaisrc/docs.genai.mts
+++ b/genaisrc/docs.genai.mts
@@ -69,7 +69,7 @@ if (!applyEdits)
 
 // filter by diff
 const gitDiff = diff ? await git.diff({ base: "dev" }) : undefined
-output.fence(gitDiff)
+dbg(`diff: %s`, gitDiff)
 const diffFiles = gitDiff ? DIFF.parse(gitDiff) : undefined
 if (diff && !diffFiles?.length) cancel(`no diff files found, exiting...`)
 if (diffFiles?.length) {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
         "prd": "node packages/cli/built/genaiscript.cjs run prd -prd --model github:gpt-4.1 --vars base=dev",
         "prd:visuals": "node packages/cli/built/genaiscript.cjs run prd-visuals -prd --model github:gpt-4.1 --vars base=dev",
         "prd:zine": "node packages/cli/built/genaiscript.cjs run prd-zine -prd --model github:gpt-4.1 --vars base=dev",
+        "prd:meme": "node packages/cli/built/genaiscript.cjs run prd-meme -prd --model github:gpt-4.1 --vars base=dev",
         "prd:sketch": "node packages/cli/built/genaiscript.cjs run prd-sketch -prd --model github:gpt-4.1 --vars base=dev",
         "prd:narration": "node packages/cli/built/genaiscript.cjs run prd-narration -prd --model github:gpt-4.1 --vars base=dev",
         "prd:dev": "node packages/cli/built/genaiscript.cjs run prd -prd --model azure:gpt-4.1_2025-04-14 --vars maxTokens=500000",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,10 @@
   ],
   "description": "A CLI for GenAIScript, a generative AI scripting framework.",
   "license": "MIT",
+  "overrides": {
+    "glob": "^11.0.2",
+    "@mapbox/node-pre-gyp": "^2.0.0"   
+  },
   "resolutions": {
     "glob": "^11.0.2",
     "@mapbox/node-pre-gyp": "^2.0.0"

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -251,7 +251,13 @@ ${this.toResultIcon(success, "")}${title}
     }
 
     item(message: string) {
+        if (!message) return
         this.appendContent(`-   ${message}\n`)
+    }
+
+    p(text: string) {
+        if (!text) return
+        this.appendContent(`\n\n${text}\n\n`)
     }
 
     itemLink(name: string, url?: string | URL, title?: string) {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -1037,6 +1037,12 @@ interface OutputTrace extends ToolCallTrace {
     itemLink(name: string, url?: string | URL, title?: string): void
 
     /**
+     * Writes a paragraph of text with empty lines before and after.
+     * @param text paragraph to write
+     */
+    p(text: string): void
+
+    /**
      * Logs a warning message.
      * @param msg - The warning message to log.
      */

--- a/packages/sample/genaisrc/samples/prd-meme.genai.mts
+++ b/packages/sample/genaisrc/samples/prd-meme.genai.mts
@@ -44,7 +44,7 @@ const { text: zine } = await runPrompt(
     Use names from the code symbols.
     do NOT explain that GIT_DIFF displays changes in the codebase
     try to extract the intent of the changes, don't focus on the details
-    The model has a context window of 4096 tokens. The output image is portrait.
+    The model has a context window of 4096 tokens. The output image is landscape.
     Generate a single page meme for all panels/pages.
     - avoid distracted boyfriend meme
     - avoid doge meme
@@ -66,7 +66,7 @@ const { image } = await generateImage(
     {
         model: "image",
         quality: "high",
-        size: "portrait",
+        size: "landscape",
         outputFormat: "jpeg",
         maxWidth: 800,
     }

--- a/packages/sample/genaisrc/samples/prd-meme.genai.mts
+++ b/packages/sample/genaisrc/samples/prd-meme.genai.mts
@@ -1,0 +1,76 @@
+script({
+    title: "Pull Request Meme",
+    description:
+        "Generate a meme from a pull request description from the git diff",
+    temperature: 0.8,
+    systemSafety: true,
+    parameters: {
+        base: {
+            type: "string",
+            description: "The base branch of the pull request",
+        },
+        maxTokens: {
+            type: "number",
+            description: "The maximum number of tokens to generate",
+            default: 14000,
+        },
+    },
+})
+const { vars, output, dbg } = env
+const maxTokens = vars.maxTokens
+const defaultBranch = vars.base || (await git.defaultBranch())
+const branch = await git.branch()
+if (branch === defaultBranch) cancel("you are already on the default branch")
+
+// compute diff
+const changes = await git.diff({
+    base: defaultBranch,
+})
+console.log(changes)
+if (!changes) cancel("no changes found")
+
+// generate map
+const { text: zine } = await runPrompt(
+    (ctx) => {
+        const gd = ctx.def("GIT_DIFF", changes, {
+            maxTokens,
+            detectPromptInjection: "available",
+        })
+        ctx.$`You are an expert at meme (funny images), prompt genius and omniscient code developer.
+    You will summarize the code in the git diff ${gd} and generate a description of the changes as a meme.
+    The description will be used by a LLM to generate an image of the meme.
+    The meme will be used to tell "tell the story" of the changes.
+    Be descriptive about the visual features of the meme as you would for a meme.
+    Use names from the code symbols.
+    do NOT explain that GIT_DIFF displays changes in the codebase
+    try to extract the intent of the changes, don't focus on the details
+    The model has a context window of 4096 tokens. The output image is portrait.
+    Generate a single page meme for all panels/pages.
+    - avoid distracted boyfriend meme
+    - avoid doge meme
+    - avoid grumpy cat meme
+    - avoid success kid meme
+    - avoid bad luck brian meme
+    - avoid troll face meme
+    - avoid scumbag steve meme
+    `.role("system")
+    },
+    {
+        label: "summarize code to meme",
+        model: "large",
+    }
+)
+const { image } = await generateImage(
+    `Your task is to generate a meme with the following instruction.
+    ${zine}`,
+    {
+        model: "image",
+        quality: "high",
+        size: "portrait",
+        outputFormat: "jpeg",
+        maxWidth: 800,
+    }
+)
+if (!image) cancel("no image found")
+const ghFile = await github.uploadAsset(image)
+await output.image(ghFile, "meme")

--- a/packages/sample/genaisrc/samples/prd-sketch.genai.mts
+++ b/packages/sample/genaisrc/samples/prd-sketch.genai.mts
@@ -44,7 +44,7 @@ const { text: zine } = await runPrompt(
     try to extract the intent of the changes, don't focus on the details
     Avoid studio ghibli style.
     Ignore the low-level programming language details, focus on the high-level concepts.
-    The model has a context window of 4096 tokens. The output image is square.
+    The model has a context window of 4096 tokens. The output image is landscape.
     `.role("system")
     },
     {
@@ -58,7 +58,7 @@ const { image } = await generateImage(
     {
         model: "image",
         quality: "high",
-        size: "square",
+        size: "landscape",
         outputFormat: "jpeg",
         maxWidth: 800,
     }

--- a/packages/sample/genaisrc/samples/prd-zine.genai.mts
+++ b/packages/sample/genaisrc/samples/prd-zine.genai.mts
@@ -45,7 +45,7 @@ const { text: zine } = await runPrompt(
     do NOT explain that GIT_DIFF displays changes in the codebase
     try to extract the intent of the changes, don't focus on the details
     Avoid studio ghibli style.
-    The model has a context window of 4096 tokens. The output image is portrait.
+    The model has a context window of 4096 tokens. The output image is landscape.
     Generate a single page zine for all panels/pages.
     `.role("system")
     },
@@ -60,7 +60,7 @@ const { image } = await generateImage(
     {
         model: "image",
         quality: "high",
-        size: "portrait",
+        size: "landscape",
         outputFormat: "jpeg",
         maxWidth: 800,
     }


### PR DESCRIPTION
Introduced a `p` method in trace and added package.json overrides.

<!-- genaiscript begin pr-describe --><hr/>

- ✨ **Added `p` method to the public API** in `OutputTrace` interface, allowing formatted paragraphs with surrounding empty lines for enhanced output readability.  
- 🛠️ Enhanced robustness in `item` and newly added `p` method by ensuring they handle empty inputs gracefully.  
- 📦 **Introduced package overrides** in `package.json` for `glob` and `@mapbox/node-pre-gyp` to standardize dependency versions across all contexts.  
- ✅ Aligned `resolutions` in `package.json` with the `overrides` section for consistent dependency management.

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/14896560451) may be incorrect. Use reactions to eval.



<!-- genaiscript end pr-describe -->



<!-- genaiscript begin prd-meme --><hr/>



![meme](https://raw.githubusercontent.com/microsoft/genaiscript/refs/heads/genai-assets/2cbed7cb9d83accd043a5e5fab0ba40d3103f0a69f1a3d6858a2d1030aaaa096.jpg)



> AI-generated content by prd-meme may be incorrect. Use reactions to eval.



<!-- genaiscript end prd-meme -->



<!-- genaiscript begin prd-sketch --><hr/>



![sketch](https://raw.githubusercontent.com/microsoft/genaiscript/refs/heads/genai-assets/be50da683c4ce3a7de33aa86b39d1ccea8107601d52b44081bfa2538dd0f53ff.jpg)



> AI-generated content by prd-sketch may be incorrect. Use reactions to eval.



<!-- genaiscript end prd-sketch -->



<!-- genaiscript begin prd-zine --><hr/>



![zine](https://raw.githubusercontent.com/microsoft/genaiscript/refs/heads/genai-assets/718df069eb52f0c0d1b2b121c5c4c9206bf247e91f153295648b8fa44789f068.jpg)



> AI-generated content by prd-zine may be incorrect. Use reactions to eval.



<!-- genaiscript end prd-zine -->

