### PR TITLE
Add package manager selection support in CLI and refine Azure credential handling

### DIFF
--- a/packages/core/src/azuretoken.ts
+++ b/packages/core/src/azuretoken.ts
@@ -47,8 +47,6 @@ async function createAzureToken(
         AzurePowerShellCredential,
         AzureDeveloperCliCredential,
         WorkloadIdentityCredential,
-        DeviceCodeCredential,
-        AzurePipelinesCredential,
         ChainedTokenCredential,
     } = await import("@azure/identity")
 
@@ -90,7 +88,7 @@ async function createAzureToken(
                 credential = new DefaultAzureCredential() // CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development........................................
             } else {
                 dbg(
-                    `node_env prod: credentialsType is env, cli, devcli, powershell`
+                    `node_env unspecified: credentialsType is env, cli, devcli, powershell`
                 )
                 credential = new ChainedTokenCredential(
                     new EnvironmentCredential(),

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -318,6 +318,7 @@ export const PLACEHOLDER_API_KEY = "<your token>"
 
 export const VSCODE_CONFIG_CLI_VERSION = "cli.version"
 export const VSCODE_CONFIG_CLI_PATH = "cli.path"
+export const VSCODE_CONFIG_CLI_PACKAGE_MANAGER = "cli.packageManager"
 
 export const CONSOLE_COLOR_INFO = 32
 export const CONSOLE_COLOR_DEBUG = 90

--- a/packages/core/src/packagemanagers.ts
+++ b/packages/core/src/packagemanagers.ts
@@ -1,5 +1,6 @@
-import { resolveCommand } from "package-manager-detector/commands"
-import { detect } from "package-manager-detector/detect"
+import { resolveCommand, detect, Agent } from "package-manager-detector"
+import { genaiscriptDebug } from "./debug"
+const dbg = genaiscriptDebug("pkg")
 
 /**
  * Resolves the install command for the detected package manager in a given directory.
@@ -13,4 +14,39 @@ export async function packageResolveInstall(cwd: string) {
 
     const { command, args } = resolveCommand(pm.agent, "frozen", [])
     return { command, args }
+}
+
+export async function packageResolveExecute(
+    cwd: string,
+    args: string[],
+    options?: {
+        agent?: "npm" | "yarn" | "pnpm" | "auto"
+    }
+): Promise<{
+    command: string
+    args: string[]
+}> {
+    dbg(`resolving`)
+    let agent: Agent = options?.agent === "auto" ? undefined : options?.agent
+    if (!agent) {
+        const pm = await detect({ cwd })
+        if (
+            pm &&
+            (pm.agent === "npm" ||
+                pm.agent === "pnpm" ||
+                pm.agent === "pnpm@6" ||
+                pm.agent === "yarn" ||
+                pm.agent === "yarn@berry")
+        )
+            agent = pm.agent
+    }
+    agent = agent || "npm"
+    dbg(`agent: %s`, agent)
+    const resolved = resolveCommand(
+        agent,
+        "execute",
+        args.filter((a) => a !== undefined)
+    )
+    dbg(`resolved: %o`, resolved)
+    return resolved
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -356,6 +356,16 @@
                         "default": true,
                         "description": "Enable or disables LLM request cache support."
                     },
+                    "genaiscript.cli.packageManager": {
+                        "type": "string",
+                        "default": "auto",
+                        "enum": [
+                            "auto",
+                            "npm",
+                            "pnpm"
+                        ],
+                        "description": "Package manager to use for GenAIScript CLI. Default is npm."
+                    },
                     "genaiscript.cli.version": {
                         "type": "string",
                         "description": "GenAIScript CLI version to use. Default matches the extension version."

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import {
     TOOL_ID,
+    VSCODE_CONFIG_CLI_PACKAGE_MANAGER,
     VSCODE_CONFIG_CLI_PATH,
     VSCODE_CONFIG_CLI_VERSION,
 } from "../../core/src/constants"
@@ -15,11 +16,16 @@ export async function resolveCli(state: ExtensionState) {
         (config.get(VSCODE_CONFIG_CLI_VERSION) as string) ||
         VSCODE_CLI_VERSION ||
         CORE_VERSION
+    const packageManager = config.get(VSCODE_CONFIG_CLI_PACKAGE_MANAGER) as
+        | "auto"
+        | "npm"
+        | "yarn"
+        | "pnpm" // TODO: add support for bun
     const gv = semverParse(CORE_VERSION)
     if (!semverSatisfies(cliVersion, ">=" + gv.major + "." + gv.minor))
         vscode.window.showWarningMessage(
             TOOL_ID +
                 ` - genaiscript cli version (${cliVersion}) outdated, please update to ${CORE_VERSION}`
         )
-    return { cliPath, cliVersion }
+    return { cliPath, cliVersion, packageManager }
 }

--- a/packages/vscode/src/servermanager.ts
+++ b/packages/vscode/src/servermanager.ts
@@ -20,6 +20,8 @@ import { semverParse, semverSatisfies } from "../../core/src/semver"
 import { resolveCli } from "./config"
 import { deleteUndefinedValues } from "../../core/src/cleaners"
 import { findRandomOpenPort } from "../../core/src/net"
+import { packageResolveExecute } from "../../core/src/packagemanagers"
+import { shellQuote } from "../../core/src/shell"
 
 export class TerminalServerManager
     extends EventTarget
@@ -184,7 +186,9 @@ export class TerminalServerManager
         logVerbose(
             `starting server on port ${this._port} at ${cwd} (DEBUG=${debug || ""})`
         )
-        const { cliPath, cliVersion } = await resolveCli(this.state)
+        const { cliPath, cliVersion, packageManager } = await resolveCli(
+            this.state
+        )
         const githubCopilotChatClient = isLanguageModelsAvailable()
             ? " --github-copilot-chat-client"
             : ""
@@ -207,10 +211,23 @@ export class TerminalServerManager
             this._terminal.sendText(
                 `node "${cliPath}" serve --port ${this._port} --dispatch-progress --cors "*"${githubCopilotChatClient}`
             )
-        else
-            this._terminal.sendText(
-                `npx --yes ${TOOL_ID}@${cliVersion} serve --port ${this._port} --dispatch-progress --cors "*"${githubCopilotChatClient}`
+        else {
+            const pkg = await packageResolveExecute(
+                cwd,
+                [
+                    `${TOOL_ID}@${cliVersion}`,
+                    `serve`,
+                    `--port`,
+                    `${this._port}`,
+                    `--dispatch-progress`,
+                    `--cors`,
+                    `*`,
+                    githubCopilotChatClient,
+                ],
+                { agent: packageManager }
             )
+            this._terminal.sendText(shellQuote([pkg.command, ...pkg.args]))
+        }
         if (!hideFromUser) this._terminal.show(true)
 
         // check node asynchronously


### PR DESCRIPTION
Introduce a new option for selecting the package manager in the GenAIScript CLI and streamline the handling of Azure credentials by removing unused imports.

<!-- genaiscript begin pr-describe --><hr/>

- 🔒 **Removed unused Azure credentials**: `DeviceCodeCredential` and `AzurePipelinesCredential` were removed from the token creation logic for streamlining credential management.  
- 📝 **Adjusted debug messaging**: Updated logs to reflect changes where `node_env` is unspecified.  
- 📦 **Enhanced package manager handling**:  
  - Introduced support for resolving and executing CLI commands with various package managers (`npm`, `yarn`, `pnpm`, `auto`).  
  - Debugging support added to track the package manager resolution process.  
- 🛠️ **New VSCode setting**: Added `genaiscript.cli.packageManager` to allow users to specify a package manager (`auto`, `npm`, `pnpm`) for the GenAIScript CLI.  
- 🚀 **VSCode config improvements**: Extended the `resolveCli` function to include the selected package manager, handling appropriate agent resolution.  
- 🤖 **Dynamic CLI execution**: Refactored the Terminal Server Manager to dynamically resolve the CLI execution logic based on the detected or user-configured package manager. This replaces hardcoded `npx` usage.  
- 🛠 **Shell parameter quoting**: Implemented proper command and argument quoting for safe execution of CLI commands.  

> AI-generated content by [pr-describe](https://github.com/microsoft/genaiscript/actions/runs/14983871349) may be incorrect. Use reactions to eval.



<!-- genaiscript end pr-describe -->

