### PR TITLE
✨ feat: add support for downloading workflow artifacts

### DIFF
--- a/docs/src/content/docs/reference/scripts/github.mdx
+++ b/docs/src/content/docs/reference/scripts/github.mdx
@@ -102,6 +102,21 @@ console.log(jobs[0].content)
 
 In GitHub Actions, grant the `actions: read` permission.
 
+### Artifacts
+
+Workflows can create and attach artifacts to the workflow run.
+You can list and download these artifacts using `listWorkflowArtifacts` and `downloadArtifact`.
+
+```js
+const artifacts = await github.listWorkflowArtifacts(runs[0].id)
+console.log(artifacts)
+
+const artifact = artifacts[0]
+// genaiscript automatically unzips the artifact
+const files = await github.downloadArtifact(artifact.id)
+console.log(files)
+```
+
 ### Search Code
 
 Use `searchCode` for a code search on the default branch in the same repository.
@@ -145,7 +160,7 @@ const url = await github.uploadAsset(file)
 console.log(url)
 ```
 
-The URL can be used in markdown in comments or issues. 
+The URL can be used in markdown in comments or issues.
 
 :::note
 

--- a/packages/core/src/githubclient.test.ts
+++ b/packages/core/src/githubclient.test.ts
@@ -57,6 +57,12 @@ describe("GitHubClient", async () => {
         assert(Array.isArray(jobs))
         const log = await client.downloadWorkflowJobLog(jobs[0].id)
         assert(typeof log === "string")
+        const artifacts = await client.listWorkflowRunArtifacts(runs[0].id)
+        assert(Array.isArray(artifacts))
+        if (artifacts.length) {
+            const files = await client.downloadArtifactFiles(artifacts[0].id)
+            assert(files.length)
+        }
     })
 
     await test("getFile() returns file content", async () => {

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -3609,6 +3609,15 @@ interface GitHubGist {
     files: WorkspaceFile[]
 }
 
+interface GitHubArtifact {
+    id: number
+    name: string
+    size_in_bytes: number
+    url: string
+    archive_download_url: string
+    expires_at: string
+}
+
 interface GitHub {
     /**
      * Gets connection information for octokit
@@ -3645,6 +3654,27 @@ interface GitHub {
      * @param runId
      */
     workflowRun(runId: number | string): Promise<GitHubWorkflowRun>
+
+    /**
+     * List artifacts for a given workflow run
+     * @param runId
+     */
+    listWorkflowRunArtifacts(
+        runId: number | string,
+        options?: GitHubPaginationOptions
+    ): Promise<GitHubArtifact[]>
+
+    /**
+     * Gets the details of a GitHub Action workflow run artifact
+     * @param artifactId
+     */
+    artifact(artifactId: number | string): Promise<GitHubArtifact>
+
+    /**
+     * Downloads and unzips archive files from a GitHub Action Artifact
+     * @param artifactId
+     */
+    downloadArtifactFiles(artifactId: number | string): Promise<WorkspaceFile[]>
 
     /**
      * Downloads a GitHub Action workflow run log


### PR DESCRIPTION
Introduces methods to list, retrieve, and download workflow artifacts.

<!-- genaiscript begin prd --><hr/>

### 🚀 Summary of Changes

- ✨ **Added support for GitHub Actions artifacts:**
  - Introduced new methods to the `GitHubClient` for listing, retrieving, and downloading workflow run artifacts.
  - Implemented `listWorkflowRunArtifacts`, `artifact`, and `downloadArtifactFiles` methods to interact with workflow artifacts via the GitHub API.
  - Integrated artifact file downloading and automatic unzipping for easier access to artifact contents.

- 🧩 **Expanded GitHub types:**
  - Defined a new `GitHubArtifact` interface to represent artifact metadata.
  - Updated the `GitHub` interface to include new artifact-related methods.

- 🧪 **Enhanced test coverage:**
  - Added tests to verify artifact listing and downloading functionality within existing GitHub client tests.

These changes bring comprehensive artifact management capabilities to the GitHub client, enabling seamless access to workflow run artifacts and their contents.

> AI-generated content by prd may be incorrect. Use reactions to eval.



<!-- genaiscript end prd -->



<!-- genaiscript begin prd-sketch --><hr/>



![sketch](https://raw.githubusercontent.com/microsoft/genaiscript/refs/heads/genai-assets/ba9391f5c26450b6ede4ef822e0a5a7d7038c18210e9c086e55a0bbaad629e34.jpg)



> AI-generated content by prd-sketch may be incorrect. Use reactions to eval.



<!-- genaiscript end prd-sketch -->

