### PR TITLE
fix litellm api key

### DIFF
--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -776,11 +776,12 @@ export async function parseTokenFromEnv(
         if (!URL.canParse(base)) {
             throw new Error(`${base} must be a valid URL`)
         }
+        const token = env.LITELLM_API_KEY;
         return {
             provider,
             model,
             base,
-            token: MODEL_PROVIDER_LITELLM,
+            token,
             type: "openai",
             source: "default",
         }


### PR DESCRIPTION
Before this change, the `litellm` string is passed as a api key, which is incorrect.