### PR TITLE
docs: fix agents memory retrieve typo

### DIFF
--- a/slides/pages/agents-memory.md
+++ b/slides/pages/agents-memory.md
@@ -20,7 +20,7 @@ flowchart LR
     agent_github --> |"remember failed_run, failed_sha"| memory
 ```
 
--   retreive
+-   retrieve
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Summary\n- Fix a spelling typo in the agents memory slide notes (retreive → retrieve).\n\n## Validation\n- git diff --check\n- git grep -n "retreive" -- slides/pages/agents-memory.md || true\n\nConfidence: 85/100 (docs/typo)