### PR TITLE
mcp sampling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,6 +71,7 @@
         "dbgi",
         "dbgp",
         "dbgr",
+        "dbgs",
         "dbgt",
         "ddir",
         "debugify",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -236,6 +236,7 @@
         "oldsrc",
         "ollama",
         "olmo",
+        "oninitialized",
         "onnx",
         "onvsc",
         "openai",

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -60,6 +60,7 @@ export async function run(
 ): Promise<GenerationResult> {
   if (!scriptId) throw new Error("scriptId is required");
   dbg(`run ${scriptId}`);
+  // eslint-disable-next-line no-param-reassign
   if (typeof files === "string") files = [files];
 
   const { signal, onMessage, ...rest } = options || {};
@@ -77,7 +78,7 @@ export async function run(
   dbg(`start ${workerJs}`);
   const worker = new Worker(workerJs, { workerData, name: options?.label });
   return new Promise((resolve, reject) => {
-    const abort = () => {
+    const abort = (): void => {
       if (worker) {
         dbg(`abort`);
         reject(new Error("aborted")); // fail early
@@ -97,7 +98,7 @@ export async function run(
         dbg(`unknown message type ${type}`);
       }
     });
-    worker.on("error", (reason) => {
+    worker.on("error", (reason: string) => {
       dbg(`error ${reason}`);
       signal?.removeEventListener("abort", abort);
       reject(reason);

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -56,6 +56,10 @@ export async function run(
      * Handles messages
      */
     onMessage?: (data: { type: "resourceChange" } & Resource) => Awaitable<void>;
+    /**
+     * Enable client language model as parent.
+     */
+    parentLanguageModel?: boolean;
   },
 ): Promise<GenerationResult> {
   if (!scriptId) throw new Error("scriptId is required");

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -55,7 +55,10 @@ export async function run(
     /**
      * Handles messages
      */
-    onMessage?: (data: { type: "resourceChange" } & Resource) => Awaitable<void>;
+    onMessage?: (
+      data: { type: "resourceChange" } & Resource,
+      postMessage: (data: any) => void,
+    ) => Awaitable<void>;
     /**
      * Enable client language model as parent.
      */
@@ -97,7 +100,10 @@ export async function run(
         signal?.removeEventListener("abort", abort);
         resolve(res.result);
       } else if (onMessage) {
-        await onMessage(res);
+        await onMessage(res, (data) => {
+          dbg(`postMessage %O`, data);
+          worker.postMessage(data);
+        });
       } else {
         dbg(`unknown message type ${type}`);
       }

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -6,12 +6,15 @@ import { delay } from "es-toolkit";
 import { NodeHost } from "@genaiscript/runtime";
 import {
   RESOURCE_CHANGE,
+  genaiscriptDebug,
   installGlobals,
   overrideStdoutWithStdErr,
   runtimeHost,
+  createWorkerLanguageModel,
 } from "@genaiscript/core";
 import type { Resource } from "@genaiscript/core";
 import { runScriptInternal } from "./run.js";
+const dbg = genaiscriptDebug("worker");
 
 /**
  * Handles worker thread execution based on the provided data type.
@@ -28,12 +31,13 @@ import { runScriptInternal } from "./run.js";
  *     - Handles resource change events and communicates them to the parent thread.
  *     - Ensures compatibility with Windows by setting the SystemRoot environment variable.
  */
-export async function worker() {
+export async function worker(): Promise<void> {
   overrideStdoutWithStdErr();
   installGlobals();
   const { type, ...data } = workerData as {
     type: string;
   };
+  dbg(`worker data: %O`, data);
   await NodeHost.install(undefined, undefined); // Install NodeHost with environment options
   if (process.platform === "win32") {
     // https://github.com/Azure/azure-sdk-for-js/issues/32374
@@ -55,9 +59,13 @@ export async function worker() {
       const { scriptId, files, options } = data as {
         scriptId: string;
         files: string[];
-        options: object;
+        options: { parentLanguageModel?: boolean };
       };
-      const { result } = await runScriptInternal(scriptId, files, options);
+      if (options.parentLanguageModel) {
+        dbg(`using parent language model`);
+        runtimeHost.clientLanguageModel = createWorkerLanguageModel();
+      }
+      const { result } = await runScriptInternal(scriptId, files, options as any);
       await delay(0); // flush streams
       parentPort.postMessage({ type: "run", result });
       break;

--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -109,8 +109,9 @@ export async function startMcpServer(
       dbg(`chatCompletion message received: %O`, data);
       const { request, ...rest } = data;
       const response = await mcpRequestSample(server, data.request);
-      dbg(`chatCompletion response: %O`, response);
-      postMessage({ ...rest, response });
+      const msg = { ...rest, response };
+      dbg(`chatCompletion response: %O`, msg);
+      postMessage(msg);
     } else {
       dbg(`unknown message type: ${data.type}`);
     }

--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -16,7 +16,7 @@ import {
   setConsoleColors,
   splitMarkdownTextImageParts,
   toStrictJSONSchema,
-  mcpCreateLanguageModel,
+  mcpRequestSample,
 } from "@genaiscript/core";
 import type {
   GenerationResult,
@@ -41,6 +41,7 @@ import type {
 import { applyRemoteOptions } from "./remote.js";
 import type { RemoteOptions } from "./remote.js";
 import { startProjectWatcher } from "./watch.js";
+import { workerData } from "worker_threads";
 const dbg = genaiscriptDebug("mcp:server");
 
 /**
@@ -65,6 +66,7 @@ export async function startMcpServer(
   await ensureDotGenaiscriptPath();
   await applyRemoteOptions(options);
   const { startup } = options || {};
+  let samplingSupported = false;
 
   const watcher = await startProjectWatcher(options);
   logVerbose(`mcp server: watching ${watcher.cwd}`);
@@ -90,10 +92,29 @@ export async function startMcpServer(
       },
     },
   );
-  watcher.addEventListener("change", async () => {
-    logVerbose(`mcp server: tools changed`);
-    await server.sendToolListChanged();
-  });
+  watcher.addEventListener(
+    "change",
+    async () => {
+      logVerbose(`mcp server: tools changed`);
+      await server.sendToolListChanged();
+    },
+    false,
+  );
+  const onMessage = async (data: any, postMessage: (data: any) => void) => {
+    if (data.type === RESOURCE_CHANGE) {
+      await runtimeHost.resources.upsertResource(data.reference, data.content);
+    } else if (data.type === "chatCompletion") {
+      if (!samplingSupported) throw new Error("Sampling not supported by client");
+      // Handle chat completion messages if needed
+      dbg(`chatCompletion message received: %O`, data);
+      const { request, ...rest } = data;
+      const response = await mcpRequestSample(server, data.request);
+      dbg(`chatCompletion response: %O`, response);
+      postMessage({ ...rest, response });
+    } else {
+      dbg(`unknown message type: ${data.type}`);
+    }
+  };
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     dbg(`fetching scripts from watcher`);
     const scripts = await watcher.scripts();
@@ -148,15 +169,8 @@ export async function startMcpServer(
         vars: vars as Record<string, string | number | boolean | object>,
         runTrace: false,
         outputTrace: false,
-        parentLanguageModel: true,
-        onMessage: async (data) => {
-          if (data.type === RESOURCE_CHANGE) {
-            dbg(`updating resource: %O`, data.reference);
-            await runtimeHost.resources.upsertResource(data.reference, data.content);
-          } else {
-            dbg(`unknown message type: %s`, data.type);
-          }
-        },
+        parentLanguageModel: samplingSupported,
+        onMessage,
       })) || { status: "error", error: { message: "run failed" } };
       dbg(`res: %s`, res.status);
       if (res.error) dbg(`error: %O`, res.error);
@@ -204,38 +218,37 @@ export async function startMcpServer(
     if (!resource) dbg(`resource not found: ${uri}`);
     return resource as ReadResourceResult;
   });
-  runtimeHost.resources.addEventListener(CHANGE, async () => {
-    await server.sendResourceListChanged();
-  });
-  runtimeHost.resources.addEventListener(RESOURCE_CHANGE, async (e) => {
-    const ev = e as CustomEvent<Resource>;
-    await server.sendResourceUpdated({
-      uri: ev.detail.reference.uri,
-    });
-  });
+  runtimeHost.resources.addEventListener(
+    CHANGE,
+    async () => {
+      await server.sendResourceListChanged();
+    },
+    false,
+  );
+  runtimeHost.resources.addEventListener(
+    RESOURCE_CHANGE,
+    async (e) => {
+      const ev = e as CustomEvent<Resource>;
+      await server.sendResourceUpdated({
+        uri: ev.detail.reference.uri,
+      });
+    },
+    false,
+  );
 
   server.oninitialized = async () => {
     dbg(`server/client connection initialized`);
     // Check if client supports sampling
     const clientCapabilities = server.getClientCapabilities();
     dbg(`client capabilities: %O`, clientCapabilities);
-    if (clientCapabilities?.sampling) {
-      dbg(`registering client sampling`);
-      runtimeHost.clientLanguageModel = mcpCreateLanguageModel(server);
-    }
+    samplingSupported = !!clientCapabilities?.sampling;
 
     if (startup) {
       logVerbose(`startup script: ${startup}`);
       await run(startup, [], {
         vars: {},
-        parentLanguageModel: true,
-        onMessage: async (data) => {
-          if (data.type === RESOURCE_CHANGE) {
-            await runtimeHost.resources.upsertResource(data.reference, data.content);
-          } else {
-            dbg(`unknown message type: ${data.type}`);
-          }
-        },
+        parentLanguageModel: samplingSupported,
+        onMessage,
       });
     }
   };

--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -160,6 +160,14 @@ export async function startMcpServer(
         vars: vars as Record<string, string | number | boolean | object>,
         runTrace: false,
         outputTrace: false,
+        onMessage: async (data) => {
+          if (data.type === RESOURCE_CHANGE) {
+            dbg(`updating resource: %O`, data.reference);
+            await runtimeHost.resources.upsertResource(data.reference, data.content);
+          } else {
+            dbg(`unknown message type: %s`, data.type);
+          }
+        }
       })) || { status: "error", error: { message: "run failed" } };
       dbg(`res: %s`, res.status);
       if (res.error) dbg(`error: %O`, res.error);
@@ -306,7 +314,7 @@ export async function startMcpServer(
       vars: {},
       onMessage: async (data) => {
         if (data.type === RESOURCE_CHANGE) {
-          await runtimeHost.resources.upsetResource(data.reference, data.content);
+          await runtimeHost.resources.upsertResource(data.reference, data.content);
         } else {
           dbg(`unknown message type: ${data.type}`);
         }

--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -148,6 +148,7 @@ export async function startMcpServer(
         vars: vars as Record<string, string | number | boolean | object>,
         runTrace: false,
         outputTrace: false,
+        parentLanguageModel: true,
         onMessage: async (data) => {
           if (data.type === RESOURCE_CHANGE) {
             dbg(`updating resource: %O`, data.reference);
@@ -213,7 +214,7 @@ export async function startMcpServer(
     });
   });
 
-  server.oninitialized = () => {
+  server.oninitialized = async () => {
     dbg(`server/client connection initialized`);
     // Check if client supports sampling
     const clientCapabilities = server.getClientCapabilities();
@@ -222,23 +223,24 @@ export async function startMcpServer(
       dbg(`registering client sampling`);
       runtimeHost.clientLanguageModel = mcpCreateLanguageModel(server);
     }
+
+    if (startup) {
+      logVerbose(`startup script: ${startup}`);
+      await run(startup, [], {
+        vars: {},
+        parentLanguageModel: true,
+        onMessage: async (data) => {
+          if (data.type === RESOURCE_CHANGE) {
+            await runtimeHost.resources.upsertResource(data.reference, data.content);
+          } else {
+            dbg(`unknown message type: ${data.type}`);
+          }
+        },
+      });
+    }
   };
 
   const transport = new StdioServerTransport();
   dbg(`connecting server with transport`);
   await server.connect(transport);
-
-  if (startup) {
-    logVerbose(`startup script: ${startup}`);
-    await run(startup, [], {
-      vars: {},
-      onMessage: async (data) => {
-        if (data.type === RESOURCE_CHANGE) {
-          await runtimeHost.resources.upsertResource(data.reference, data.content);
-        } else {
-          dbg(`unknown message type: ${data.type}`);
-        }
-      },
-    });
-  }
 }

--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -167,7 +167,7 @@ export async function startMcpServer(
       const text = res?.error?.message || (res.json ? JSON.stringify(res.json) : res.text) || "";
       dbg(`inlining images`);
       const parts = await splitMarkdownTextImageParts(text, {
-        dir: res.env.runDir,
+        dir: res.env?.runDir,
         convertToDataUri: true,
       });
       dbg(`parts: %O`, parts);
@@ -217,84 +217,88 @@ export async function startMcpServer(
     });
   });
 
+  server.oninitialized = () => {
+    dbg(`server/client connection initialized`);
+    // Check if client supports sampling
+    const clientCapabilities = server.getClientCapabilities();
+    dbg(`client capabilities: %O`, clientCapabilities);
+    if (clientCapabilities?.sampling) {
+      dbg(`registering client sampling`);
+      runtimeHost.clientLanguageModel = Object.freeze<LanguageModel>({
+        id: MODEL_PROVIDER_MCP,
+        completer: async (
+          req: CreateChatCompletionRequest,
+          connection: LanguageModelConfiguration,
+          completerOptions: ChatCompletionsOptions,
+          trace: MarkdownTrace,
+        ): Promise<ChatCompletionResponse> => {
+          // Implement the completer logic here
+          dbgs(`sampling ${req.model}`);
+          const { model } = parseModelIdentifier(req.model);
+          const { partialCb, inner } = completerOptions || {};
+
+          const maxTokens = req.max_completion_tokens;
+          const systemMessages = req.messages.filter(({ role }) => role === "system");
+          const systemPrompt = systemMessages.map(({ content }) => content).join(SYSTEM_FENCE);
+          const otherMessages = req.messages.filter(({ role }) => role !== "system");
+
+          const body = deleteUndefinedValues({
+            method: "sampling/createMessage",
+            params: deleteUndefinedValues({
+              messages: otherMessages,
+              temperature: req.temperature,
+              metadata: req.metadata,
+              modelPreferences: {
+                hints: [
+                  {
+                    name: model,
+                  },
+                ].filter(({ name }) => !!name),
+                intelligencePriority: 0.8,
+                speedPriority: 0.5,
+              },
+              systemPrompt,
+              maxTokens,
+            }),
+          });
+
+          trace.detailsFenced(`🧪 mcp sampling`, body, "json");
+
+          let responseSoFar = "";
+          const res = await server.request(body, CreateMessageResultSchema, {
+            onprogress: (data) => {
+              dbgs(`%d/%d %s`, data.progress, data.total, data.message);
+              responseSoFar += data.message;
+              partialCb?.({
+                responseSoFar,
+                responseChunk: data.message,
+                tokensSoFar: data.progress,
+                inner,
+              });
+            },
+          });
+
+          trace.detailsFenced(`🧪 sampling result`, res, "json");
+          // "endTurn", "stopSequence", "maxTokens"
+          const finishReason: "stop" | "length" | "fail" =
+            {
+              ["endTurn"]: "stop",
+              ["stopSequence"]: "stop",
+              ["maxTokens"]: "length",
+            }[res.stopReason] ?? ("fail" as any);
+          return {
+            model: res.model,
+            text: res.content?.type === "text" ? res.content.text : "",
+            finishReason,
+          } satisfies ChatCompletionResponse;
+        },
+      } satisfies LanguageModel);
+    }
+  };
+
   const transport = new StdioServerTransport();
   dbg(`connecting server with transport`);
   await server.connect(transport);
-  // Check if client supports sampling
-  const clientCapabilities = server.getClientCapabilities();
-  dbg(`client capabilities: %O`, clientCapabilities);
-  if (clientCapabilities?.sampling) {
-    dbg(`registering client sampling`);
-    runtimeHost.clientLanguageModel = {
-      id: MODEL_PROVIDER_MCP,
-      completer: async (
-        req: CreateChatCompletionRequest,
-        connection: LanguageModelConfiguration,
-        completerOptions: ChatCompletionsOptions,
-        trace: MarkdownTrace,
-      ): Promise<ChatCompletionResponse> => {
-        // Implement the completer logic here
-        dbgs(`sampling ${req.model}`);
-        const { model } = parseModelIdentifier(req.model);
-        const { partialCb, inner } = completerOptions || {};
-
-        const maxTokens = req.max_completion_tokens;
-        const systemMessages = req.messages.filter(({ role }) => role === "system");
-        const systemPrompt = systemMessages.map(({ content }) => content).join(SYSTEM_FENCE);
-        const otherMessages = req.messages.filter(({ role }) => role !== "system");
-
-        const body = deleteUndefinedValues({
-          method: "sampling/createMessage",
-          params: deleteUndefinedValues({
-            messages: otherMessages,
-            temperature: req.temperature,
-            metadata: req.metadata,
-            modelPreferences: {
-              hints: [
-                {
-                  name: model,
-                },
-              ].filter(({ name }) => !!name),
-              intelligencePriority: 0.8,
-              speedPriority: 0.5,
-            },
-            systemPrompt,
-            maxTokens,
-          }),
-        });
-
-        trace.detailsFenced(`🧪 mcp sampling`, body, "json");
-
-        let responseSoFar = "";
-        const res = await server.request(body, CreateMessageResultSchema, {
-          onprogress: (data) => {
-            dbgs(`%d/%d %s`, data.progress, data.total, data.message);
-            responseSoFar += data.message;
-            partialCb?.({
-              responseSoFar,
-              responseChunk: data.message,
-              tokensSoFar: data.progress,
-              inner,
-            });
-          },
-        });
-
-        trace.detailsFenced(`🧪 sampling result`, res, "json");
-        // "endTurn", "stopSequence", "maxTokens"
-        const finishReason: "stop" | "length" | "fail" =
-          {
-            ["endTurn"]: "stop",
-            ["stopSequence"]: "stop",
-            ["maxTokens"]: "length",
-          }[res.stopReason] ?? ("fail" as any);
-        return {
-          model: res.model,
-          text: res.content?.type === "text" ? res.content.text : "",
-          finishReason,
-        } satisfies ChatCompletionResponse;
-      },
-    } satisfies LanguageModel;
-  }
 
   if (startup) {
     logVerbose(`startup script: ${startup}`);

--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -4,9 +4,7 @@
 import {
   CHANGE,
   CORE_VERSION,
-  MODEL_PROVIDER_MCP,
   RESOURCE_CHANGE,
-  SYSTEM_FENCE,
   TOOL_ID,
   deleteUndefinedValues,
   ensureDotGenaiscriptPath,
@@ -14,21 +12,15 @@ import {
   genaiscriptDebug,
   logVerbose,
   logWarn,
-  parseModelIdentifier,
   runtimeHost,
   setConsoleColors,
   splitMarkdownTextImageParts,
   toStrictJSONSchema,
+  mcpCreateLanguageModel,
 } from "@genaiscript/core";
 import type {
-  ChatCompletionResponse,
-  ChatCompletionsOptions,
-  CreateChatCompletionRequest,
   GenerationResult,
   JSONSchemaObject,
-  LanguageModel,
-  LanguageModelConfiguration,
-  MarkdownTrace,
   Resource,
   ResourceContents,
   ScriptFilterOptions,
@@ -38,8 +30,6 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
   ReadResourceRequestSchema,
-  CreateMessageRequestSchema,
-  CreateMessageResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type {
   CallToolResult,
@@ -51,9 +41,7 @@ import type {
 import { applyRemoteOptions } from "./remote.js";
 import type { RemoteOptions } from "./remote.js";
 import { startProjectWatcher } from "./watch.js";
-import { stderr } from "@genaiscript/core";
 const dbg = genaiscriptDebug("mcp:server");
-const dbgs = genaiscriptDebug("mcp:server:sampling");
 
 /**
  * Starts the MCP server.
@@ -167,7 +155,7 @@ export async function startMcpServer(
           } else {
             dbg(`unknown message type: %s`, data.type);
           }
-        }
+        },
       })) || { status: "error", error: { message: "run failed" } };
       dbg(`res: %s`, res.status);
       if (res.error) dbg(`error: %O`, res.error);
@@ -232,75 +220,7 @@ export async function startMcpServer(
     dbg(`client capabilities: %O`, clientCapabilities);
     if (clientCapabilities?.sampling) {
       dbg(`registering client sampling`);
-      runtimeHost.clientLanguageModel = Object.freeze<LanguageModel>({
-        id: MODEL_PROVIDER_MCP,
-        completer: async (
-          req: CreateChatCompletionRequest,
-          connection: LanguageModelConfiguration,
-          completerOptions: ChatCompletionsOptions,
-          trace: MarkdownTrace,
-        ): Promise<ChatCompletionResponse> => {
-          // Implement the completer logic here
-          dbgs(`sampling ${req.model}`);
-          const { model } = parseModelIdentifier(req.model);
-          const { partialCb, inner } = completerOptions || {};
-
-          const maxTokens = req.max_completion_tokens;
-          const systemMessages = req.messages.filter(({ role }) => role === "system");
-          const systemPrompt = systemMessages.map(({ content }) => content).join(SYSTEM_FENCE);
-          const otherMessages = req.messages.filter(({ role }) => role !== "system");
-
-          const body = deleteUndefinedValues({
-            method: "sampling/createMessage",
-            params: deleteUndefinedValues({
-              messages: otherMessages,
-              temperature: req.temperature,
-              metadata: req.metadata,
-              modelPreferences: {
-                hints: [
-                  {
-                    name: model,
-                  },
-                ].filter(({ name }) => !!name),
-                intelligencePriority: 0.8,
-                speedPriority: 0.5,
-              },
-              systemPrompt,
-              maxTokens,
-            }),
-          });
-
-          trace.detailsFenced(`🧪 mcp sampling`, body, "json");
-
-          let responseSoFar = "";
-          const res = await server.request(body, CreateMessageResultSchema, {
-            onprogress: (data) => {
-              dbgs(`%d/%d %s`, data.progress, data.total, data.message);
-              responseSoFar += data.message;
-              partialCb?.({
-                responseSoFar,
-                responseChunk: data.message,
-                tokensSoFar: data.progress,
-                inner,
-              });
-            },
-          });
-
-          trace.detailsFenced(`🧪 sampling result`, res, "json");
-          // "endTurn", "stopSequence", "maxTokens"
-          const finishReason: "stop" | "length" | "fail" =
-            {
-              ["endTurn"]: "stop",
-              ["stopSequence"]: "stop",
-              ["maxTokens"]: "length",
-            }[res.stopReason] ?? ("fail" as any);
-          return {
-            model: res.model,
-            text: res.content?.type === "text" ? res.content.text : "",
-            finishReason,
-          } satisfies ChatCompletionResponse;
-        },
-      } satisfies LanguageModel);
+      runtimeHost.clientLanguageModel = mcpCreateLanguageModel(server);
     }
   };
 

--- a/packages/cli/src/mcpserver.ts
+++ b/packages/cli/src/mcpserver.ts
@@ -4,21 +4,31 @@
 import {
   CHANGE,
   CORE_VERSION,
+  MODEL_PROVIDER_MCP,
   RESOURCE_CHANGE,
+  SYSTEM_FENCE,
   TOOL_ID,
   deleteUndefinedValues,
   ensureDotGenaiscriptPath,
   errorMessage,
+  genaiscriptDebug,
   logVerbose,
   logWarn,
+  parseModelIdentifier,
   runtimeHost,
   setConsoleColors,
   splitMarkdownTextImageParts,
   toStrictJSONSchema,
 } from "@genaiscript/core";
 import type {
+  ChatCompletionResponse,
+  ChatCompletionsOptions,
+  CreateChatCompletionRequest,
   GenerationResult,
   JSONSchemaObject,
+  LanguageModel,
+  LanguageModelConfiguration,
+  MarkdownTrace,
   Resource,
   ResourceContents,
   ScriptFilterOptions,
@@ -28,6 +38,8 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
   ReadResourceRequestSchema,
+  CreateMessageRequestSchema,
+  CreateMessageResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type {
   CallToolResult,
@@ -39,8 +51,9 @@ import type {
 import { applyRemoteOptions } from "./remote.js";
 import type { RemoteOptions } from "./remote.js";
 import { startProjectWatcher } from "./watch.js";
-import debug from "debug";
-const dbg = debug("genaiscript:mcp:server");
+import { stderr } from "@genaiscript/core";
+const dbg = genaiscriptDebug("mcp:server");
+const dbgs = genaiscriptDebug("mcp:server:sampling");
 
 /**
  * Starts the MCP server.
@@ -57,7 +70,7 @@ export async function startMcpServer(
     RemoteOptions & {
       startup?: string;
     },
-) {
+): Promise<void> {
   setConsoleColors(false);
   logVerbose(`mcp server: starting...`);
 
@@ -112,7 +125,7 @@ export async function startMcpServer(
           properties: {},
         };
         const outputSchema = responseSchema ? toStrictJSONSchema(responseSchema) : undefined;
-        if (accept !== "none")
+        if (accept !== "none") {
           scriptSchema.properties.files = {
             type: "array",
             items: {
@@ -120,6 +133,7 @@ export async function startMcpServer(
               description: `Filename or globs relative to the workspace used by the script.${accept ? ` Accepts: ${accept}` : ""}`,
             },
           };
+        }
         if (!description) logWarn(`script ${id} has no description`);
         return deleteUndefinedValues({
           name: id,
@@ -206,6 +220,81 @@ export async function startMcpServer(
   const transport = new StdioServerTransport();
   dbg(`connecting server with transport`);
   await server.connect(transport);
+  // Check if client supports sampling
+  const clientCapabilities = server.getClientCapabilities();
+  dbg(`client capabilities: %O`, clientCapabilities);
+  if (clientCapabilities?.sampling) {
+    dbg(`registering client sampling`);
+    runtimeHost.clientLanguageModel = {
+      id: MODEL_PROVIDER_MCP,
+      completer: async (
+        req: CreateChatCompletionRequest,
+        connection: LanguageModelConfiguration,
+        completerOptions: ChatCompletionsOptions,
+        trace: MarkdownTrace,
+      ): Promise<ChatCompletionResponse> => {
+        // Implement the completer logic here
+        dbgs(`sampling ${req.model}`);
+        const { model } = parseModelIdentifier(req.model);
+        const { partialCb, inner } = completerOptions || {};
+
+        const maxTokens = req.max_completion_tokens;
+        const systemMessages = req.messages.filter(({ role }) => role === "system");
+        const systemPrompt = systemMessages.map(({ content }) => content).join(SYSTEM_FENCE);
+        const otherMessages = req.messages.filter(({ role }) => role !== "system");
+
+        const body = deleteUndefinedValues({
+          method: "sampling/createMessage",
+          params: deleteUndefinedValues({
+            messages: otherMessages,
+            temperature: req.temperature,
+            metadata: req.metadata,
+            modelPreferences: {
+              hints: [
+                {
+                  name: model,
+                },
+              ].filter(({ name }) => !!name),
+              intelligencePriority: 0.8,
+              speedPriority: 0.5,
+            },
+            systemPrompt,
+            maxTokens,
+          }),
+        });
+
+        trace.detailsFenced(`🧪 mcp sampling`, body, "json");
+
+        let responseSoFar = "";
+        const res = await server.request(body, CreateMessageResultSchema, {
+          onprogress: (data) => {
+            dbgs(`%d/%d %s`, data.progress, data.total, data.message);
+            responseSoFar += data.message;
+            partialCb?.({
+              responseSoFar,
+              responseChunk: data.message,
+              tokensSoFar: data.progress,
+              inner,
+            });
+          },
+        });
+
+        trace.detailsFenced(`🧪 sampling result`, res, "json");
+        // "endTurn", "stopSequence", "maxTokens"
+        const finishReason: "stop" | "length" | "fail" =
+          {
+            ["endTurn"]: "stop",
+            ["stopSequence"]: "stop",
+            ["maxTokens"]: "length",
+          }[res.stopReason] ?? ("fail" as any);
+        return {
+          model: res.model,
+          text: res.content?.type === "text" ? res.content.text : "",
+          finishReason,
+        } satisfies ChatCompletionResponse;
+      },
+    } satisfies LanguageModel;
+  }
 
   if (startup) {
     logVerbose(`startup script: ${startup}`);

--- a/packages/cli/src/watch.ts
+++ b/packages/cli/src/watch.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { FSWatcher, watch } from "chokidar";
+import { watch } from "chokidar";
+import type { FSWatcher } from "chokidar";
 import { basename, resolve } from "node:path";
 import {
   CHANGE,
@@ -40,11 +41,11 @@ export class ProjectWatcher extends EventTarget {
     signal?.addEventListener("abort", this.close.bind(this));
   }
 
-  get cwd() {
+  get cwd(): string {
     return this.options.cwd;
   }
 
-  async open() {
+  async open(): Promise<void> {
     if (this._watcher) return;
 
     dbg(`starting`);
@@ -77,7 +78,7 @@ export class ProjectWatcher extends EventTarget {
       depth: 30,
       cwd,
     });
-    const changed = () => {
+    const changed = (): void => {
       dbg(`changed`);
       this.dispatchEvent(new Event(CHANGE));
     };
@@ -90,11 +91,11 @@ export class ProjectWatcher extends EventTarget {
     this.dispatchEvent(new Event(OPEN));
   }
 
-  private async refresh() {
+  private async refresh(): Promise<void> {
     this._project = undefined;
   }
 
-  async project() {
+  async project(): Promise<Project> {
     if (!this._project) {
       dbg(`building project`);
       this._project = await buildProject();
@@ -102,7 +103,7 @@ export class ProjectWatcher extends EventTarget {
     return this._project;
   }
 
-  async scripts() {
+  async scripts(): Promise<PromptScript[]> {
     if (!this._scripts) {
       const project = await this.project();
       this._scripts = filterScripts(project.scripts, this.options);
@@ -110,7 +111,7 @@ export class ProjectWatcher extends EventTarget {
     return this._scripts?.slice(0);
   }
 
-  async close() {
+  async close(): Promise<void> {
     dbg(`closing`);
     await this._watcher?.close();
     this._watcher = undefined;
@@ -133,7 +134,7 @@ export async function startProjectWatcher(
     paths?: ElementOrArray<string>;
     cwd?: string;
   } & CancellationOptions,
-) {
+): Promise<ProjectWatcher> {
   const { paths = ".", cwd = resolve("."), ...rest } = options || {};
   const watcher = new ProjectWatcher({ paths, cwd, ...rest });
   await watcher.open();

--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -85,7 +85,7 @@ export function collectFolders(
  * @returns The script with the matching ID, or undefined if no match is found.
  */
 export function resolveScript(prj: Project, system: SystemPromptInstance) {
-  return prj?.scripts?.find((t) => t.id == system.id); // Find and return the template with the matching ID
+  return prj?.scripts?.find((t) => t.id === system.id); // Find and return the template with the matching ID
 }
 
 export interface ScriptFilterOptions {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -205,6 +205,7 @@ export const MODEL_PROVIDER_WINDOWS_AI = "windows";
 export const MODEL_PROVIDER_DOCKER_MODEL_RUNNER = "docker";
 export const MODEL_PROVIDER_ECHO = "echo";
 export const MODEL_PROVIDER_NONE = "none";
+export const MODEL_PROVIDER_MCP = "mcp";
 
 export const MODEL_GITHUB_COPILOT_CHAT_CURRENT = MODEL_PROVIDER_GITHUB_COPILOT_CHAT + ":current";
 

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -52,6 +52,7 @@ import {
   GITHUB_TOKENS,
   MODEL_PROVIDER_DOCKER_MODEL_RUNNER,
   DOCKER_MODEL_RUNNER_API_BASE,
+  MODEL_PROVIDER_MCP,
 } from "./constants.js";
 import { runtimeHost } from "./host.js";
 import { parseModelIdentifier } from "./models.js";
@@ -821,6 +822,20 @@ export async function parseTokenFromEnv(
       modelId,
       base: undefined,
       token: MODEL_PROVIDER_GITHUB_COPILOT_CHAT,
+    };
+  }
+
+  if (provider === MODEL_PROVIDER_MCP) {
+    dbg(`processing MODEL_PROVIDER_MCP`);
+    if (!runtimeHost.clientLanguageModel) {
+      throw new Error(`${MODEL_PROVIDER_MCP} requires MCP Client with Sampling.`);
+    }
+    return {
+      provider,
+      model,
+      modelId,
+      base: undefined,
+      token: MODEL_PROVIDER_MCP,
     };
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ export * from "./markdown.js";
 export * from "./math.js";
 export * from "./mcpclient.js";
 export * from "./mcpresource.js";
+export * from "./mcpsampling.js";
 export * from "./mdchunk.js";
 export * from "./mddiff.js";
 export * from "./mdstringify.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -189,6 +189,7 @@ export * from "./version.js";
 export * from "./websearch.js";
 export * from "./whisperasr.js";
 export * from "./workdir.js";
+export * from "./workerlm.js";
 export * from "./workspace.js";
 export * from "./xlsx.js";
 export * from "./xml.js";

--- a/packages/core/src/llmsdata.ts
+++ b/packages/core/src/llmsdata.ts
@@ -729,6 +729,21 @@ export default {
       env: {},
     },
     {
+      id: "mcp",
+      detail: "MCP Client Sampling",
+      hidden: true,
+      tools: false,
+      prediction: false,
+      tokenless: true,
+      aliases: {
+        large: "gpt-4o",
+        small: "gpt-4o-mini",
+        reasoning: "o3-mini",
+        reasoning_small: "o1-mini",
+      },
+      env: {},
+    },
+    {
       id: "echo",
       detail: "A fake LLM provider that responds with the input messages.",
       tools: true,

--- a/packages/core/src/lm.ts
+++ b/packages/core/src/lm.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AnthropicBedrockModel, AnthropicModel } from "./anthropic.js";
-import { LanguageModel } from "./chat.js";
+import type { LanguageModel } from "./chat.js";
 import {
   MODEL_PROVIDER_ANTHROPIC,
   MODEL_PROVIDER_ANTHROPIC_BEDROCK,
@@ -15,6 +15,7 @@ import {
   MODEL_PROVIDER_ECHO,
   MODEL_PROVIDER_NONE,
   MODEL_PROVIDER_AZURE_AI_INFERENCE,
+  MODEL_PROVIDER_MCP,
 } from "./constants.js";
 import { runtimeHost } from "./host.js";
 import { OllamaModel } from "./ollama.js";
@@ -44,6 +45,11 @@ export function resolveLanguageModel(provider: string): LanguageModel {
   if (provider === MODEL_PROVIDER_GITHUB_COPILOT_CHAT) {
     const m = runtimeHost.clientLanguageModel;
     if (!m) throw new Error("Github Copilot Chat Models not available");
+    return m;
+  }
+  if (provider === MODEL_PROVIDER_MCP) {
+    const m = runtimeHost.clientLanguageModel;
+    if (!m) throw new Error("MCP Client Sampling not available");
     return m;
   }
   if (provider === MODEL_PROVIDER_AZURE_OPENAI) return AzureOpenAIModel;

--- a/packages/core/src/mcpclient.ts
+++ b/packages/core/src/mcpclient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { TraceOptions } from "./trace.js";
+import type { TraceOptions } from "./trace.js";
 import { arrayify } from "./cleaners.js";
 import { logError, logVerbose } from "./util.js";
 import type {
@@ -10,7 +10,8 @@ import type {
   EmbeddedResource,
 } from "@modelcontextprotocol/sdk/types.js";
 import { errorMessage } from "./error.js";
-import { CancellationOptions, toSignal } from "./cancellation.js";
+import type { CancellationOptions } from "./cancellation.js";
+import { toSignal } from "./cancellation.js";
 import type { ProgressCallback } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import { deleteUndefinedValues } from "./cleaners.js";
 import { hash } from "./crypto.js";
@@ -91,9 +92,6 @@ function patchInputSchema(inputSchema: any): any {
 
 export class McpClientManager extends EventTarget implements AsyncDisposable {
   private _clients: McpClient[] = [];
-  constructor() {
-    super();
-  }
 
   async startMcpServer(
     serverConfig: McpServerConfig,
@@ -144,6 +142,8 @@ export class McpClientManager extends EventTarget implements AsyncDisposable {
           stderr: "inherit",
         }),
       );
+      // eslint-disable-next-line prefer-const
+      let mcpClient: McpClient;
       let client = new Client({ name: id, version }, { capabilities });
       dbgc(`connecting stdio transport`);
       await client.connect(transport);
@@ -224,7 +224,7 @@ export class McpClientManager extends EventTarget implements AsyncDisposable {
         }
 
         const tools = toolDefinitions.map(({ name, description, inputSchema }) => {
-          const toolSpec = toolSpecs.find(({ id }) => id === name);
+          const toolSpec = toolSpecs.find(({ id: tid }) => tid === name);
           const toolOptions = {
             ...commonToolOptions,
             ...(toolSpec || {}),
@@ -301,7 +301,7 @@ export class McpClientManager extends EventTarget implements AsyncDisposable {
 
       const dispose = async () => {
         dbgc(`disposing`);
-        const i = this._clients.indexOf(res);
+        const i = this._clients.indexOf(mcpClient);
         if (i >= 0) this._clients.splice(i, 1);
         try {
           await client.close();
@@ -339,7 +339,7 @@ export class McpClientManager extends EventTarget implements AsyncDisposable {
         } satisfies McpServerToolResult);
       };
 
-      const res = Object.freeze({
+      mcpClient = Object.freeze({
         config: Object.freeze({ ...serverConfig }),
         ping,
         listTools,
@@ -350,8 +350,8 @@ export class McpClientManager extends EventTarget implements AsyncDisposable {
         dispose,
         [Symbol.asyncDispose]: dispose,
       } satisfies McpClient);
-      this._clients.push(res);
-      return res;
+      this._clients.push(mcpClient);
+      return mcpClient;
     } finally {
       trace?.endDetails();
     }

--- a/packages/core/src/mcpresource.ts
+++ b/packages/core/src/mcpresource.ts
@@ -57,12 +57,12 @@ export class ResourceManager extends EventTarget {
   ) {
     dbg(`publishing ${typeof body}`);
     const res = await createResource(name, body, options);
-    await this.upsetResource(res.reference, res.content);
+    await this.upsertResource(res.reference, res.content);
     const { reference } = res;
     return reference.uri;
   }
 
-  async upsetResource(
+  async upsertResource(
     reference: ResourceReference,
     content: ResourceContents | undefined,
   ): Promise<void> {

--- a/packages/core/src/mcpresource.ts
+++ b/packages/core/src/mcpresource.ts
@@ -5,7 +5,7 @@ import { resolveBufferLike } from "./bufferlike.js";
 import { CHANGE, MCP_RESOURCE_PROTOCOL, RESOURCE_CHANGE } from "./constants.js";
 import debug from "debug";
 import { fileTypeFromBuffer } from "./filetype.js";
-import { TraceOptions } from "./trace.js";
+import type { TraceOptions } from "./trace.js";
 import { hash } from "./crypto.js";
 import { resolveFileContent } from "./file.js";
 import { redactSecrets } from "./secretscanner.js";

--- a/packages/core/src/mcpsampling.ts
+++ b/packages/core/src/mcpsampling.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CreateMessageResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { LanguageModel } from "./chat.js";
+import type {
+  ChatCompletionResponse,
+  ChatCompletionsOptions,
+  CreateChatCompletionRequest,
+} from "./chattypes.js";
+import { deleteUndefinedValues } from "./cleaners.js";
+import { MODEL_PROVIDER_MCP, SYSTEM_FENCE } from "./constants.js";
+import { genaiscriptDebug } from "./debug.js";
+import { parseModelIdentifier } from "./models.js";
+import type { LanguageModelConfiguration } from "./server/messages.js";
+import type { MarkdownTrace } from "./trace.js";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+const dbgs = genaiscriptDebug("mcp:server:sampling");
+
+export function mcpCreateLanguageModel(server: Server): LanguageModel {
+  return Object.freeze<LanguageModel>({
+    id: MODEL_PROVIDER_MCP,
+    completer: async (
+      req: CreateChatCompletionRequest,
+      connection: LanguageModelConfiguration,
+      completerOptions: ChatCompletionsOptions,
+      trace: MarkdownTrace,
+    ): Promise<ChatCompletionResponse> => {
+      // Implement the completer logic here
+      dbgs(`sampling ${req.model}`);
+      const { model } = parseModelIdentifier(req.model);
+      const { partialCb, inner } = completerOptions || {};
+
+      const maxTokens = req.max_completion_tokens;
+      const systemMessages = req.messages.filter(({ role }) => role === "system");
+      const systemPrompt = systemMessages.map(({ content }) => content).join(SYSTEM_FENCE);
+      const otherMessages = req.messages.filter(({ role }) => role !== "system");
+
+      const body = deleteUndefinedValues({
+        method: "sampling/createMessage",
+        params: deleteUndefinedValues({
+          messages: otherMessages,
+          temperature: req.temperature,
+          metadata: req.metadata,
+          modelPreferences: {
+            hints: [
+              {
+                name: model,
+              },
+            ].filter(({ name }) => !!name),
+            intelligencePriority: 0.8,
+            speedPriority: 0.5,
+          },
+          systemPrompt,
+          maxTokens,
+        }),
+      });
+
+      trace.detailsFenced(`🧪 mcp sampling`, body, "json");
+
+      let responseSoFar = "";
+      const res = await server.request(body, CreateMessageResultSchema, {
+        onprogress: (data) => {
+          dbgs(`%d/%d %s`, data.progress, data.total, data.message);
+          responseSoFar += data.message;
+          partialCb?.({
+            responseSoFar,
+            responseChunk: data.message,
+            tokensSoFar: data.progress,
+            inner,
+          });
+        },
+      });
+
+      trace.detailsFenced(`🧪 sampling result`, res, "json");
+      // "endTurn", "stopSequence", "maxTokens"
+      const finishReason: "stop" | "length" | "fail" =
+        {
+          ["endTurn"]: "stop",
+          ["stopSequence"]: "stop",
+          ["maxTokens"]: "length",
+        }[res.stopReason] ?? ("fail" as any);
+      return {
+        model: res.model,
+        text: res.content?.type === "text" ? res.content.text : "",
+        finishReason,
+      } satisfies ChatCompletionResponse;
+    },
+  } satisfies LanguageModel);
+}

--- a/packages/core/src/mcpsampling.ts
+++ b/packages/core/src/mcpsampling.ts
@@ -18,6 +18,7 @@ import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 const dbgs = genaiscriptDebug("mcp:server:sampling");
 
 export function mcpCreateLanguageModel(server: Server): LanguageModel {
+  dbgs(`creating mcp sampling language model`);
   return Object.freeze<LanguageModel>({
     id: MODEL_PROVIDER_MCP,
     completer: async (

--- a/packages/core/src/mcpsampling.ts
+++ b/packages/core/src/mcpsampling.ts
@@ -2,90 +2,77 @@
 // Licensed under the MIT License.
 
 import { CreateMessageResultSchema } from "@modelcontextprotocol/sdk/types.js";
-import type { LanguageModel } from "./chat.js";
-import type {
-  ChatCompletionResponse,
-  ChatCompletionsOptions,
-  CreateChatCompletionRequest,
-} from "./chattypes.js";
+import type { ChatCompletionResponse, CreateChatCompletionRequest } from "./chattypes.js";
 import { deleteUndefinedValues } from "./cleaners.js";
-import { MODEL_PROVIDER_MCP, SYSTEM_FENCE } from "./constants.js";
+import { SYSTEM_FENCE } from "./constants.js";
 import { genaiscriptDebug } from "./debug.js";
 import { parseModelIdentifier } from "./models.js";
-import type { LanguageModelConfiguration } from "./server/messages.js";
-import type { MarkdownTrace } from "./trace.js";
+import type { TraceOptions } from "./trace.js";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { toSignal } from "./cancellation.js";
+import type { CancellationOptions } from "./cancellation.js";
 const dbgs = genaiscriptDebug("mcp:server:sampling");
 
-export function mcpCreateLanguageModel(server: Server): LanguageModel {
-  dbgs(`creating mcp sampling language model`);
-  return Object.freeze<LanguageModel>({
-    id: MODEL_PROVIDER_MCP,
-    completer: async (
-      req: CreateChatCompletionRequest,
-      connection: LanguageModelConfiguration,
-      completerOptions: ChatCompletionsOptions,
-      trace: MarkdownTrace,
-    ): Promise<ChatCompletionResponse> => {
-      // Implement the completer logic here
-      dbgs(`sampling ${req.model}`);
-      const { model } = parseModelIdentifier(req.model);
-      const { partialCb, inner } = completerOptions || {};
+export async function mcpRequestSample(
+  server: Server,
+  req: CreateChatCompletionRequest,
+  options?: TraceOptions & CancellationOptions,
+): Promise<ChatCompletionResponse> {
+  // Implement the completer logic here
+  dbgs(`sampling ${req.model}`);
+  const { trace, cancellationToken } = options ?? {};
+  const { model } = parseModelIdentifier(req.model);
+  const signal = toSignal(cancellationToken);
 
-      const maxTokens = req.max_completion_tokens;
-      const systemMessages = req.messages.filter(({ role }) => role === "system");
-      const systemPrompt = systemMessages.map(({ content }) => content).join(SYSTEM_FENCE);
-      const otherMessages = req.messages.filter(({ role }) => role !== "system");
+  const maxTokens = req.max_completion_tokens;
+  const systemMessages = req.messages.filter(({ role }) => role === "system");
+  const systemPrompt = systemMessages.map(({ content }) => content).join(SYSTEM_FENCE);
+  const otherMessages = req.messages.filter(({ role }) => role !== "system");
 
-      const body = deleteUndefinedValues({
-        method: "sampling/createMessage",
-        params: deleteUndefinedValues({
-          messages: otherMessages,
-          temperature: req.temperature,
-          metadata: req.metadata,
-          modelPreferences: {
-            hints: [
-              {
-                name: model,
-              },
-            ].filter(({ name }) => !!name),
-            intelligencePriority: 0.8,
-            speedPriority: 0.5,
+  const body = deleteUndefinedValues({
+    method: "sampling/createMessage",
+    params: deleteUndefinedValues({
+      messages: otherMessages,
+      temperature: req.temperature,
+      metadata: req.metadata,
+      modelPreferences: {
+        hints: [
+          {
+            name: model,
           },
-          systemPrompt,
-          maxTokens,
-        }),
-      });
+        ].filter(({ name }) => !!name),
+        intelligencePriority: 0.8,
+        speedPriority: 0.5,
+      },
+      systemPrompt,
+      maxTokens,
+      signal,
+    }),
+  });
 
-      trace.detailsFenced(`🧪 mcp sampling`, body, "json");
+  trace?.detailsFenced(`🧪 mcp sampling`, body, "json");
 
-      let responseSoFar = "";
-      const res = await server.request(body, CreateMessageResultSchema, {
-        onprogress: (data) => {
-          dbgs(`%d/%d %s`, data.progress, data.total, data.message);
-          responseSoFar += data.message;
-          partialCb?.({
-            responseSoFar,
-            responseChunk: data.message,
-            tokensSoFar: data.progress,
-            inner,
-          });
-        },
-      });
-
-      trace.detailsFenced(`🧪 sampling result`, res, "json");
-      // "endTurn", "stopSequence", "maxTokens"
-      const finishReason: "stop" | "length" | "fail" =
-        {
-          ["endTurn"]: "stop",
-          ["stopSequence"]: "stop",
-          ["maxTokens"]: "length",
-        }[res.stopReason] ?? ("fail" as any);
-      return {
-        model: res.model,
-        text: res.content?.type === "text" ? res.content.text : "",
-        finishReason,
-      } satisfies ChatCompletionResponse;
+  let responseSoFar = "";
+  const res = await server.request(body, CreateMessageResultSchema, {
+    onprogress: (data) => {
+      dbgs(`%d/%d %s`, data.progress, data.total, data.message);
+      responseSoFar += data.message;
     },
-  } satisfies LanguageModel);
+  });
+  dbgs(`sampling result: %O`, res);
+  trace?.detailsFenced(`🧪 sampling result`, res, "json");
+  // "endTurn", "stopSequence", "maxTokens"
+  const finishReason: "stop" | "length" | "fail" =
+    {
+      ["endTurn"]: "stop",
+      ["stopSequence"]: "stop",
+      ["maxTokens"]: "length",
+    }[res.stopReason] ?? ("stop" as any);
+  const response = {
+    model: res.model,
+    text: res.content?.type === "text" ? res.content.text : "",
+    finishReason,
+  } satisfies ChatCompletionResponse;
+  dbgs(`response: %O`, response);
+  return response;
 }

--- a/packages/core/src/workerlm.ts
+++ b/packages/core/src/workerlm.ts
@@ -24,7 +24,7 @@ export interface ChatCompletionRequestMessage {
 export interface ChatCompletionResponseMessage {
   type: "chatCompletion";
   id: string;
-  result: ChatCompletionResponse;
+  response?: ChatCompletionResponse;
   error?: SerializedError;
 }
 
@@ -42,20 +42,21 @@ export function createWorkerLanguageModel() {
       dbg(`request %s`, id);
       return new Promise<ChatCompletionResponse>((resolve, reject) => {
         // eslint-disable-next-line n/no-unsupported-features/node-builtins
-        parentPort.addEventListener("message", (ev: any) => {
+        const handler = (ev: any) => {
           dbg(`%O`, ev);
           const { detail } = ev as { detail: ChatCompletionResponseMessage };
-          if (detail.type !== "chatCompletion" || detail.id !== id) {
+          if (detail?.type !== "chatCompletion" || detail?.id !== id) {
             return;
           }
           dbg(`response %s`, id);
-          const { result, error } = detail;
+          const { response: result, error } = detail;
           if (error) {
             reject(error.message);
           } else if (!result) {
             reject("No result returned from worker");
           } else resolve(result);
-        });
+        };
+        parentPort.addEventListener("message", handler, { once: true });
         parentPort.postMessage({
           type: "chatCompletion",
           id,

--- a/packages/core/src/workerlm.ts
+++ b/packages/core/src/workerlm.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { parentPort } from "node:worker_threads";
+import type { LanguageModel } from "./chat.js";
+import type {
+  ChatCompletionResponse,
+  ChatCompletionsOptions,
+  CreateChatCompletionRequest,
+} from "./chattypes.js";
+import type { LanguageModelConfiguration } from "./server/messages.js";
+import type { MarkdownTrace } from "./trace.js";
+import { generateId } from "./id.js";
+import { genaiscriptDebug } from "./debug.js";
+import type { SerializedError } from "./types.js";
+const dbg = genaiscriptDebug("worker:lm");
+
+export interface ChatCompletionRequestMessage {
+  type: "chatCompletion";
+  id: string;
+  request: CreateChatCompletionRequest;
+}
+
+export interface ChatCompletionResponseMessage {
+  type: "chatCompletion";
+  id: string;
+  result: ChatCompletionResponse;
+  error?: SerializedError;
+}
+
+export function createWorkerLanguageModel() {
+  if (!parentPort) throw new Error("This function must be called in a worker thread");
+  return Object.freeze<LanguageModel>({
+    id: "worker",
+    completer: async (
+      request: CreateChatCompletionRequest,
+      connection: LanguageModelConfiguration,
+      completerOptions: ChatCompletionsOptions,
+      trace: MarkdownTrace,
+    ): Promise<ChatCompletionResponse> => {
+      const id = generateId();
+      dbg(`request %s`, id);
+      return new Promise<ChatCompletionResponse>((resolve, reject) => {
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+        parentPort.addEventListener("message", (ev: any) => {
+          dbg(`%O`, ev);
+          const { detail } = ev as { detail: ChatCompletionResponseMessage };
+          if (detail.type !== "chatCompletion" || detail.id !== id) {
+            return;
+          }
+          dbg(`response %s`, id);
+          const { result, error } = detail;
+          if (error) {
+            reject(error.message);
+          } else if (!result) {
+            reject("No result returned from worker");
+          } else resolve(result);
+        });
+        parentPort.postMessage({
+          type: "chatCompletion",
+          id,
+          request,
+        } satisfies ChatCompletionRequestMessage);
+      });
+    },
+  });
+}

--- a/packages/core/src/workerlm.ts
+++ b/packages/core/src/workerlm.ts
@@ -43,7 +43,7 @@ export function createWorkerLanguageModel() {
       return new Promise<ChatCompletionResponse>((resolve, reject) => {
         // eslint-disable-next-line n/no-unsupported-features/node-builtins
         const handler = (ev: any) => {
-          dbg(`%O`, ev);
+          dbg(`message: %O`, ev);
           const { detail } = ev as { detail: ChatCompletionResponseMessage };
           if (detail?.type !== "chatCompletion" || detail?.id !== id) {
             return;

--- a/packages/core/src/workerlm.ts
+++ b/packages/core/src/workerlm.ts
@@ -40,11 +40,11 @@ export function createWorkerLanguageModel() {
     ): Promise<ChatCompletionResponse> => {
       const id = generateId();
       dbg(`request %s`, id);
+      const { partialCb, inner } = completerOptions || {};
       return new Promise<ChatCompletionResponse>((resolve, reject) => {
         // eslint-disable-next-line n/no-unsupported-features/node-builtins
-        const handler = (ev: any) => {
-          dbg(`message: %O`, ev);
-          const { detail } = ev as { detail: ChatCompletionResponseMessage };
+        const handler = (detail: ChatCompletionResponseMessage) => {
+          dbg(`message: %O`, detail);
           if (detail?.type !== "chatCompletion" || detail?.id !== id) {
             return;
           }
@@ -54,9 +54,17 @@ export function createWorkerLanguageModel() {
             reject(error.message);
           } else if (!result) {
             reject("No result returned from worker");
-          } else resolve(result);
+          } else {
+            partialCb?.({
+              responseSoFar: result.text,
+              responseChunk: result.text,
+              tokensSoFar: result.usage?.total_tokens,
+              inner,
+            });
+            resolve(result);
+          }
         };
-        parentPort.addEventListener("message", handler, { once: true });
+        parentPort.once("message", handler);
         parentPort.postMessage({
           type: "chatCompletion",
           id,

--- a/samples/sample/genaisrc/emojifier.genai.mjs
+++ b/samples/sample/genaisrc/emojifier.genai.mjs
@@ -1,4 +1,5 @@
 script({
+  model: "mcp",
   group: "mcp",
   parameters: {
     text: "the text to emojify",


### PR DESCRIPTION


<!-- genaiscript begin prd --><hr/>

## Pull Request Summary

### MCP Client Sampling Integration 🚀

- **Introduced MCP Client Sampling Support:**  
  - Added a new language model provider `"mcp"` that enables sampling via the Model Context Protocol (MCP) client.
  - Implemented `mcpRequestSample` to handle chat completion requests through the MCP server and return responses using a streaming protocol.

- **Worker Language Model Bridge 🧑‍💻**
  - Created a `createWorkerLanguageModel` utility, allowing worker threads to delegate language model requests back to the parent process for sampling.
  - Enhanced worker and API logic to support passing chat completion requests and responses between processes.

- **API and Server Enhancements 🔗**
  - Extended the `run` API to support an `onMessage` callback with a `postMessage` function for bidirectional communication.
  - Enabled the server to detect and use client sampling capabilities, forwarding chat completion requests to the client when `"mcp"` is the selected model.
  - Updated server initialization to check client capabilities and set up the appropriate language model bridge.

- **Resource Management Improvements 🗂️**
  - Fixed a typo in resource upsert method (`upsetResource` → `upsertResource`).
  - Ensured resource updates are handled correctly via event listeners and upsert logic.

- **LLM Data and Model Resolution Updates 🧠**
  - Registered `"mcp"` as a valid model provider and updated model resolution logic to support it.
  - Added metadata and configuration for the `"mcp"` provider in the LLMs data registry.

- **Sample Script Update 📝**
  - Modified the `emojifier` sample script to use the new `"mcp"` model provider for demonstration.

- **Type and Code Quality Improvements 🧹**
  - Improved type annotations and consistency across multiple modules.
  - Refactored event handling and watcher logic for better reliability and maintainability.

---

These changes collectively enable MCP-based client sampling for language model completions, allowing for advanced, pluggable model usage and improved extensibility in the platform.

> AI-generated content by prd may be incorrect.



<!-- genaiscript end prd -->

