### PR TITLE
✨ feat: add asset URL resolution for GitHub uploads

### DIFF
--- a/docs/src/content/docs/reference/scripts/github.mdx
+++ b/docs/src/content/docs/reference/scripts/github.mdx
@@ -126,6 +126,19 @@ const files = await github.downloadArtifact(artifact.id)
 console.log(files)
 ```
 
+### Assets
+
+Image or video assets urls uploaded through the GitHub UI can be resolved using `resolveAssetUrl`.
+They are typically of the form `https://github.com/.../assets/<uuid>`. The function returns a short lived URL with an embedded
+access token to download the asset.
+
+```js
+const url = await github.resolveAssetUrl(
+    "https://github.com/user-attachments/assets/a6e1935a-868e-4cca-9531-ad0ccdb9eace"
+)
+console.log(url)
+```
+
 ### Search Code
 
 Use `searchCode` for a code search on the default branch in the same repository.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -457,3 +457,5 @@ export const BOX_UP_AND_DOWN = "│"
 export const BOX_DOWN_UP_AND_RIGHT = "├"
 export const BOX_LEFT_AND_DOWN = "╮"
 export const BOX_LEFT_AND_UP = "╯"
+
+export const GITHUB_ASSET_URL_RX = /^https:\/\/github\.com\/.*\/assets\/.*$/i

--- a/packages/core/src/githubclient.test.ts
+++ b/packages/core/src/githubclient.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url"
 import { isCI } from "./ci"
 import { TestHost } from "./testhost"
 import { resolveBufferLike } from "./bufferlike"
