### PR TITLE
Max retry after

### DIFF
--- a/packages/api/src/run.ts
+++ b/packages/api/src/run.ts
@@ -102,6 +102,9 @@ import {
   rmDir,
   tryStat,
   createGitIgnorer,
+  OPENAI_MAX_RETRY_AFTER_DEFAULT,
+  OPENAI_MAX_RETRY_DELAY,
+  OPENAI_MAX_RETRY_COUNT,
 } from "@genaiscript/core";
 
 const dbg = genaiscriptDebug("run");
@@ -193,9 +196,10 @@ export async function runScriptInternal(
   let workspaceFiles = options.workspaceFiles || [];
   const excludedFiles = options.excludedFiles || [];
   const stream = !options.json;
-  const retry = normalizeInt(options.retry) || 8;
-  const retryDelay = normalizeInt(options.retryDelay) || 15000;
-  const maxDelay = normalizeInt(options.maxDelay) || 180000;
+  const retries = normalizeInt(options.retry);
+  const retryDelay = normalizeInt(options.retryDelay) || OPENAI_MAX_RETRY_COUNT;
+  const maxDelay = normalizeInt(options.maxDelay) || OPENAI_MAX_RETRY_DELAY;
+  const maxRetryAfter = normalizeInt(options.maxRetryAfter) || OPENAI_MAX_RETRY_AFTER_DEFAULT;
   const outTrace = options.outTrace;
   const outOutput = options.outOutput;
   const outAnnotations = options.outAnnotations;
@@ -500,9 +504,10 @@ export async function runScriptInternal(
       maxDataRepairs,
       model: info.model,
       embeddingsModel: options.embeddingsModel,
-      retry,
+      retries,
       retryDelay,
       maxDelay,
+      maxRetryAfter,
       vars,
       trace,
       outputTrace: runOutputTrace,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,7 @@ import {
   OPENAI_MAX_RETRY_COUNT,
   OPENAI_MAX_RETRY_DELAY,
   OPENAI_RETRY_DEFAULT_DEFAULT,
+  OPENAI_MAX_RETRY_AFTER_DEFAULT,
   RUNTIME_ERROR_CODE,
   SERVER_PORT,
   TOOL_ID,
@@ -194,7 +195,7 @@ export async function cli() {
       "--out-annotations <string>",
       "output file for annotations (.csv will be rendered as csv, .jsonl/ndjson will be aggregated)",
     )
-    .option("--out-changelog <string>", "output file for changelogs")
+    .option("--out-changelog <string>", "output file for changelogs");
   addPullRequestOptions(run)
     .option("--teams-message", "Posts a message to the teams channel")
     .option("-j, --json", "emit full JSON response to output")
@@ -206,6 +207,10 @@ export async function cli() {
       String(OPENAI_RETRY_DEFAULT_DEFAULT),
     )
     .option("--max-delay <number>", "maximum delay between retries", String(OPENAI_MAX_RETRY_DELAY))
+    .option(
+      "--max-retry-after <number>",
+      "maximum retry-after delay in milliseconds before giving up", String(OPENAI_MAX_RETRY_AFTER_DEFAULT)
+    )
     .option("-l, --label <string>", "label for the run")
     .option("-t, --temperature <number>", "temperature for the run")
     .option("--top-p <number>", "top-p for the run")

--- a/packages/core/src/anthropic.ts
+++ b/packages/core/src/anthropic.ts
@@ -288,17 +288,26 @@ const completerFactory = (
   ) => Promise<Omit<Anthropic.Beta.Messages, "batches" | "countTokens">>,
 ) => {
   const completion: ChatCompletionHandler = async (req, cfg, options, trace) => {
-    const { requestOptions, partialCb, cancellationToken, inner, retry, maxDelay, retryDelay } =
-      options;
+    const {
+      requestOptions,
+      partialCb,
+      cancellationToken,
+      inner,
+      retries,
+      maxDelay,
+      maxRetryAfter,
+      retryDelay,
+    } = options;
     const { headers } = requestOptions || {};
     const { provider, model, reasoningEffort } = parseModelIdentifier(req.model);
     const { encode: encoder } = await resolveTokenEncoder(model);
 
     const fetch = await createFetch({
       trace,
-      retries: retry,
+      retries,
       retryDelay,
       maxDelay,
+      maxRetryAfter,
       cancellationToken,
     });
     // https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#how-to-implement-prompt-caching

--- a/packages/core/src/chattypes.ts
+++ b/packages/core/src/chattypes.ts
@@ -9,7 +9,7 @@
  */
 
 import OpenAI from "openai";
-import type { Logprob, PromptCacheControlType, SerializedError } from "./types.js";
+import type { Logprob, PromptCacheControlType, RetryOptions, SerializedError } from "./types.js";
 
 export type ChatModel = OpenAI.Models.Model;
 
@@ -186,14 +186,11 @@ export interface ChatCompletionsProgressReport {
 /**
  * Interface representing options for chat completions.
  */
-export interface ChatCompletionsOptions {
+export interface ChatCompletionsOptions extends RetryOptions {
   partialCb?: (progress: ChatCompletionsProgressReport) => void; // Callback for partial responses
   requestOptions?: Partial<Omit<RequestInit, "signal">>; // Custom request options
   maxCachedTemperature?: number; // Max temperature for caching responses
   maxCachedTopP?: number; // Max top-p for caching responses
   cache?: boolean | string; // Cache setting or cache name
-  retry?: number; // Number of retries for failed requests
-  retryDelay?: number; // Delay between retries
-  maxDelay?: number; // Maximum delay for retry attempts
   inner: boolean; // Indicates if the option is for inner processing
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -99,11 +99,19 @@ export const ICON_LOGO_NAME = "genaiscript-logo";
 export const SARIFF_RULEID_PREFIX = "genaiscript/";
 export const SARIFF_BUILDER_URL = "https://github.com/microsoft/genaiscript/";
 export const SARIFF_BUILDER_TOOL_DRIVER_NAME = TOOL_ID;
+
+export const OPENAI_MAX_RETRY_DELAY = 60000; // 60s
+export const OPENAI_MAX_RETRY_COUNT = 10;
+export const OPENAI_RETRY_DEFAULT_DEFAULT = 1000;
+export const OPENAI_MAX_RETRY_AFTER_DEFAULT = 300000; // 300s
+
 export const FETCH_RETRY_DEFAULT = 6;
 export const FETCH_RETRY_DEFAULT_DEFAULT = 2000;
-export const FETCH_RETRY_MAX_DELAY_DEFAULT = 120000;
+export const FETCH_RETRY_MAX_DELAY_DEFAULT = 60000; // 60s
+export const FETCH_RETRY_MAX_RETRY_AFTER_DEFAULT = 300000; // 300s
 export const FETCH_RETRY_GROWTH_FACTOR = 1.5;
 export const FETCH_RETRY_ON_DEFAULT = [408, 429, 500, 504];
+
 export const EXEC_MAX_BUFFER = 64;
 export const DOT_ENV_FILENAME = ".env";
 export const DOT_ENV_GENAISCRIPT_FILENAME = ".env.genaiscript";
@@ -335,10 +343,6 @@ export const MAX_TOKENS_ELLIPSE = "...";
 export const ESTIMATE_TOKEN_OVERHEAD = 2;
 
 export const DEDENT_INSPECT_MAX_DEPTH = 3;
-
-export const OPENAI_MAX_RETRY_DELAY = 10000;
-export const OPENAI_MAX_RETRY_COUNT = 10;
-export const OPENAI_RETRY_DEFAULT_DEFAULT = 1000;
 
 export const ANTHROPIC_MAX_TOKEN = 4096;
 export const TEMPLATE_ARG_FILE_MAX_TOKENS = 4000;

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -8,6 +8,7 @@ import {
   FETCH_RETRY_DEFAULT_DEFAULT,
   FETCH_RETRY_GROWTH_FACTOR,
   FETCH_RETRY_MAX_DELAY_DEFAULT,
+  FETCH_RETRY_MAX_RETRY_AFTER_DEFAULT,
   FETCH_RETRY_ON_DEFAULT,
 } from "./constants.js";
 import { errorMessage } from "./error.js";
@@ -61,6 +62,22 @@ export function parseRetryAfter(retryAfterHeader: string): number | null {
   return null;
 }
 
+function parseRetryAfterHeader(response: Response) {
+  const retryAfterHeader =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    response.headers.get?.("retry-after") || (response.headers as any)["retry-after"];
+  dbgr(`retry-after header: %s`, retryAfterHeader);
+  if (retryAfterHeader) {
+    const retryAfterSeconds = parseRetryAfter(retryAfterHeader);
+    if (retryAfterSeconds !== null) {
+      const retryAfter = retryAfterSeconds * 1000; // Convert to milliseconds
+      dbgr(`retry-after header: %s`, prettyDuration(retryAfter));
+      return retryAfter;
+    }
+  }
+  return undefined;
+}
+
 export type FetchType = (
   input: string | URL | globalThis.Request,
   options?: FetchOptions & TraceOptions,
@@ -92,6 +109,7 @@ export async function createFetch(
     trace,
     retryDelay = FETCH_RETRY_DEFAULT_DEFAULT,
     maxDelay = FETCH_RETRY_MAX_DELAY_DEFAULT,
+    maxRetryAfter = FETCH_RETRY_MAX_RETRY_AFTER_DEFAULT,
     cancellationToken,
   } = options;
 
@@ -115,18 +133,24 @@ export async function createFetch(
 
   // Create a fetch function with retry logic
   dbgr(
-    `retries: %d, retryOn: %s, retryDelay: %d, maxDelay: %d`,
+    `retries: %d, retry on: %o, retry delay: %d, max delay: %d, max retry after: %d`,
     retries,
     retryOn,
     retryDelay,
     maxDelay,
+    maxRetryAfter,
   );
   const fetchRetry = wrapFetch(crossFetchWithProxy, {
-    retryOn,
     retries,
-    retryDelay: (attempt, error, response) => {
+    retryOn: (attempt, error, response) => {
       const code: string = (error as { code?: string })?.code as string;
-      dbgr(`retry attempt: %d, error code: %s`, attempt, code);
+
+      if (response.ok) {
+        dbgr("status %d is success, not retrying", response.status);
+        return false;
+      }
+
+      dbgr(`retry #%d, %d`, attempt, response.status);
       if (
         code === "ECONNRESET" ||
         code === "ENOTFOUND" ||
@@ -137,55 +161,43 @@ export async function createFetch(
         return undefined;
       }
 
-      const message = errorMessage(error);
-      const status = statusToMessage(response);
-      dbgr(`message %s`, message);
-      dbgr(`status %s`, status);
-
+      const status = response.status;
+      if (retryOn?.length && !retryOn.includes(status)) {
+        dbgr(`status %d not in retryOn %o, not retrying`, status, retryOn);
+        return false;
+      }
+      const retryAfter = parseRetryAfterHeader(response);
+      if (!isNaN(maxRetryAfter) && retryAfter > maxRetryAfter) {
+        dbgr(
+          `retry-after %s exceeds max-retry-after %s, give up`,
+          prettyDuration(retryAfter),
+          prettyDuration(maxRetryAfter),
+        );
+        return false;
+      }
+      return true;
+    },
+    retryDelay: (attempt, error, response) => {
       // Check for retry-after header and respect its value
       let delay: number;
-      let retryAfterInfo = "";
+      let retryAfter = parseRetryAfterHeader(response);
 
-      if (response?.headers) {
-        const retryAfterHeader =
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          response.headers.get?.("retry-after") || (response.headers as any)["retry-after"];
-        dbgr(`retry-after header: %s`, retryAfterHeader);
-        if (retryAfterHeader) {
-          const retryAfterSeconds = parseRetryAfter(retryAfterHeader);
-          if (retryAfterSeconds) {
-            delay = Math.min(maxDelay, retryAfterSeconds * 1000); // Convert to milliseconds
-            retryAfterInfo = `retry-after: ${prettyDuration(retryAfterSeconds * 1000)}`;
-            dbgr(`using retry-after header value: %d seconds`, retryAfterSeconds);
-          } else {
-            // Fallback to exponential backoff if retry-after parsing failed
-            delay =
-              Math.min(maxDelay, Math.pow(FETCH_RETRY_GROWTH_FACTOR, attempt) * retryDelay) *
-              (1 + Math.random() / 20);
-            dbgr(`using exponential backoff: %d`, delay);
-          }
-        } else {
-          // No retry-after header, use exponential backoff
-          delay =
-            Math.min(maxDelay, Math.pow(FETCH_RETRY_GROWTH_FACTOR, attempt) * retryDelay) *
-            (1 + Math.random() / 20);
-          dbgr(`no retry-after header, using exponential backoff: %d`, delay);
-        }
+      if (retryAfter) {
+        delay = Math.min(maxDelay, retryAfter); // Convert to milliseconds
       } else {
-        // No response headers, use exponential backoff
+        // Fallback to exponential backoff if retry-after parsing failed
         delay =
           Math.min(maxDelay, Math.pow(FETCH_RETRY_GROWTH_FACTOR, attempt) * retryDelay) *
           (1 + Math.random() / 20);
-        dbgr(`no response headers, using exponential backoff: %d`, delay);
+        dbgr(`using exponential backoff: %d`, delay);
       }
-
       const msg = prettyStrings(
         `retry #${attempt + 1} in ${prettyDuration(delay)}`,
-        retryAfterInfo,
+        `retry after: ${prettyDuration(retryAfter)}`,
         `max delay: ${prettyDuration(maxDelay)}`,
         `retry delay: ${prettyDuration(retryDelay)}`,
-        message,
-        status,
+        errorMessage(error),
+        statusToMessage(response),
       );
       logVerbose(msg);
       trace?.resultItem(false, msg);

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -35,7 +35,7 @@ export function parseRetryAfter(retryAfterHeader: string): number | null {
   if (!retryAfterHeader) return null;
 
   const trimmed = retryAfterHeader.trim();
-  dbg(`parsing retry-after header: ${trimmed}`);
+  dbgr(`parsing retry-after header: ${trimmed}`);
 
   // Try to parse as seconds (integer) first - must be a valid non-negative integer
   const seconds = parseInt(trimmed, 10);
@@ -54,11 +54,11 @@ export function parseRetryAfter(retryAfterHeader: string): number | null {
         return delaySeconds;
       }
     } catch (e) {
-      dbg(`failed to parse retry-after header as date: %s`, errorMessage(e));
+      dbgr(`failed to parse retry-after header as date: %s`, errorMessage(e));
     }
   }
 
-  dbg(`failed to parse retry-after header: ${retryAfterHeader}`);
+  dbgr(`failed to parse retry-after header: ${retryAfterHeader}`);
   return null;
 }
 
@@ -66,12 +66,11 @@ function parseRetryAfterHeader(response: Response) {
   const retryAfterHeader =
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     response.headers.get?.("retry-after") || (response.headers as any)["retry-after"];
-  dbgr(`retry-after header: %s`, retryAfterHeader);
   if (retryAfterHeader) {
     const retryAfterSeconds = parseRetryAfter(retryAfterHeader);
     if (retryAfterSeconds !== null) {
       const retryAfter = retryAfterSeconds * 1000; // Convert to milliseconds
-      dbgr(`retry-after header: %s`, prettyDuration(retryAfter));
+      dbgr(`retry-after: %s`, prettyDuration(retryAfter));
       return retryAfter;
     }
   }
@@ -180,7 +179,7 @@ export async function createFetch(
     retryDelay: (attempt, error, response) => {
       // Check for retry-after header and respect its value
       let delay: number;
-      let retryAfter = parseRetryAfterHeader(response);
+      const retryAfter = parseRetryAfterHeader(response);
 
       if (retryAfter) {
         delay = Math.min(maxDelay, retryAfter); // Convert to milliseconds

--- a/packages/core/src/openai.ts
+++ b/packages/core/src/openai.ts
@@ -115,8 +115,16 @@ export function getConfigHeaders(cfg: LanguageModelConfiguration) {
 }
 
 export const OpenAIChatCompletion: ChatCompletionHandler = async (req, cfg, options, trace) => {
-  const { requestOptions, partialCb, retry, retryDelay, maxDelay, cancellationToken, inner } =
-    options;
+  const {
+    requestOptions,
+    partialCb,
+    retries,
+    retryDelay,
+    maxDelay,
+    maxRetryAfter,
+    cancellationToken,
+    inner,
+  } = options;
   const { headers = {}, ...rest } = requestOptions || {};
   const { provider, model, family, reasoningEffort } = parseModelIdentifier(req.model);
   const features = providerFeatures(provider);
@@ -256,9 +264,10 @@ export const OpenAIChatCompletion: ChatCompletionHandler = async (req, cfg, opti
   let numReasoningTokens = 0;
   const fetchRetry = await createFetch({
     trace,
-    retries: retry,
+    retries,
     retryDelay,
     maxDelay,
+    maxRetryAfter,
     cancellationToken,
   });
   trace?.dispatchChange();

--- a/packages/core/src/server/messages.ts
+++ b/packages/core/src/server/messages.ts
@@ -155,6 +155,7 @@ export interface PromptScriptRunOptions {
   retry: string;
   retryDelay: string;
   maxDelay: string;
+  maxRetryAfter: string;
   json: boolean;
   outTrace: string;
   outOutput: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5609,6 +5609,7 @@ export interface RetryOptions {
   retries?: number; // Number of retry attempts
   retryDelay?: number; // Initial delay between retries
   maxDelay?: number; // Maximum delay between retries
+  maxRetryAfter?: number; // Maximum retry-after in milliseconds before giving up
 }
 
 export interface CacheOptions {

--- a/packages/sample/proxy/github/devproxyrc.json
+++ b/packages/sample/proxy/github/devproxyrc.json
@@ -19,6 +19,6 @@
   "gitHubModelsApi": {
     "errorsFile": "github-models-errors.json"
   },
-  "rate": 90,
+  "rate": 99,
   "logLevel": "information"
 }


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

### Summary of Changes

- 🚦 **Enhanced Retry Logic for API Requests**
  - Introduced new configuration options for controlling retry behavior, including `maxRetryAfter`, which limits the maximum "retry-after" delay before giving up on a request.
  - Updated CLI and internal run logic to accept and pass through these new retry-related parameters.
  - Improved handling of the `Retry-After` HTTP header, ensuring delays respect both `maxDelay` and `maxRetryAfter` limits.
  - Refactored retry logic to be more robust and configurable, aligning with best practices for handling rate-limited or transient API errors.

- 🛠️ **Consistent Option Naming and Usage**
  - Standardized retry-related parameter names (`retries`, `retryDelay`, `maxDelay`, `maxRetryAfter`) across internal APIs and types.
  - Updated interfaces and type definitions to reflect these changes, improving clarity and maintainability.

- 🧪 **Configuration and Defaults Update**
  - Adjusted default values for retry delays and maximum retry-after durations in constants, providing more sensible and consistent defaults.

- 📝 **Sample Proxy Configuration Tweaks**
  - Increased the `rate` limit in the GitHub proxy sample configuration for demonstration or testing purposes.

These changes improve the reliability and configurability of API interactions, especially when dealing with rate limits or transient failures, and make retry behaviors more transparent and manageable.

> AI-generated content by prd may be incorrect.



<!-- genaiscript end prd -->