+import { tryResolveResource } from "./resources"
 
 describe("GitHubClient", async () => {
     const client = GitHubClient.default()
@@ -111,13 +112,17 @@ describe("GitHubClient", async () => {
         const un = await client.uploadAsset(undefined)
         assert(un === undefined)
     })
-    await test("resolveAssetUrl", async () => {
-        const resolved = await client.resolveAssetUrl(
+    await test("resolveAssetUrl - indirect", async () => {
+        const bytes = await resolveBufferLike(
             "https://github.com/user-attachments/assets/a6e1935a-868e-4cca-9531-ad0ccdb9eace"
         )
-        assert(resolved)
-        console.log(resolved)
-        const bytes = await resolveBufferLike(resolved)
         assert(bytes.length)
+    })
+
+    await test("resolveAssetUrl", async () => {
+        const resolved = await tryResolveResource(
+            "https://github.com/user-attachments/assets/a6e1935a-868e-4cca-9531-ad0ccdb9eace"
+        )
+        assert(resolved.files[0].content)
     })
 })

--- a/packages/core/src/githubclient.test.ts
+++ b/packages/core/src/githubclient.test.ts
@@ -112,17 +112,26 @@ describe("GitHubClient", async () => {
         const un = await client.uploadAsset(undefined)
         assert(un === undefined)
     })
-    await test("resolveAssetUrl - indirect", async () => {
-        const bytes = await resolveBufferLike(
+    await test("resolveAssetUrl -image", async () => {
+        const resolved = await client.resolveAssetUrl(
             "https://github.com/user-attachments/assets/a6e1935a-868e-4cca-9531-ad0ccdb9eace"
         )
-        assert(bytes.length)
+        assert(resolved)
+        assert(resolved.includes("githubusercontent.com"))
+    })
+    await test("resolveAssetUrl - mp4", async () => {
+        const resolved = await client.resolveAssetUrl(
+            "https://github.com/user-attachments/assets/f7881bef-931d-4f76-8f63-b4d12b1f021e"
+        )
+        console.log(resolved)
+        assert(resolved.includes("githubusercontent.com"))
     })
 
-    await test("resolveAssetUrl", async () => {
+    await test("resolveAssetUrl - image - indirect", async () => {
         const resolved = await tryResolveResource(
             "https://github.com/user-attachments/assets/a6e1935a-868e-4cca-9531-ad0ccdb9eace"
         )
         assert(resolved.files[0].content)
+        assert.strictEqual(resolved.files[0].type, "image/jpeg")
     })
 })

--- a/packages/core/src/githubclient.test.ts
+++ b/packages/core/src/githubclient.test.ts
@@ -5,6 +5,7 @@ import { readFile } from "node:fs/promises"
 import { fileURLToPath } from "node:url"
 import { isCI } from "./ci"
 import { TestHost } from "./testhost"
+import { resolveBufferLike } from "./bufferlike"
 
 describe("GitHubClient", async () => {
     const client = GitHubClient.default()
@@ -109,5 +110,14 @@ describe("GitHubClient", async () => {
         // Test with undefined buffer
         const un = await client.uploadAsset(undefined)
         assert(un === undefined)
+    })
+    await test("resolveAssetUrl", async () => {
+        const resolved = await client.resolveAssetUrl(
+            "https://github.com/user-attachments/assets/a6e1935a-868e-4cca-9531-ad0ccdb9eace"
+        )
+        assert(resolved)
+        console.log(resolved)
+        const bytes = await resolveBufferLike(resolved)
+        assert(bytes.length)
     })
 })

--- a/packages/core/src/githubclient.ts
+++ b/packages/core/src/githubclient.ts
@@ -1352,12 +1352,15 @@ export class GitHubClient implements GitHub {
         const { data, status } = await client.rest.markdown.render({
             owner,
             repo,
+            context: `${owner}/${repo}`, // force html with token
             text: `![](${url})`,
             mode: "gfm",
         })
         dbg(`asset: resolution %s`, status)
         const { resolved } =
-            /href="(?<resolved>[^"]+)"/i.exec(data)?.groups || {}
+            /<img src="(?<resolved>[^"]+)"/i.exec(data)?.groups || {}
+        if (!resolved) dbg(`markdown:\n%s`, data)
+
         return resolved
     }
 

--- a/packages/core/src/resources.ts
+++ b/packages/core/src/resources.ts
@@ -83,7 +83,6 @@ const uriResolvers: Record<
         // https://.../.../....git
         if (/\.git($|\/)/.test(url.pathname))
             return await uriResolvers.git(dbg, url, options)
-
         // regular fetch
         const fetch = await createFetch(options)
         dbg(`fetch %s`, uriRedact(url.href))

--- a/packages/core/src/resources.ts
+++ b/packages/core/src/resources.ts
@@ -12,6 +12,7 @@ import { GitClient } from "./git"
 import { expandFiles } from "./fs"
 import { join } from "node:path"
 import { isCancelError } from "./error"
+import { GITHUB_ASSET_URL_RX } from "./constants"
 const dbg = genaiscriptDebug("res")
 const dbgAdaptors = dbg.extend("adaptors")
 const dbgFiles = dbg.extend("files")
@@ -19,7 +20,7 @@ dbgFiles.enabled = false
 
 const urlAdapters: {
     id: string
-    matcher: (url: string) => string
+    matcher: (url: string) => Awaitable<string>
 }[] = [
     {
         id: "github blob",
@@ -41,6 +42,17 @@ const urlAdapters: {
         },
     },
     {
+        id: "github assets",
+        matcher: async (url) => {
+            if (GITHUB_ASSET_URL_RX.test(url)) {
+                const client = GitHubClient.default()
+                const resolved = await client.resolveAssetUrl(url)
+                return resolved
+            }
+            return undefined
+        },
+    },
+    {
         id: "gist",
         matcher: (url) => {
             const m =
@@ -54,10 +66,10 @@ const urlAdapters: {
     },
 ]
 
-function applyUrlAdapters(url: string) {
+async function applyUrlAdapters(url: string) {
     // Use URL adapters to modify the URL if needed
     for (const a of urlAdapters) {
-        const newUrl = a.matcher(url)
+        const newUrl = await a.matcher(url)
         if (newUrl) {
             dbgAdaptors(`%s: %s`, a.id, uriRedact(url))
             return newUrl
@@ -210,7 +222,7 @@ export async function tryResolveResource(
     options?: TraceOptions & CancellationOptions
 ): Promise<{ uri: URL; files: WorkspaceFile[] } | undefined> {
     if (!url) return undefined
-    url = applyUrlAdapters(url)
+    url = await applyUrlAdapters(url)
     const uri = uriTryParse(url)
     if (!uri) return undefined
     const { cancellationToken } = options || {}

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -3871,7 +3871,7 @@ interface GitHub {
     ): Promise<string>
 
     /**
-     * Resolves user uploaded assets to a short lived URL with access token.
+     * Resolves user uploaded assets to a short lived URL with access token. Returns undefined if the asset is not found.
      */
     resolveAssetUrl(url: string): Promise<string | undefined>
 

--- a/packages/core/src/types/prompt_template.d.ts
+++ b/packages/core/src/types/prompt_template.d.ts
@@ -3871,6 +3871,11 @@ interface GitHub {
     ): Promise<string>
 
     /**
+     * Resolves user uploaded assets to a short lived URL with access token.
+     */
+    resolveAssetUrl(url: string): Promise<string | undefined>
+
+    /**
      * Gets the underlying Octokit client
      */
     api(): Promise<any>


### PR DESCRIPTION
Introduced asset URL resolution in GitHubClient's API interface.
![](https://github.com/user-attachments/assets/a6e1935a-868e-4cca-9531-ad0ccdb9eace)


https://github.com/user-attachments/assets/f7881bef-931d-4f76-8f63-b4d12b1f021e


